### PR TITLE
fix: use proper website name

### DIFF
--- a/apps/dash2/app/(main)/websites/[id]/assistant/components/ai-assistant-main.tsx
+++ b/apps/dash2/app/(main)/websites/[id]/assistant/components/ai-assistant-main.tsx
@@ -9,7 +9,7 @@ import VisualizationSection, { VisualizationSkeleton } from "./visualization-sec
 import { cn } from "@/lib/utils";
 
 export default function AIAssistantMain(props: WebsiteDataTabProps) {
-  const chat = useChat(props.websiteId, props.websiteData);
+  const chat = useChat(props.websiteId, props.websiteData?.name);
   
   const latestVisualizationMessage = chat.messages
     .slice()


### PR DESCRIPTION
Fixes an issue where the ai would mention [object Object] instead of the website name.

![image](https://github.com/user-attachments/assets/ce06a80d-415a-4c92-918a-732bee98108e)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved how website information is handled by the AI Assistant, ensuring only the website name is used where needed. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->