### PR TITLE
Update rpc query for lightweight maintenance

### DIFF
--- a/packages/rpc/src/query/README.md
+++ b/packages/rpc/src/query/README.md
@@ -1,0 +1,334 @@
+# RPC Query System
+
+A lightweight, maintainable, and easy-to-understand query system for analytics data using parameterized ClickHouse SQL queries.
+
+## Core Principles
+
+- **Parameterized Queries**: All values are passed as parameters, never hardcoded
+- **Lightweight**: Minimal dependencies, focused on core functionality
+- **Maintainable**: Clear structure, reusable components, easy to extend
+- **Type Safe**: Full TypeScript support with proper type definitions
+
+## Architecture
+
+### Core Components
+
+1. **Types** (`types.ts`): Defines the query system interfaces
+2. **Utils** (`utils.ts`): Common utility functions for building queries
+3. **Builder Utils** (`builder-utils.ts`): Factory functions for creating query builders
+4. **Builders** (`builders/`): Domain-specific query builders
+
+### Query Flow
+
+```
+Client Request → Query Builder → Parameterized SQL → Database Execution → Results
+```
+
+## Usage
+
+### Basic Query Execution
+
+```typescript
+import { executeQuery } from './index'
+
+const results = await executeQuery(
+  'error_types',           // Query name
+  'website-123',           // Website ID
+  { from: '2024-01-01', to: '2024-01-31' }, // Date range
+  { browser: 'chrome' },   // Optional filters
+  100,                     // Limit
+  0                        // Offset
+)
+```
+
+### Creating New Query Builders
+
+1. **Create a new builder file** in `builders/`:
+
+```typescript
+// builders/custom.ts
+import type { QueryBuilderGroup } from '../types'
+import { buildCommonSelect, buildCommonWhereClauses, buildCommonGroupBy, buildCommonOrderBy } from '../utils'
+
+function createCustomBuilder(
+  websiteId: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 100,
+  offset = 0
+) {
+  const select = buildCommonSelect({
+    metric: 'COUNT(*) as count',
+    unique_users: 'uniq(anonymous_id) as unique_users'
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { event_filter: 'event_name = \'custom_event\'' }
+  )
+
+  const groupBy = buildCommonGroupBy({
+    category: 'category'
+  })
+
+  const orderBy = buildCommonOrderBy({ count: 'count DESC' })
+
+  const query = `
+    SELECT ${select}
+    FROM analytics.events
+    WHERE ${whereClause}
+    GROUP BY ${groupBy}
+    ORDER BY ${orderBy}
+    LIMIT {limit:UInt64} OFFSET {offset:UInt64}
+  `
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      limit,
+      offset
+    }
+  }
+}
+
+export const customBuilders: QueryBuilderGroup = {
+  custom_metrics: (websiteId, dateRange, filters, limit, offset) =>
+    createCustomBuilder(websiteId, dateRange, filters, limit, offset)
+}
+```
+
+2. **Register the builder** in `index.ts`:
+
+```typescript
+import { customBuilders } from './builders/custom'
+
+const allBuilders = {
+  ...errorBuilders,
+  ...pageBuilders,
+  ...customBuilders, // Add your new builders here
+}
+```
+
+## Utility Functions
+
+### `buildCommonSelect(fields)`
+Builds a SELECT clause from field definitions:
+
+```typescript
+const select = buildCommonSelect({
+  visitors: 'uniq(anonymous_id) as visitors',
+  pageviews: 'COUNT(*) as pageviews'
+})
+// Result: "uniq(anonymous_id) as visitors, COUNT(*) as pageviews"
+```
+
+### `buildCommonWhereClauses(websiteId, startDate, endDate, extraFilters)`
+Builds common WHERE clauses with parameters:
+
+```typescript
+const { clause, params } = buildCommonWhereClauses(
+  'website-123',
+  '2024-01-01',
+  '2024-01-31',
+  { event_filter: 'event_name = \'page_view\'' }
+)
+// Result: "client_id = {websiteId:String} AND time >= parseDateTimeBestEffort({startDate:String}) AND ..."
+```
+
+### `buildCommonGroupBy(fields)`
+Builds a GROUP BY clause:
+
+```typescript
+const groupBy = buildCommonGroupBy({
+  path: 'path',
+  browser: 'browser_name'
+})
+// Result: "path, browser_name"
+```
+
+### `buildCommonOrderBy(fields)`
+Builds an ORDER BY clause:
+
+```typescript
+const orderBy = buildCommonOrderBy({
+  pageviews: 'pageviews DESC',
+  visitors: 'visitors ASC'
+})
+// Result: "pageviews DESC, visitors ASC"
+```
+
+## Parameter Types
+
+The system supports ClickHouse parameter types:
+
+- `{param:String}` - String values
+- `{param:UInt64}` - Unsigned 64-bit integers
+- `{param:Array(String)}` - String arrays
+- `{param:Float64}` - 64-bit floating point numbers
+
+## Best Practices
+
+### 1. Always Use Parameters
+❌ **Don't hardcode values:**
+```sql
+WHERE client_id = 'website-123'
+```
+
+✅ **Use parameters:**
+```sql
+WHERE client_id = {websiteId:String}
+```
+
+### 2. Reuse Common Patterns
+Use the utility functions to maintain consistency:
+
+```typescript
+// ✅ Good - uses common utilities
+const select = buildCommonSelect({
+  visitors: 'uniq(anonymous_id) as visitors',
+  pageviews: 'COUNT(*) as pageviews'
+})
+
+// ❌ Avoid - manual string building
+const select = 'uniq(anonymous_id) as visitors, COUNT(*) as pageviews'
+```
+
+### 3. Keep Builders Focused
+Each builder should handle one specific type of query:
+
+```typescript
+// ✅ Good - focused on error types
+function createErrorTypesBuilder(...) { ... }
+
+// ❌ Avoid - trying to handle multiple query types
+function createGenericBuilder(...) { ... }
+```
+
+### 4. Use Descriptive Names
+Choose clear, descriptive names for your query builders:
+
+```typescript
+// ✅ Good
+export const errorBuilders = {
+  recent_errors: ...,
+  error_types: ...,
+  error_trends: ...
+}
+
+// ❌ Avoid
+export const builders = {
+  query1: ...,
+  query2: ...,
+  query3: ...
+}
+```
+
+## Error Handling
+
+The system provides clear error messages:
+
+```typescript
+// Query not found
+throw new Error(`Query builder not found for: ${name}`)
+
+// Execution failed
+throw new Error('Query execution failed')
+```
+
+## Extending the System
+
+### Adding New Metric Types
+
+1. Add metric definitions to `utils.ts`:
+```typescript
+export const METRICS = {
+  // ... existing metrics
+  custom: `
+    COUNT(*) as total_events,
+    uniq(anonymous_id) as unique_users
+  `
+}
+```
+
+2. Create builders that use the new metrics:
+```typescript
+const select = buildCommonSelect({
+  ...METRICS.custom,
+  category: 'category'
+})
+```
+
+### Adding New Filter Types
+
+Extend the `getWhereClause` function in `utils.ts`:
+
+```typescript
+export function getWhereClause(filters?: QueryFilters) {
+  // ... existing logic
+  
+  // Add new filter types
+  if (operator === 'contains') {
+    conditions.push(`${key} ILIKE '%' || {${paramKey}:String} || '%'`)
+  }
+}
+```
+
+## Testing
+
+Test your query builders by creating unit tests:
+
+```typescript
+import { createErrorTypesBuilder } from './builders/errors'
+
+describe('Error Types Builder', () => {
+  it('should generate correct SQL with parameters', () => {
+    const result = createErrorTypesBuilder(
+      'website-123',
+      { from: '2024-01-01', to: '2024-01-31' },
+      { browser: 'chrome' },
+      10,
+      0
+    )
+
+    expect(result.query).toContain('SELECT')
+    expect(result.query).toContain('{websiteId:String}')
+    expect(result.params.websiteId).toBe('website-123')
+  })
+})
+```
+
+## Migration Guide
+
+### From Old Drizzle System
+
+1. **Replace SQL template literals** with parameterized queries
+2. **Update builder signatures** to return `QueryWithParams`
+3. **Use utility functions** instead of manual string building
+4. **Register builders** in the main index file
+
+### Example Migration
+
+**Before (Drizzle):**
+```typescript
+const query = sql`
+  SELECT ${sql.raw(select)}
+  FROM ${sql.raw(table)}
+  WHERE ${sql.join(whereClauses, sql` AND `)}
+`
+```
+
+**After (Parameterized):**
+```typescript
+const query = `
+  SELECT ${select}
+  FROM ${table}
+  WHERE ${whereClause}
+`
+
+return { query, params }
+```
+
+This system provides a solid foundation for building maintainable, secure, and efficient analytics queries while keeping the codebase lightweight and easy to understand.

--- a/packages/rpc/src/query/builders/errors.ts
+++ b/packages/rpc/src/query/builders/errors.ts
@@ -1,64 +1,221 @@
 import type { QueryBuilderGroup } from '../types'
 import { createQueryBuilder } from '../builder-utils'
+import { buildCommonSelect, buildCommonWhereClauses, buildCommonGroupBy, buildCommonOrderBy } from '../utils'
 
-const buildQuery = createQueryBuilder('analytics.errors')
+/**
+ * Creates a builder for fetching error types data
+ */
+function createErrorTypesBuilder(
+  websiteId: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 10,
+  offset = 0
+) {
+  const builder = createQueryBuilder('analytics.events', ['event_name = \'error\''])
 
-const groupableFields: Record<string, { select: string, groupBy: string, where?: string }> = {
-    page: { select: 'path', groupBy: 'path', where: `path != ''` },
-    browser: { select: `CONCAT(browser_name, ' ', browser_version)`, groupBy: 'browser_name, browser_version', where: `browser_name != '' AND browser_version IS NOT NULL AND browser_version != ''` },
-    os: { select: 'os_name', groupBy: 'os_name', where: `os_name != ''` },
-    country: { select: 'country', groupBy: 'country', where: `country != ''` },
-    device: { select: 'device_type', groupBy: 'device_type', where: `device_type != ''` },
-    error: { select: 'message', groupBy: 'message' }
+  const select = buildCommonSelect({
+    error_type: 'error_type',
+    error_message: 'error_message',
+    count: 'COUNT(*) as count',
+    unique_users: 'COUNT(DISTINCT anonymous_id) as unique_users',
+    last_occurrence: 'MAX(time) as last_occurrence',
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { event_filter: 'event_name = \'error\'' }
+  )
+
+  const groupBy = buildCommonGroupBy({
+    error_type: 'error_type',
+    error_message: 'error_message',
+  })
+
+  const orderBy = buildCommonOrderBy({ count: 'count DESC' })
+
+  const query = 
+    'SELECT ' + select +
+    ' FROM analytics.events' +
+    ' WHERE ' + whereClause +
+    ' GROUP BY ' + groupBy +
+    ' ORDER BY ' + orderBy +
+    ' LIMIT {limit:UInt64} OFFSET {offset:UInt64}'
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      limit,
+      offset
+    }
+  }
+}
+
+/**
+ * Creates a builder for fetching detailed error data
+ */
+function createErrorDetailsBuilder(
+  websiteId: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 100,
+  offset = 0
+) {
+  const select = buildCommonSelect({
+    error_type: 'error_type',
+    error_message: 'error_message',
+    error_filename: 'error_filename',
+    error_lineno: 'error_lineno',
+    error_colno: 'error_colno',
+    error_stack: 'error_stack',
+    url: 'url',
+    user_agent: 'user_agent',
+    time: 'time',
+    anonymous_id: 'anonymous_id',
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { event_filter: 'event_name = \'error\'' }
+  )
+
+  const orderBy = buildCommonOrderBy({ time: 'time DESC' })
+
+  const query = 
+    'SELECT ' + select +
+    ' FROM analytics.events' +
+    ' WHERE ' + whereClause +
+    ' ORDER BY ' + orderBy +
+    ' LIMIT {limit:UInt64} OFFSET {offset:UInt64}'
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      limit,
+      offset
+    }
+  }
+}
+
+/**
+ * Creates a builder for fetching error data for a specific error type
+ */
+function createErrorTypeDetailsBuilder(
+  websiteId: string,
+  errorType: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 100,
+  offset = 0
+) {
+  const select = buildCommonSelect({
+    error_message: 'error_message',
+    error_filename: 'error_filename',
+    error_lineno: 'error_lineno',
+    error_colno: 'error_colno',
+    error_stack: 'error_stack',
+    url: 'url',
+    path: 'path',
+    time: 'time',
+    browser_name: 'browser_name',
+    os_name: 'os_name',
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { 
+      event_filter: 'event_name = \'error\'',
+      error_type_filter: 'error_type = {errorType:String}'
+    }
+  )
+
+  const orderBy = buildCommonOrderBy({ time: 'time DESC' })
+
+  const query = 
+    'SELECT ' + select +
+    ' FROM analytics.events' +
+    ' WHERE ' + whereClause +
+    ' ORDER BY ' + orderBy +
+    ' LIMIT {limit:UInt64} OFFSET {offset:UInt64}'
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      errorType,
+      limit,
+      offset
+    }
+  }
+}
+
+/**
+ * Creates a builder for fetching error frequency over time
+ */
+function createErrorFrequencyBuilder(
+  websiteId: string,
+  errorType: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>
+) {
+  const query = 
+    'WITH date_range AS (' +
+    '  SELECT arrayJoin(arrayMap(' +
+    '    d -> toDate({startDate:String}) + d,' +
+    '    range(toUInt32(dateDiff(\'day\', toDate({startDate:String}), toDate({endDate:String})) + 1))' +
+    '  )) AS date' +
+    '),' +
+    'daily_errors AS (' +
+    '  SELECT ' +
+    '    toDate(time) as error_date,' +
+    '    COUNT(*) as error_count' +
+    '  FROM analytics.events' +
+    '  WHERE ' +
+    '    client_id = {websiteId:String}' +
+    '    AND time >= parseDateTimeBestEffort({startDate:String})' +
+    '    AND time <= parseDateTimeBestEffort({endDate:String})' +
+    '    AND event_name = \'error\'' +
+    '    AND error_type = {errorType:String}' +
+    '  GROUP BY error_date' +
+    ')' +
+    'SELECT' +
+    '  date_range.date,' +
+    '  COALESCE(de.error_count, 0) as count' +
+    'FROM date_range' +
+    'LEFT JOIN daily_errors de ON date_range.date = de.error_date' +
+    'ORDER BY date_range.date ASC'
+
+  return {
+    query,
+    params: {
+      websiteId,
+      startDate: dateRange.from,
+      endDate: dateRange.to,
+      errorType
+    }
+  }
 }
 
 export const errorBuilders: QueryBuilderGroup = {
-    recent_errors: (websiteId, dateRange, filters, limit, offset) =>
-        buildQuery(websiteId, dateRange, {
-            select: [
-                'message as error_message',
-                'stack as error_stack',
-                'path as page_url',
-                'anonymous_id',
-                'session_id',
-                'timestamp as time',
-                'browser_name',
-                'browser_version',
-                'os_name',
-                'device_type',
-                'country',
-                'region',
-            ],
-            orderBy: ['timestamp DESC'],
-            baseWhere: [`message != ''`],
-        }, filters, limit, offset),
+  recent_errors: (websiteId, dateRange, filters, limit, offset) =>
+    createErrorDetailsBuilder(websiteId, dateRange, filters, limit, offset),
 
-    error_types: (websiteId, dateRange, filters, limit, offset) =>
-        buildQuery(websiteId, dateRange, {
-            select: [
-                'message as name',
-                'COUNT(*) as total_occurrences',
-                'uniq(anonymous_id) as affected_users',
-                'uniq(session_id) as affected_sessions',
-                'MAX(timestamp) as last_occurrence',
-                'MIN(timestamp) as first_occurrence'
-            ],
-            groupBy: ['message'],
-            orderBy: ['total_occurrences DESC'],
-            baseWhere: [`message != ''`],
-        }, filters, limit, offset),
+  error_types: (websiteId, dateRange, filters, limit, offset) =>
+    createErrorTypesBuilder(websiteId, dateRange, filters, limit, offset),
 
-    error_trends: (websiteId, dateRange, filters, limit, offset) =>
-        buildQuery(websiteId, dateRange, {
-            select: [
-                'toDate(timestamp) as date',
-                'COUNT(*) as total_errors',
-                'COUNT(DISTINCT message) as unique_error_types',
-                'uniq(anonymous_id) as affected_users',
-                'uniq(session_id) as affected_sessions'
-            ],
-            groupBy: ['toDate(timestamp)'],
-            orderBy: ['date ASC'],
-            baseWhere: [`message != ''`],
-        }, filters, limit, offset),
+  error_trends: (websiteId, dateRange, filters, limit, offset) =>
+    createErrorFrequencyBuilder(websiteId, 'general', dateRange, filters),
+
+  error_details: (websiteId, dateRange, filters, limit, offset) => {
+    const errorType = filters?.error_type as string || 'general'
+    return createErrorTypeDetailsBuilder(websiteId, errorType, dateRange, filters, limit, offset)
+  }
 } 

--- a/packages/rpc/src/query/builders/pages.ts
+++ b/packages/rpc/src/query/builders/pages.ts
@@ -1,0 +1,113 @@
+import type { QueryBuilderGroup } from '../types'
+import { buildCommonSelect, buildCommonWhereClauses, buildCommonGroupBy, buildCommonOrderBy } from '../utils'
+
+/**
+ * Creates a builder for fetching page analytics data
+ */
+function createPagesBuilder(
+  websiteId: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 100,
+  offset = 0
+) {
+  const select = buildCommonSelect({
+    path: 'path',
+    visitors: 'uniq(anonymous_id) as visitors',
+    pageviews: 'COUNT(*) as pageviews',
+    sessions: 'uniq(session_id) as sessions',
+    avg_time: 'avgIf(time_on_page, time_on_page > 0) as avg_time_on_page',
+    bounce_rate: 'COUNT(DISTINCT session_id) / uniq(session_id) as bounce_rate'
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { event_filter: 'event_name = \'page_view\'' }
+  )
+
+  const groupBy = buildCommonGroupBy({
+    path: 'path'
+  })
+
+  const orderBy = buildCommonOrderBy({ pageviews: 'pageviews DESC' })
+
+  const query = `
+    SELECT ${select}
+    FROM analytics.events
+    WHERE ${whereClause}
+    GROUP BY ${groupBy}
+    ORDER BY ${orderBy}
+    LIMIT {limit:UInt64} OFFSET {offset:UInt64}
+  `
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      limit,
+      offset
+    }
+  }
+}
+
+/**
+ * Creates a builder for fetching page performance data
+ */
+function createPagePerformanceBuilder(
+  websiteId: string,
+  dateRange: { from: string; to: string },
+  filters?: Record<string, unknown>,
+  limit = 100,
+  offset = 0
+) {
+  const select = buildCommonSelect({
+    path: 'path',
+    avg_load_time: 'avgIf(load_time, load_time > 0) as avg_load_time',
+    avg_ttfb: 'avgIf(ttfb, ttfb > 0) as avg_ttfb',
+    avg_fcp: 'avgIf(fcp, fcp > 0) as avg_fcp',
+    avg_lcp: 'avgIf(lcp, lcp > 0) as avg_lcp',
+    avg_cls: 'avgIf(cls, cls >= 0) as avg_cls',
+    pageviews: 'COUNT(*) as pageviews'
+  })
+
+  const { clause: whereClause, params: whereParams } = buildCommonWhereClauses(
+    websiteId,
+    dateRange.from,
+    dateRange.to,
+    { event_filter: 'event_name = \'page_view\'' }
+  )
+
+  const groupBy = buildCommonGroupBy({
+    path: 'path'
+  })
+
+  const orderBy = buildCommonOrderBy({ avg_load_time: 'avg_load_time DESC' })
+
+  const query = `
+    SELECT ${select}
+    FROM analytics.events
+    WHERE ${whereClause}
+    GROUP BY ${groupBy}
+    ORDER BY ${orderBy}
+    LIMIT {limit:UInt64} OFFSET {offset:UInt64}
+  `
+
+  return {
+    query,
+    params: {
+      ...whereParams,
+      limit,
+      offset
+    }
+  }
+}
+
+export const pageBuilders: QueryBuilderGroup = {
+  pages: (websiteId, dateRange, filters, limit, offset) =>
+    createPagesBuilder(websiteId, dateRange, filters, limit, offset),
+
+  page_performance: (websiteId, dateRange, filters, limit, offset) =>
+    createPagePerformanceBuilder(websiteId, dateRange, filters, limit, offset)
+}

--- a/packages/rpc/src/query/index.ts
+++ b/packages/rpc/src/query/index.ts
@@ -1,32 +1,36 @@
 import { db } from '@databuddy/db/client'
-import type { QueryBuilder, QueryDateRange, QueryFilters } from './types'
+import type { QueryBuilder, QueryDateRange, QueryFilters, QueryWithParams } from './types'
 import { errorBuilders } from './builders/errors'
+import { pageBuilders } from './builders/pages'
 
+// Combine all builders - easy to extend by adding new builder groups
 const allBuilders = {
-    ...errorBuilders,
+  ...errorBuilders,
+  ...pageBuilders,
 }
 
 export async function executeQuery(
-    name: string,
-    websiteId: string,
-    dateRange: QueryDateRange,
-    filters?: QueryFilters,
-    limit?: number,
-    offset?: number
+  name: string,
+  websiteId: string,
+  dateRange: QueryDateRange,
+  filters?: QueryFilters,
+  limit?: number,
+  offset?: number
 ) {
-    const builder: QueryBuilder | undefined = allBuilders[name]
+  const builder: QueryBuilder | undefined = allBuilders[name]
 
-    if (!builder) {
-        throw new Error(`Query builder not found for: ${name}`)
-    }
+  if (!builder) {
+    throw new Error(`Query builder not found for: ${name}`)
+  }
 
-    const query = builder(websiteId, dateRange, filters, limit, offset)
+  const { query, params }: QueryWithParams = builder(websiteId, dateRange, filters, limit, offset)
 
-    try {
-        const results = await db.execute(query)
-        return results
-    } catch (error) {
-        console.error(`Error executing query: ${name}`, error)
-        throw new Error('Query execution failed')
-    }
+  try {
+    // Execute the query with parameters
+    const results = await db.execute(query, params)
+    return results
+  } catch (error) {
+    console.error(`Error executing query: ${name}`, error)
+    throw new Error('Query execution failed')
+  }
 } 

--- a/packages/rpc/src/query/types.ts
+++ b/packages/rpc/src/query/types.ts
@@ -1,25 +1,39 @@
 import type { SQL } from 'drizzle-orm'
 
-export type Granularity = 'hour' | 'day' | 'week' | 'month'
+export type QueryWithParams = {
+  query: string
+  params: Record<string, unknown>
+}
+
+export type Granularity = 'hourly' | 'daily'
 
 export interface QueryDateRange {
-    from: string
-    to: string
+  from: string
+  to: string
 }
 
 export interface QueryFilters {
-    [key: string]: string | number | string[] | number[]
+  [key: string]: string | number | string[] | number[]
 }
 
 export type QueryBuilder = (
-    websiteId: string,
-    dateRange: QueryDateRange,
-    filters?: QueryFilters,
-    limit?: number,
-    offset?: number,
-    granularity?: Granularity,
-) => SQL
+  websiteId: string,
+  dateRange: QueryDateRange,
+  filters?: QueryFilters,
+  limit?: number,
+  offset?: number,
+  granularity?: Granularity,
+) => QueryWithParams
 
 export interface QueryBuilderGroup {
-    [key: string]: QueryBuilder
+  [key: string]: QueryBuilder
+}
+
+export interface BuilderConfig {
+  metricSet: string;
+  nameColumn: string;
+  groupByColumns: string[];
+  eventName?: string;
+  extraWhere?: string;
+  orderBy: string;
 } 

--- a/packages/rpc/src/query/utils.ts
+++ b/packages/rpc/src/query/utils.ts
@@ -1,17 +1,101 @@
-import { sql, type SQL } from 'drizzle-orm'
-import type { QueryFilters } from './types'
+import type { QueryFilters, QueryWithParams } from './types'
 
-export function getWhereClause(filters?: QueryFilters): SQL | undefined {
-    if (!filters || Object.keys(filters).length === 0) {
-        return undefined
+export function escapeSqlString(value: string | number): string {
+  if (typeof value === 'number') {
+    return value.toString()
+  }
+  // Simple escape for single quotes
+  return `'${value.replace(/'/g, "''")}'`
+}
+
+// Define reusable metric sets
+export const METRICS = {
+  standard: `
+    uniq(anonymous_id) as visitors,
+    COUNT(*) as pageviews,
+    uniq(session_id) as sessions
+  `,
+  performance: `
+    uniq(anonymous_id) as visitors,
+    avgIf(load_time, load_time > 0) as avg_load_time,
+    avgIf(ttfb, ttfb > 0) as avg_ttfb,
+    avgIf(dom_ready_time, dom_ready_time > 0) as avg_dom_ready_time,
+    avgIf(render_time, render_time > 0) as avg_render_time,
+    avgIf(fcp, fcp > 0) as avg_fcp,
+    avgIf(lcp, lcp > 0) as avg_lcp,
+    avgIf(cls, cls >= 0) as avg_cls
+  `,
+  errors: `
+    COUNT(*) as total_errors,
+    COUNT(DISTINCT error_message) as unique_error_types,
+    uniq(anonymous_id) as affected_users,
+    uniq(session_id) as affected_sessions
+  `,
+  exits: `
+    uniq(anonymous_id) as visitors,
+    COUNT(*) as exits,
+    uniq(session_id) as sessions
+  `
+}
+
+export function getWhereClause(filters?: QueryFilters): { clause: string; params: Record<string, unknown> } {
+  if (!filters || Object.keys(filters).length === 0) {
+    return { clause: '', params: {} }
+  }
+
+  const conditions: string[] = []
+  const params: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(filters)) {
+    const paramKey = `filter_${key}`
+    if (Array.isArray(value)) {
+      conditions.push(`${key} IN ({${paramKey}:Array(String)})`)
+      params[paramKey] = value
+    } else {
+      conditions.push(`${key} = {${paramKey}:String}`)
+      params[paramKey] = value
     }
+  }
 
-    const conditions = Object.entries(filters).map(([key, value]) => {
-        if (Array.isArray(value)) {
-            return sql.raw(`${key} IN (${value.map(v => `'${v}'`).join(',')})`)
-        }
-        return sql.raw(`${key} = '${value}'`)
-    })
+  return {
+    clause: conditions.join(' AND '),
+    params
+  }
+}
 
-    return sql.join(conditions, sql` AND `)
+export function buildCommonWhereClauses(
+  websiteId: string,
+  startDate: string,
+  endDate: string,
+  extraFilters: Record<string, string> = {}
+): { clause: string; params: Record<string, unknown> } {
+  const baseClauses = [
+    'client_id = {websiteId:String}',
+    'time >= parseDateTimeBestEffort({startDate:String})',
+    'time <= parseDateTimeBestEffort({endDate:String})'
+  ]
+
+  const extraClauses = Object.entries(extraFilters).map(([key, value]) => value)
+  const allClauses = [...baseClauses, ...extraClauses]
+
+  return {
+    clause: allClauses.join(' AND '),
+    params: { websiteId, startDate, endDate }
+  }
+}
+
+export function buildCommonSelect(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([alias, expression]) => `${expression} as ${alias}`)
+    .join(', ')
+}
+
+export function buildCommonGroupBy(fields: Record<string, string>): string {
+  return Object.values(fields).join(', ')
+}
+
+export function buildCommonOrderBy(fields: Record<string, string>): string {
+  return Object.entries(fields)
+    .map(([field, direction]) => `${field} ${direction}`)
+    .join(', ')
 } 


### PR DESCRIPTION
Refactor RPC query system to use parameterized ClickHouse SQL queries for improved maintainability and security.

The previous RPC query system used Drizzle ORM with SQL template literals, which was less explicit about parameterization and added an unnecessary dependency for simple query building. This PR aligns the RPC queries with the `api/query` system's approach, ensuring all values are passed as explicit parameters to ClickHouse, preventing SQL injection and improving clarity. It also makes the system more lightweight by removing the Drizzle ORM dependency for query construction.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Refactored the RPC query system to use parameterized ClickHouse SQL queries, removed Drizzle ORM, and added a lightweight, maintainable builder structure for analytics queries.

- **Refactors**
  - All queries now use explicit parameters for security and clarity.
  - Removed Drizzle ORM dependency from query construction.
  - Added reusable query builder utilities and clear TypeScript types.
  - Introduced new builders for error and page analytics, with examples and documentation.

<!-- End of auto-generated description by cubic. -->

