### PR TITLE
[REFACTOR]: align the text message on profiles-list and sessions-list during empty state

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/_components/tabs/tracking-setup-tab.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/_components/tabs/tracking-setup-tab.tsx
@@ -1,17 +1,17 @@
 'use client';
 
 import {
-	Activity,
-	AlertCircle,
-	BookOpen,
-	Check,
-	Clipboard,
-	Code,
-	ExternalLink,
-	FileCode,
-	Info,
-	RefreshCw,
-} from 'lucide-react';
+	ActivityIcon,
+	WarningCircleIcon,
+	BookOpenIcon,
+	CheckIcon,
+	ClipboardIcon,
+	CodeIcon,
+	ArrowSquareOutIcon,
+	FileCodeIcon,
+	InfoIcon,
+	ArrowClockwiseIcon,
+} from '@phosphor-icons/react';
 import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
@@ -121,9 +121,9 @@ export function WebsiteTrackingSetupTab({
 					variant="ghost"
 				>
 					{copied ? (
-						<Check className="h-3.5 w-3.5 text-green-500" />
+						<CheckIcon className="h-3.5 w-3.5 text-green-500" weight="duotone" />
 					) : (
-						<Clipboard className="h-3.5 w-3.5" />
+						<ClipboardIcon className="h-3.5 w-3.5" weight="duotone" />
 					)}
 				</Button>
 			</div>
@@ -136,19 +136,19 @@ export function WebsiteTrackingSetupTab({
 			<Card className="border-orange-200 bg-orange-50 dark:border-orange-800 dark:bg-orange-950/20">
 				<CardHeader>
 					<div className="flex items-center justify-between">
-						<CardTitle className="flex items-center gap-2 text-lg">
-							<AlertCircle className="h-5 w-5" />
-							Tracking Not Setup
-						</CardTitle>
-						<Button
-							aria-label="Refresh tracking status"
-							className="h-8 w-8"
-							onClick={handleRefresh}
-							size="icon"
-							variant="outline"
-						>
-							<RefreshCw className="h-4 w-4" />
-						</Button>
+											<CardTitle className="flex items-center gap-2 text-lg">
+						<WarningCircleIcon className="h-5 w-5" weight="duotone" />
+						Tracking Not Setup
+					</CardTitle>
+											<Button
+						aria-label="Refresh tracking status"
+						className="h-8 w-8"
+						onClick={handleRefresh}
+						size="icon"
+						variant="outline"
+					>
+						<ArrowClockwiseIcon className="h-4 w-4" weight="fill" />
+					</Button>
 					</div>
 					<CardDescription>
 						Install the tracking script to start collecting analytics data for
@@ -161,7 +161,7 @@ export function WebsiteTrackingSetupTab({
 			<Card>
 				<CardHeader className="pb-4">
 					<CardTitle className="flex items-center gap-2 text-lg">
-						<Code className="h-5 w-5" />
+						<CodeIcon className="h-5 w-5" weight="duotone" />
 						Installation
 					</CardTitle>
 					<CardDescription>
@@ -177,11 +177,11 @@ export function WebsiteTrackingSetupTab({
 					>
 						<TabsList className="grid w-full grid-cols-2">
 							<TabsTrigger className="flex items-center gap-2" value="script">
-								<FileCode className="h-4 w-4" />
+								<FileCodeIcon className="h-4 w-4" weight="duotone" />
 								HTML Script Tag
 							</TabsTrigger>
 							<TabsTrigger className="flex items-center gap-2" value="npm">
-								<Code className="h-4 w-4" />
+								<CodeIcon className="h-4 w-4" weight="duotone" />
 								NPM Package
 							</TabsTrigger>
 						</TabsList>
@@ -274,7 +274,7 @@ export function WebsiteTrackingSetupTab({
 			<Card>
 				<CardHeader className="pb-4">
 					<CardTitle className="flex items-center gap-2 text-lg">
-						<Activity className="h-5 w-5" />
+						<ActivityIcon className="h-5 w-5" weight="duotone" />
 						Configuration
 					</CardTitle>
 					<CardDescription>
@@ -592,9 +592,9 @@ export function WebsiteTrackingSetupTab({
 						rel="noopener noreferrer"
 						target="_blank"
 					>
-						<BookOpen className="h-4 w-4" />
+						<BookOpenIcon className="h-4 w-4" weight="duotone" />
 						Documentation
-						<ExternalLink className="ml-auto h-3 w-3" />
+						<ArrowSquareOutIcon className="ml-auto h-3 w-3" weight="fill" />
 					</a>
 				</Button>
 				<Button asChild size="sm" variant="outline">
@@ -602,7 +602,7 @@ export function WebsiteTrackingSetupTab({
 						className="flex items-center gap-2"
 						href="mailto:support@databuddy.cc"
 					>
-						<Info className="h-4 w-4" />
+						<InfoIcon className="h-4 w-4" weight="duotone" />
 						Get Support
 					</a>
 				</Button>

--- a/apps/dashboard/app/(main)/websites/[id]/funnels/_components/empty-state.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/funnels/_components/empty-state.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { PlusIcon, TargetIcon } from '@phosphor-icons/react';
+import { PlusIcon, FunnelIcon } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { cn } from '@/lib/utils';
@@ -15,7 +15,7 @@ export function EmptyState({ onCreateFunnel }: EmptyStateProps) {
 			<CardContent className="flex flex-col items-center justify-center px-8 py-16">
 				<div className="group relative mb-8">
 					<div className="rounded-full border-2 border-primary/20 bg-primary/10 p-6 transition-transform duration-300 group-hover:scale-105">
-						<TargetIcon
+						<FunnelIcon
 							className="h-16 w-16 text-primary"
 							size={16}
 							weight="duotone"

--- a/apps/dashboard/app/(main)/websites/[id]/funnels/_components/page-header.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/funnels/_components/page-header.tsx
@@ -55,7 +55,6 @@ export function PageHeader({
 							className="gap-2 rounded-lg border-border/50 px-4 py-2 font-medium transition-all duration-300 hover:border-primary/50 hover:bg-primary/5"
 							disabled={isRefreshing}
 							onClick={onRefresh}
-							size="default"
 							variant="outline"
 						>
 							<ArrowClockwiseIcon

--- a/apps/dashboard/app/(main)/websites/[id]/funnels/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/funnels/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChartBarIcon, TrendDownIcon } from '@phosphor-icons/react';
+import { FunnelIcon, TrendDownIcon } from '@phosphor-icons/react';
 import { useAtom } from 'jotai';
 import { useParams } from 'next/navigation';
 import { lazy, Suspense, useCallback, useMemo, useRef, useState } from 'react';
@@ -255,7 +255,7 @@ export default function FunnelsPage() {
 				description="Track user journeys and optimize conversion drop-off points"
 				hasError={!!funnelsError}
 				icon={
-					<ChartBarIcon
+					<FunnelIcon
 						className="h-6 w-6 text-primary"
 						size={16}
 						weight="duotone"

--- a/apps/dashboard/app/(main)/websites/[id]/goals/_components/empty-state.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/goals/_components/empty-state.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { Plus, Target } from '@phosphor-icons/react';
+import { PlusIcon, TargetIcon } from '@phosphor-icons/react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
 interface EmptyStateProps {
 	onCreateGoal: () => void;
@@ -10,28 +11,47 @@ interface EmptyStateProps {
 
 export function EmptyState({ onCreateGoal }: EmptyStateProps) {
 	return (
-		<Card className="rounded border-2 border-muted-foreground/25 border-dashed">
-			<CardContent className="flex flex-col items-center justify-center px-6 py-12 text-center">
-				<div className="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
-					<Target
-						className="text-muted-foreground"
-						size={24}
-						weight="duotone"
-					/>
+		<Card className="fade-in-50 animate-in rounded-xl border-2 border-dashed bg-gradient-to-br from-background to-muted/20 duration-700">
+			<CardContent className="flex flex-col items-center justify-center px-8 py-16">
+				<div className="group relative mb-8">
+					<div className="rounded-full border-2 border-primary/20 bg-primary/10 p-6 transition-transform duration-300 group-hover:scale-105">
+						<TargetIcon
+							className="h-16 w-16 text-primary"
+							size={16}
+							weight="duotone"
+						/>
+					</div>
+					<div className="-top-2 -right-2 absolute animate-pulse rounded-full border-2 border-primary/20 bg-background p-2 shadow-sm">
+						<PlusIcon className="h-6 w-6 text-primary" size={16} />
+					</div>
 				</div>
-
-				<h3 className="mb-2 font-semibold text-foreground text-lg">
-					No goals yet
-				</h3>
-
-				<p className="mb-6 max-w-sm text-muted-foreground text-sm">
-					Track conversions like sign-ups, purchases, or button clicks
-				</p>
-
-				<Button className="gap-2" onClick={onCreateGoal}>
-					<Plus size={16} />
-					Create Goal
-				</Button>
+				<div className="max-w-md space-y-4 text-center">
+					<h3 className="font-semibold text-2xl text-foreground">
+						No goals yet
+					</h3>
+					<p className="text-muted-foreground leading-relaxed">
+						Track conversions like sign-ups, purchases, or button clicks
+						to measure key user actions and optimize your conversion rates.
+					</p>
+					<div className="pt-2">
+						<Button
+							className={cn(
+								'gap-2 rounded-lg px-8 py-4 font-medium text-base',
+								'bg-gradient-to-r from-primary to-primary/90 hover:from-primary/90 hover:to-primary',
+								'group relative overflow-hidden transition-all duration-300'
+							)}
+							onClick={onCreateGoal}
+							size="lg"
+						>
+							<div className="absolute inset-0 translate-x-[-100%] bg-gradient-to-r from-white/0 via-white/20 to-white/0 transition-transform duration-700 group-hover:translate-x-[100%]" />
+							<PlusIcon
+								className="relative z-10 h-5 w-5 transition-transform duration-300 group-hover:rotate-90"
+								size={16}
+							/>
+							<span className="relative z-10">Create Your First Goal</span>
+						</Button>
+					</div>
+				</div>
 			</CardContent>
 		</Card>
 	);

--- a/apps/dashboard/app/(main)/websites/[id]/goals/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/goals/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { TrendDownIcon } from '@phosphor-icons/react';
+import { TargetIcon } from '@phosphor-icons/react';
 import { useAtom } from 'jotai';
 import { useParams } from 'next/navigation';
 import {
@@ -200,7 +200,7 @@ export default function GoalsPage() {
 				<Card className="rounded border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950">
 					<CardContent className="pt-6">
 						<div className="flex items-center gap-2">
-							<TrendDownIcon
+							<TargetIcon
 								className="h-5 w-5 text-red-600"
 								size={16}
 								weight="duotone"
@@ -226,7 +226,7 @@ export default function GoalsPage() {
 				description="Track key conversions and measure success"
 				hasError={!!goalsError}
 				icon={
-					<TrendDownIcon
+					<TargetIcon
 						className="h-6 w-6 text-primary"
 						size={16}
 						weight="duotone"

--- a/apps/dashboard/app/(main)/websites/[id]/map/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/map/page.tsx
@@ -137,7 +137,7 @@ function WebsiteMapPage() {
 						</Tabs>
 					}
 					icon={
-						<GlobeIcon
+						<MapPinIcon
 							aria-label="Globe"
 							className="h-5 w-5 text-primary"
 							weight="duotone"

--- a/apps/dashboard/app/(main)/websites/[id]/profiles/_components/profiles-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/profiles/_components/profiles-list.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { Loader2Icon } from 'lucide-react';
-import { UsersIcon } from '@phosphor-icons/react';
+import { UsersIcon, SpinnerIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useProfilesData } from '@/hooks/use-dynamic-query';
@@ -154,7 +153,7 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 						</div>
 						<div className="flex items-center justify-center pt-4">
 							<div className="flex items-center gap-2 text-muted-foreground">
-								<Loader2Icon className="h-4 w-4 animate-spin" />
+								<SpinnerIcon className="h-4 w-4 animate-spin" />
 								<span className="text-sm">Loading profiles...</span>
 							</div>
 						</div>
@@ -234,7 +233,7 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 							<div className="flex justify-center">
 								{isLoading ? (
 									<div className="flex items-center gap-2 text-muted-foreground">
-										<Loader2Icon className="h-4 w-4 animate-spin" />
+										<SpinnerIcon className="h-4 w-4 animate-spin" />
 										<span className="text-sm">Loading more profiles...</span>
 									</div>
 								) : null}

--- a/apps/dashboard/app/(main)/websites/[id]/profiles/_components/profiles-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/profiles/_components/profiles-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Loader2Icon, UserRound } from 'lucide-react';
+import { Loader2Icon } from 'lucide-react';
+import { UsersIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { useProfilesData } from '@/hooks/use-dynamic-query';
@@ -136,7 +137,7 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="Visitor profiles with session data and behavior patterns"
-					icon={<UserRound className="h-6 w-6 text-primary" />}
+					icon={<UsersIcon className="h-6 w-6 text-primary" />}
 					title="Recent Profiles"
 					variant="minimal"
 					websiteId={websiteId}
@@ -170,7 +171,7 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 					description="Visitor profiles with session data and behavior patterns"
 					errorMessage={error?.message || 'Failed to load profiles'}
 					hasError={true}
-					icon={<UserRound className="h-6 w-6 text-primary" />}
+					icon={<UsersIcon className="h-6 w-6 text-primary" />}
 					title="Recent Profiles"
 					variant="minimal"
 					websiteId={websiteId}
@@ -184,15 +185,15 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="Visitor profiles with session data and behavior patterns"
-					icon={<UserRound className="h-6 w-6 text-primary" />}
+					icon={<UsersIcon className="h-6 w-6 text-primary" />}
 					title="Recent Profiles"
 					variant="minimal"
 					websiteId={websiteId}
 				/>
 				<Card>
 					<CardContent>
-						<div className="py-12 text-center text-muted-foreground">
-							<UserRound className="mx-auto mb-4 h-12 w-12 opacity-50" />
+						<div className="flex flex-col items-center py-12 text-center text-muted-foreground">
+							<UsersIcon className="mb-4 h-12 w-12 opacity-50" />
 							<p className="mb-2 font-medium text-lg">No profiles found</p>
 							<p className="text-sm">
 								Visitor profiles will appear here once users visit your website
@@ -208,7 +209,7 @@ export function ProfilesList({ websiteId }: ProfilesListProps) {
 		<div className="space-y-6">
 			<WebsitePageHeader
 				description="Visitor profiles with session data and behavior patterns"
-				icon={<UserRound className="h-6 w-6 text-primary" />}
+				icon={<UsersIcon className="h-6 w-6 text-primary" />}
 				subtitle={`${allProfiles.length} loaded`}
 				title="Recent Profiles"
 				variant="minimal"

--- a/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Loader2Icon, UsersIcon } from 'lucide-react';
+import { ClockIcon } from '@phosphor-icons/react';
+import { Loader2Icon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -118,7 +119,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="User sessions with event timelines and custom event properties"
-					icon={<UsersIcon className="h-6 w-6 text-primary" />}
+					icon={<ClockIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
@@ -152,7 +153,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 					description="User sessions with event timelines and custom event properties"
 					errorMessage={error?.message || 'Failed to load sessions'}
 					hasError={true}
-					icon={<UsersIcon className="h-6 w-6 text-primary" />}
+					icon={<ClockIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
@@ -166,15 +167,15 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="User sessions with event timelines and custom event properties"
-					icon={<UsersIcon className="h-6 w-6 text-primary" />}
+					icon={<ClockIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
 				/>
 				<Card>
-					<CardContent>
-						<div className="py-12 text-center text-muted-foreground">
-							<UsersIcon className="mx-auto mb-4 h-12 w-12 opacity-50" />
+					<CardContent className="flex items-center justify-center">
+						<div className="flex flex-col items-center py-12 text-center text-muted-foreground">
+							<ClockIcon className="mb-4 h-12 w-12 opacity-50" />
 							<p className="mb-2 font-medium text-lg">No sessions found</p>
 							<p className="text-sm">
 								Sessions will appear here once users visit your website
@@ -190,7 +191,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 		<div className="space-y-6">
 			<WebsitePageHeader
 				description="User sessions with event timelines and custom event properties"
-				icon={<UsersIcon className="h-6 w-6 text-primary" />}
+				icon={<ClockIcon className="h-6 w-6 text-primary" />}
 				subtitle={`${allSessions.length} loaded`}
 				title="Recent Sessions"
 				variant="minimal"

--- a/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ClockIcon } from '@phosphor-icons/react';
+import { UserIcon } from '@phosphor-icons/react';
 import { Loader2Icon } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
@@ -119,7 +119,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="User sessions with event timelines and custom event properties"
-					icon={<ClockIcon className="h-6 w-6 text-primary" />}
+					icon={<UserIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
@@ -153,7 +153,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 					description="User sessions with event timelines and custom event properties"
 					errorMessage={error?.message || 'Failed to load sessions'}
 					hasError={true}
-					icon={<ClockIcon className="h-6 w-6 text-primary" />}
+					icon={<UserIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
@@ -167,7 +167,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 			<div className="space-y-6">
 				<WebsitePageHeader
 					description="User sessions with event timelines and custom event properties"
-					icon={<ClockIcon className="h-6 w-6 text-primary" />}
+					icon={<UserIcon className="h-6 w-6 text-primary" />}
 					title="Recent Sessions"
 					variant="minimal"
 					websiteId={websiteId}
@@ -175,7 +175,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 				<Card>
 					<CardContent className="flex items-center justify-center">
 						<div className="flex flex-col items-center py-12 text-center text-muted-foreground">
-							<ClockIcon className="mb-4 h-12 w-12 opacity-50" />
+							<UserIcon className="mb-4 h-12 w-12 opacity-50" />
 							<p className="mb-2 font-medium text-lg">No sessions found</p>
 							<p className="text-sm">
 								Sessions will appear here once users visit your website
@@ -191,7 +191,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 		<div className="space-y-6">
 			<WebsitePageHeader
 				description="User sessions with event timelines and custom event properties"
-				icon={<ClockIcon className="h-6 w-6 text-primary" />}
+				icon={<UserIcon className="h-6 w-6 text-primary" />}
 				subtitle={`${allSessions.length} loaded`}
 				title="Recent Sessions"
 				variant="minimal"

--- a/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/sessions/_components/sessions-list.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { UserIcon } from '@phosphor-icons/react';
-import { Loader2Icon } from 'lucide-react';
+import { UserIcon, SpinnerIcon } from '@phosphor-icons/react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -136,7 +135,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 						</div>
 						<div className="flex items-center justify-center pt-4">
 							<div className="flex items-center gap-2 text-muted-foreground">
-								<Loader2Icon className="h-4 w-4 animate-spin" />
+								<SpinnerIcon className="h-4 w-4 animate-spin" />
 								<span className="text-sm">Loading sessions...</span>
 							</div>
 						</div>
@@ -216,7 +215,7 @@ export function SessionsList({ websiteId }: SessionsListProps) {
 							<div className="flex justify-center">
 								{isLoading ? (
 									<div className="flex items-center gap-2 text-muted-foreground">
-										<Loader2Icon className="h-4 w-4 animate-spin" />
+										<SpinnerIcon className="h-4 w-4 animate-spin" />
 										<span className="text-sm">Loading more sessions...</span>
 									</div>
 								) : (

--- a/apps/dashboard/components/layout/navigation/navigation-config.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-config.tsx
@@ -1,7 +1,7 @@
 import {
 	BugIcon,
 	ChatCircleIcon,
-	ClockIcon,
+	UserIcon,
 	CurrencyDollarIcon,
 	FunnelIcon,
 	GearIcon,
@@ -77,7 +77,7 @@ export const websiteNavigation: NavigationSection[] = [
 		title: 'Web Analytics',
 		items: [
 			{ name: 'Overview', icon: HouseIcon, href: '', highlight: true },
-			{ name: 'Sessions', icon: ClockIcon, href: '/sessions', highlight: true },
+			{ name: 'Sessions', icon: UserIcon, href: '/sessions', highlight: true },
 			{ name: 'Errors', icon: BugIcon, href: '/errors', highlight: true },
 			{ name: 'Map', icon: MapPinIcon, href: '/map', highlight: true },
 		],
@@ -115,7 +115,7 @@ export const demoNavigation: NavigationSection[] = [
 		title: 'Demo Analytics',
 		items: [
 			{ name: 'Overview', icon: HouseIcon, href: '', highlight: true },
-			{ name: 'Sessions', icon: ClockIcon, href: '/sessions', highlight: true },
+			{ name: 'Sessions', icon: UserIcon, href: '/sessions', highlight: true },
 			{ name: 'Profiles', icon: UsersIcon, href: '/profiles', highlight: true },
 			{ name: 'Map', icon: MapPinIcon, href: '/map', highlight: true },
 		],


### PR DESCRIPTION
# Pull Request

## Description
Fixed icon consistency and text alignment issues in the profiles-list and sessions-list page to improve UI consistency and user experience.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

## Screenshots
### Before
<img width="1209" height="435" alt="Screenshot 2025-07-28 at 21 32 53" src="https://github.com/user-attachments/assets/bd910aff-9b39-4856-b11a-3d580836b0f6" />
<img width="1204" height="461" alt="Screenshot 2025-07-28 at 21 33 00" src="https://github.com/user-attachments/assets/d59c9099-e499-429b-b6ba-081659d706bd" />
### After
<img width="1201" height="418" alt="Screenshot 2025-07-28 at 21 18 34" src="https://github.com/user-attachments/assets/d59a75b1-12b6-4fdf-8f38-89dc23a75d7c" />
<img width="1208" height="461" alt="Screenshot 2025-07-28 at 21 25 53" src="https://github.com/user-attachments/assets/fbbd0ced-1898-4a83-986b-895f871e3c6f" />