### PR TITLE
[FIX]: key generation in EditFunnelDialog component

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/funnels/_components/edit-funnel-dialog.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/funnels/_components/edit-funnel-dialog.tsx
@@ -469,7 +469,7 @@ export function EditFunnelDialog({
 											<Draggable
 												draggableId={`step-${index}`}
 												index={index}
-												key={`step-${index}-${step.type}-${step.target}-${step.name}`}
+												key={`step-${index}`}
 											>
 												{(provided: any, snapshot: any) => (
 													<div
@@ -529,7 +529,7 @@ export function EditFunnelDialog({
 								{formData.filters.map((filter, index) => (
 									<div
 										className="flex items-center gap-3 rounded border bg-muted/30 p-3"
-										key={`filter-${index}-${filter.field}-${filter.operator}-${filter.value}`}
+										key={`filter-${index}`}
 									>
 										<Select
 											onValueChange={(value) =>


### PR DESCRIPTION
# Pull Request

## Description
**Fixed focus loss in edit funnel dialog input fields**

This PR resolves an issue where users would lose input focus after typing a single character in the funnel step routes, names, descriptions, and filter value fields within the edit funnel dialog.

### Root Cause
The issue was caused by unstable React `key` props that included dynamic values (`step.target`, `step.name`, `filter.value`). When users typed, these values changed, causing React to treat the components as entirely new instances, resulting in component unmounting/remounting and subsequent focus loss.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

## Screen Recoding

https://github.com/user-attachments/assets/a8c03b68-969b-417c-890c-763e08750c07