### PR TITLE
Remove redundant sign-in failure toast.

### DIFF
--- a/apps/dashboard/app/(auth)/login/page.tsx
+++ b/apps/dashboard/app/(auth)/login/page.tsx
@@ -66,7 +66,7 @@ function LoginPage() {
 
 		setIsLoading(true);
 		try {
-			const result = await signIn.email({
+			await signIn.email({
 				email,
 				password,
 				callbackURL: '/home',
@@ -92,11 +92,6 @@ function LoginPage() {
 					},
 				},
 			});
-
-			if (result?.error) {
-				toast.error('Invalid credentials');
-				return;
-			}
 		} catch (_error) {
 			toast.error('Something went wrong');
 		} finally {


### PR DESCRIPTION
When user tries to sign-in and if the email/password is invalid; two toasts are shown at the top.

This PR removes the "Invalid credentials" toast as those are already handled by the `onError` event handler.

<details>
<summary>Before</summary>

<img width="393" height="93" alt="Screenshot 2025-08-01 at 9 45 49 PM" src="https://github.com/user-attachments/assets/5001f4f9-dd03-4524-b9eb-310a587848ad" />
<br>
<img width="414" height="181" alt="Screenshot 2025-08-01 at 9 25 57 PM" src="https://github.com/user-attachments/assets/3cf31a10-3bd6-4533-8af9-42a5961063b3" />
</details>

<details>
<summary>After</summary>

<img width="395" height="87" alt="Screenshot 2025-08-01 at 9 43 11 PM" src="https://github.com/user-attachments/assets/1949656b-85d9-471e-bdd6-a029fcabf41c" />
</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during login by relying on centralized error callbacks, ensuring users receive clearer feedback for invalid credentials or unexpected errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->