### PR TITLE
[FIX]: docs link and improve button layout in tracking setup tab

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/_components/tabs/tracking-setup-tab.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/_components/tabs/tracking-setup-tab.tsx
@@ -9,7 +9,7 @@ import {
 	ClipboardIcon,
 	CodeIcon,
 	FileCodeIcon,
-	InfoIcon,
+	ChatCircleIcon,
 	WarningCircleIcon,
 } from '@phosphor-icons/react';
 import { useState } from 'react';
@@ -600,22 +600,21 @@ export function WebsiteTrackingSetupTab({ websiteId }: WebsiteDataTabProps) {
 			<div className="grid grid-cols-2 gap-3">
 				<Button asChild size="sm" variant="outline">
 					<a
-						className="flex items-center gap-2"
-						href="https://docs.databuddy.cc"
+						className="flex items-center justify-center gap-2"
+						href="https://www.databuddy.cc/docs"
 						rel="noopener noreferrer"
 						target="_blank"
 					>
 						<BookOpenIcon className="h-4 w-4" weight="duotone" />
 						Documentation
-						<ArrowSquareOutIcon className="ml-auto h-3 w-3" weight="fill" />
 					</a>
 				</Button>
 				<Button asChild size="sm" variant="outline">
 					<a
-						className="flex items-center gap-2"
+						className="flex items-center justify-center gap-2"
 						href="mailto:support@databuddy.cc"
 					>
-						<InfoIcon className="h-4 w-4" weight="duotone" />
+						<ChatCircleIcon className="h-4 w-4" weight="duotone" />
 						Get Support
 					</a>
 				</Button>


### PR DESCRIPTION
# Pull Request

## Description
Fixed the Docs Link, and Documentation and Get Support buttons on the tracking setup page to have consistent styling.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

## Screen Recordings
### Before

https://github.com/user-attachments/assets/74dd8336-d2aa-4d2b-a3e6-8846315c553e

### After

https://github.com/user-attachments/assets/c3f38e96-9ab2-4c8e-ac37-79b922d7b3d3

