### PR TITLE
Fix hourly events query.

### DIFF
--- a/apps/api/src/query/builders/summary.ts
+++ b/apps/api/src/query/builders/summary.ts
@@ -141,7 +141,7 @@ export const SummaryBuilders: Record<string, SimpleQueryConfig> = {
                 ),
                 hour_range AS (
                   SELECT arrayJoin(arrayMap(
-                    h -> toDateTime(concat({startDate:String}, ' 00:00:00')) + (h * 3600),
+                    h -> toStartOfHour(toTimeZone(toDateTime(concat({startDate:String}, ' 00:00:00')) + (h * 3600), {timezone:String})),
                     range(toUInt32(dateDiff('hour', toDateTime(concat({startDate:String}, ' 00:00:00')), toDateTime(concat({endDate:String}, ' 23:59:59'))) + 1))
                   )) AS datetime
                 ),


### PR DESCRIPTION
When the hourly filter on the dashboard is selected, the chart shows no data; that is due to a missing timezone conversion in the hourly query.

| Before   |      After      | 
|----------|:-------------:
| <img width="2515" height="1239" alt="image" src="https://github.com/user-attachments/assets/b92f7178-8899-4cea-b450-c69e741fbb47" /> |  <img width="2531" height="1268" alt="image" src="https://github.com/user-attachments/assets/6b485a50-9335-4100-b05f-cf68e68d92fc" /> | 

