### PR TITLE
Simplify databunny api.

### DIFF
--- a/apps/api/src/agent/handlers/chart-handler.ts
+++ b/apps/api/src/agent/handlers/chart-handler.ts
@@ -72,7 +72,7 @@ export async function* handleChartResponse(
 					: getRandomMessage(noDataMessages),
 			data: {
 				hasVisualization: queryResult.data.length > 0,
-				chartType: parsedAiJson.chart_type,
+				chartType: parsedAiJson.chart_type || 'bar',
 				data: queryResult.data,
 				responseType: 'chart',
 			},

--- a/apps/api/src/agent/index.ts
+++ b/apps/api/src/agent/index.ts
@@ -7,7 +7,7 @@ export { processAssistantRequest } from './processor';
 export {
 	AIPlanSchema,
 	AIResponseJsonSchema,
-	comprehensiveUnifiedPrompt,
+	comprehensiveSystemPrompt,
 } from './prompts/agent';
 export { getAICompletion } from './utils/ai-client';
 export { executeQuery } from './utils/query-executor';

--- a/apps/api/src/agent/prompts/agent.ts
+++ b/apps/api/src/agent/prompts/agent.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import type { AssistantRequestType } from '../../schemas/assistant-schemas';
 
 export const AIResponseJsonSchema = z.object({
 	sql: z.string().nullable().optional(),
@@ -41,14 +42,11 @@ export const AIPlanSchema = z.object({
 	plan: z.array(z.string()),
 });
 
-export const comprehensiveUnifiedPrompt = (
-	userQuery: string,
+export const comprehensiveSystemPrompt = (
 	websiteId: string,
 	websiteHostname: string,
 	mode: 'analysis_only' | 'execute_chat' | 'execute_agent_step',
-	previousMessages?: Array<{ role: string; content: string }>,
-	agentToolResult?: Record<string, unknown>,
-	_model?: 'chat' | 'agent' | 'agent-max'
+	_model?: AssistantRequestType['model']
 ) => `
 <persona>
 You are Databunny, a world-class, specialized data analyst for the website ${websiteHostname}. You are precise, analytical, and secure. Your sole purpose is to help users understand their website's analytics data by providing insights, generating SQL queries, and creating visualizations.
@@ -168,25 +166,8 @@ You are Databunny, a world-class, specialized data analyst for the website ${web
   <website_id>${websiteId}</website_id>
   <website_hostname>${websiteHostname}</website_hostname>
   <mode>${mode}</mode>
-  <user_query>${userQuery}</user_query>
   <current_date_utc>${new Date().toISOString().split('T')[0]}</current_date_utc>
   <current_timestamp_utc>${new Date().toISOString()}</current_timestamp_utc>
-  ${
-		previousMessages && previousMessages.length > 0
-			? `
-  <conversation_history>
-    ${previousMessages
-			.slice(-4)
-			.map(
-				(msg) =>
-					`<message role="${msg.role}">${msg.content?.substring(0, 200)}${msg.content?.length > 200 ? '...' : ''}</message>`
-			)
-			.join('\n')}
-  </conversation_history>
-  `
-			: ''
-	}
-  ${agentToolResult ? `<agent_tool_result>${JSON.stringify(agentToolResult)}</agent_tool_result>` : ''}
 </request_context>
 
 <workflow_instructions>

--- a/apps/api/src/routes/assistant.ts
+++ b/apps/api/src/routes/assistant.ts
@@ -25,10 +25,10 @@ export const assistant = new Elysia({ prefix: '/v1/assistant' })
 	.post(
 		'/stream',
 		async ({ body, user }: { body: AssistantRequestType; user: User }) => {
-			const { message, website_id, model, context } = body;
+			const { messages, websiteId, model } = body;
 
 			try {
-				const websiteValidation = await validateWebsite(website_id);
+				const websiteValidation = await validateWebsite(websiteId);
 
 				if (!websiteValidation.success) {
 					return createStreamingResponse(
@@ -45,11 +45,10 @@ export const assistant = new Elysia({ prefix: '/v1/assistant' })
 				}
 
 				const assistantRequest: AssistantRequest = {
-					message,
-					website_id,
-					website_hostname: website.domain,
+					messages,
+					websiteId,
+					websiteHostname: website.domain,
 					model: model || 'chat',
-					context,
 				};
 
 				const assistantContext: AssistantContext = {

--- a/apps/api/src/schemas/assistant-schemas.ts
+++ b/apps/api/src/schemas/assistant-schemas.ts
@@ -1,33 +1,23 @@
 import { t } from 'elysia';
 
-export const AssistantRequestSchema = t.Object({
-	message: t.String(),
-	website_id: t.String(),
-	model: t.Optional(
-		t.Union([t.Literal('chat'), t.Literal('agent'), t.Literal('agent-max')])
-	),
-	context: t.Optional(
-		t.Object({
-			previousMessages: t.Optional(
-				t.Array(
-					t.Object({
-						role: t.Optional(t.String()),
-						content: t.String(),
-					})
-				)
+export const AssistantRequestSchema = t.Object(
+	{
+		messages: t.Array(
+			t.Object(
+				{
+					role: t.Union([t.Literal('user'), t.Literal('assistant')]),
+					content: t.String(),
+				},
+				{ additionalProperties: false }
 			),
-		})
-	),
-});
+			{ minItems: 1 }
+		),
+		websiteId: t.String(),
+		model: t.Optional(
+			t.Union([t.Literal('chat'), t.Literal('agent'), t.Literal('agent-max')])
+		),
+	},
+	{ additionalProperties: false }
+);
 
-export type AssistantRequestType = {
-	message: string;
-	website_id: string;
-	model?: 'chat' | 'agent' | 'agent-max';
-	context?: {
-		previousMessages?: Array<{
-			role?: string;
-			content: string;
-		}>;
-	};
-};
+export type AssistantRequestType = typeof AssistantRequestSchema.static;

--- a/apps/dashboard/app/(main)/websites/[id]/_components/tabs/overview-tab.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/_components/tabs/overview-tab.tsx
@@ -914,7 +914,7 @@ export function WebsiteOverviewTab({
 	);
 
 	return (
-		<div className="space-y-6 pt-6">
+		<div className="space-y-6">
 			<EventLimitIndicator />
 			<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 sm:gap-4 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-6">
 				{[

--- a/apps/dashboard/app/(main)/websites/[id]/assistant/components/chat-section.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/assistant/components/chat-section.tsx
@@ -1,15 +1,15 @@
 'use client';
 
 import {
-	Brain,
-	ChartBar,
+	BrainIcon,
+	ChartBarIcon,
 	ChatIcon,
-	ClockCounterClockwise,
-	Hash,
-	Lightning,
-	PaperPlaneRight,
-	Sparkle,
-	TrendUp,
+	ClockCounterClockwiseIcon,
+	HashIcon,
+	LightningIcon,
+	PaperPlaneRightIcon,
+	SparkleIcon,
+	TrendUpIcon,
 } from '@phosphor-icons/react';
 import { useAtom } from 'jotai';
 import { useEffect, useRef, useState } from 'react';
@@ -98,12 +98,16 @@ export default function ChatSection() {
 	const quickQuestions = [
 		{
 			text: 'Show me page views over the last 7 days',
-			icon: TrendUp,
+			icon: TrendUpIcon,
 			type: 'chart',
 		},
-		{ text: 'How many visitors yesterday?', icon: Hash, type: 'metric' },
-		{ text: 'Top traffic sources breakdown', icon: ChartBar, type: 'chart' },
-		{ text: "What's my bounce rate?", icon: Hash, type: 'metric' },
+		{ text: 'How many visitors yesterday?', icon: HashIcon, type: 'metric' },
+		{
+			text: 'Top traffic sources breakdown',
+			icon: ChartBarIcon,
+			type: 'chart',
+		},
+		{ text: "What's my bounce rate?", icon: HashIcon, type: 'metric' },
 	];
 
 	// Focus input when component mounts and after sending
@@ -140,7 +144,7 @@ export default function ChatSection() {
 				<div className="flex min-w-0 flex-1 items-center gap-3">
 					<div className="relative">
 						<div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-primary/20 to-accent/20 shadow-sm">
-							<Brain className="h-6 w-6 text-primary" />
+							<BrainIcon className="h-6 w-6 text-primary" weight="duotone" />
 						</div>
 						{isLoading && (
 							<div className="-bottom-1 -right-1 absolute flex h-4 w-4 items-center justify-center rounded-full bg-green-500">
@@ -177,7 +181,7 @@ export default function ChatSection() {
 						title="Open chat history"
 						variant="ghost"
 					>
-						<ChatIcon className="h-5 w-5" />
+						<ChatIcon className="h-5 w-5" weight="duotone" />
 					</Button>
 					<Button
 						className="h-9 w-9 flex-shrink-0 transition-all duration-200 hover:bg-destructive/10 hover:text-destructive"
@@ -187,7 +191,7 @@ export default function ChatSection() {
 						title="Reset chat"
 						variant="ghost"
 					>
-						<ClockCounterClockwise
+						<ClockCounterClockwiseIcon
 							className={cn(
 								'h-4 w-4 transition-transform duration-200',
 								isLoading && 'animate-spin'
@@ -206,7 +210,10 @@ export default function ChatSection() {
 							<div className="fade-in-0 slide-in-from-bottom-4 animate-in space-y-6 duration-500">
 								<div className="py-8 text-center">
 									<div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gradient-to-br from-primary/10 to-accent/10">
-										<Sparkle className="h-8 w-8 text-primary" />
+										<SparkleIcon
+											className="h-8 w-8 text-primary"
+											weight="duotone"
+										/>
 									</div>
 									<h3 className="mb-2 font-semibold text-lg">
 										Welcome to Databunny
@@ -220,7 +227,7 @@ export default function ChatSection() {
 
 								<div className="space-y-3">
 									<div className="mb-3 flex items-center gap-2 text-muted-foreground text-sm">
-										<Lightning className="h-4 w-4" />
+										<LightningIcon className="h-4 w-4" weight="duotone" />
 										<span>Try these examples:</span>
 									</div>
 									{quickQuestions.map((question, index) => (
@@ -317,7 +324,7 @@ export default function ChatSection() {
 							size="icon"
 							title="Send message"
 						>
-							<PaperPlaneRight
+							<PaperPlaneRightIcon
 								className={cn(
 									'h-4 w-4',
 									inputValue.trim() &&
@@ -325,6 +332,7 @@ export default function ChatSection() {
 										!isRateLimited &&
 										'scale-110'
 								)}
+								weight="duotone"
 							/>
 						</Button>
 					</div>
@@ -332,20 +340,20 @@ export default function ChatSection() {
 					{/* Helper text */}
 					<div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
 						<div className="flex items-center gap-2 text-muted-foreground">
-							<Sparkle className="h-3 w-3 flex-shrink-0" />
+							<SparkleIcon className="h-3 w-3 flex-shrink-0" weight="duotone" />
 							<span>Ask about trends, comparisons, or specific metrics</span>
 						</div>
 						{hasMessages && (
 							<div className="flex items-center gap-3 text-muted-foreground">
 								{messageStats.charts > 0 && (
 									<span className="flex items-center gap-1">
-										<ChartBar className="h-3 w-3" />
+										<ChartBarIcon className="h-3 w-3" weight="duotone" />
 										{messageStats.charts}
 									</span>
 								)}
 								{messageStats.metrics > 0 && (
 									<span className="flex items-center gap-1">
-										<Hash className="h-3 w-3" />
+										<HashIcon className="h-3 w-3" weight="duotone" />
 										{messageStats.metrics}
 									</span>
 								)}

--- a/apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.ts
@@ -182,10 +182,12 @@ export function useChat() {
 						},
 						credentials: 'include',
 						body: JSON.stringify({
-							message: messageContent,
-							website_id: websiteId || '',
+							messages: [...messages, userMessage].map(({ type, content }) => ({
+								role: type,
+								content,
+							})),
+							websiteId: websiteId || '',
 							model,
-							context: { previousMessages: messages },
 						}),
 					}
 				);


### PR DESCRIPTION
Had to add default chart type as `bar`, because for some reason the LLM response was not giving one.

Might be solved by making use of [discriminated unions](https://zod.dev/api#discriminated-unions) in the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Chart responses now default to a bar chart when chart type is missing, improving reliability.

- Documentation
  - Assistant streaming API: send a messages array (role: 'user' | 'assistant', content) and websiteId (camelCase) instead of message/context and website_id.

- Refactor
  - Assistant backend request and prompt flow streamlined (no user-visible behavior changes).

- Style
  - Dashboard assistant icons standardized to Icon variants; minor layout tweak in Websites Overview (removed top padding).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->