### PR TITLE
[FIX]: adjust mail icon styling in footer

### DIFF
--- a/apps/docs/components/docs-footer.tsx
+++ b/apps/docs/components/docs-footer.tsx
@@ -146,7 +146,7 @@ export function DocsFooter() {
 									className="group flex items-center gap-3 text-muted-foreground hover:text-foreground"
 									href="mailto:support@databuddy.cc"
 								>
-									<IoMdMail className="h-5 w-5" />
+									<IoMdMail className="h-5 w-5 shrink-0" />
 									support@databuddy.cc
 								</a>
 							</li>


### PR DESCRIPTION
# Pull Request

## Description
Fixed the visibility of support mail icon in the desktop view.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

## Screenshots
<img width="274" height="257" alt="Screenshot 2025-08-18 at 11 57 18" src="https://github.com/user-attachments/assets/73d25e41-4cbf-4a7c-8281-1f6c3d7ea2f8" />
<img width="286" height="250" alt="Screenshot 2025-08-18 at 11 53 42" src="https://github.com/user-attachments/assets/f033220f-fd02-4b50-b7e4-d53d9508275f" />
