### PR TITLE
Update AI message handling in useChat hook

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.ts
@@ -1,7 +1,6 @@
 import type { StreamingUpdate } from '@databuddy/shared';
 import { useAtom } from 'jotai';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { trpc } from '@/lib/trpc';
 import {
 	inputValueAtom,
 	isLoadingAtom,
@@ -121,6 +120,15 @@ export function useChat() {
 		};
 	}, []);
 
+	function updateAiMessage(message: Message) {
+		setMessages((prev) => {
+			//TODO: find a way to update the message with the correct id
+			const newMessages = [...prev];
+			newMessages[newMessages.length - 1] = message;
+			return newMessages;
+		});
+	}
+
 	const sendMessage = useCallback(
 		async (content?: string) => {
 			const messageContent = content || inputValue.trim();
@@ -154,6 +162,8 @@ export function useChat() {
 				hasVisualization: false,
 				thinkingSteps: [],
 			};
+
+			setMessages((prev) => [...prev, assistantMessage]);
 
 			try {
 				// Stream the AI response using the new single endpoint
@@ -304,6 +314,7 @@ export function useChat() {
 											break;
 										}
 									}
+									updateAiMessage(assistantMessage);
 								} catch (_parseError) {
 									console.warn('Failed to parse SSE data:', line);
 								}
@@ -323,8 +334,6 @@ export function useChat() {
 			} finally {
 				setIsLoading(false);
 			}
-
-			setMessages((prev) => [...prev, assistantMessage]);
 		},
 		[
 			inputValue,


### PR DESCRIPTION
This pull request refactors the message update logic in the `useChat` hook to ensure that AI-generated messages are properly updated during streaming responses, rather than being appended multiple times. The changes streamline how assistant messages are managed in state, improving consistency and preventing duplicate entries.

**Message update logic improvements:**

* Added a new `updateAiMessage` function to update the latest assistant message in the `messages` state, ensuring that streamed AI responses are reflected in place rather than appended as new messages. ([apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.tsR123-R131](diffhunk://#diff-73e8f4fbb4ca4ccdf73a44940f2311570d608773a2c2d007e2abfcd411621fdfR123-R131))
* Moved the initial insertion of the assistant message to the start of the response streaming process, so updates can be applied incrementally. ([apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.tsR166-R167](diffhunk://#diff-73e8f4fbb4ca4ccdf73a44940f2311570d608773a2c2d007e2abfcd411621fdfR166-R167))
* Updated the streaming response handler to use `updateAiMessage` for each streamed chunk, replacing the previous approach of appending messages. ([apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.tsR317](diffhunk://#diff-73e8f4fbb4ca4ccdf73a44940f2311570d608773a2c2d007e2abfcd411621fdfR317))
* Removed the redundant final appending of the assistant message after response completion, as updates are now handled during streaming. ([apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.tsL326-L327](diffhunk://#diff-73e8f4fbb4ca4ccdf73a44940f2311570d608773a2c2d007e2abfcd411621fdfL326-L327))

**Code cleanup:**

* Removed unused `trpc` import from `use-chat.ts` to tidy up dependencies. ([apps/dashboard/app/(main)/websites/[id]/assistant/hooks/use-chat.tsL4](diffhunk://#diff-73e8f4fbb4ca4ccdf73a44940f2311570d608773a2c2d007e2abfcd411621fdfL4))