### PR TITLE
Add zoom limits and panning constraints to map component

### DIFF
--- a/apps/dashboard/components/analytics/map-component.tsx
+++ b/apps/dashboard/components/analytics/map-component.tsx
@@ -323,7 +323,7 @@ export function MapComponent({
 		return () => window.removeEventListener('resize', updateHeight);
 	}, []);
 
-	const zoom = resolvedHeight ? Math.log2(resolvedHeight / 400) + 1 : 1;
+	const zoom = 2.2;
 
 	useEffect(() => {
 		if (mapRef.current) {
@@ -437,6 +437,10 @@ export function MapComponent({
 					attributionControl={false}
 					center={[40, 3]}
 					className={resolvedTheme === 'dark' ? 'map-dark' : 'map-light'}
+					maxBounds={[[-85, -180], [85, 180]]}
+					maxBoundsViscosity={1.0}
+					maxZoom={5}
+					minZoom={2.2}
 					preferCanvas
 					ref={mapRef}
 					style={{


### PR DESCRIPTION
This PR adds zoom limits (min: 2.2, max: 5) and panning constraints to prevent users from zooming out infinitely or dragging the map completely out of view. The map now starts at zoom level 2.2 for consistent user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map now opens at a consistent zoom level for all users.
  * Panning is restricted to the world map, preventing navigation beyond map edges.
  * Zoom is clamped to a sensible range to avoid excessive zooming in or out.
  * Existing interactions (e.g., click-to-fly, tooltips) are preserved.
  * Delivers more predictable navigation across screen sizes and resolutions without altering any public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->