### PR TITLE
quick ui change to dialogue pop up

### DIFF
--- a/apps/dashboard/components/organizations/create-organization-dialog.tsx
+++ b/apps/dashboard/components/organizations/create-organization-dialog.tsx
@@ -76,6 +76,13 @@ export function CreateOrganizationDialog({
 		metadata: {},
 	});
 	const [slugManuallyEdited, setSlugManuallyEdited] = useState(false);
+	const [touchedFields, setTouchedFields] = useState<{
+		name: boolean;
+		slug: boolean;
+	}>({
+		name: false,
+		slug: false,
+	});
 
 	// Image upload state
 	const [preview, setPreview] = useState<string | null>(null);
@@ -106,6 +113,7 @@ export function CreateOrganizationDialog({
 		setPreview(null);
 		setLogoFile(null);
 		setSlugManuallyEdited(false);
+		setTouchedFields({ name: false, slug: false });
 		resetCropState();
 		setIsCropModalOpen(false);
 	};
@@ -299,16 +307,19 @@ export function CreateOrganizationDialog({
 								</Label>
 								{(() => {
 									const isNameValid = formData.name.trim().length >= 2;
+									const hasUserTyped = formData.name.length > 0;
+									const shouldShowError = (touchedFields.name || hasUserTyped) && !isNameValid;
 									return (
 										<>
 											<Input
 												aria-describedby="org-name-help"
-												aria-invalid={!isNameValid}
+												aria-invalid={shouldShowError}
 												className={`rounded border-border/50 focus:border-primary/50 focus:ring-primary/20 ${
-													isNameValid ? '' : 'border-destructive'
+													shouldShowError ? 'border-destructive' : ''
 												}`}
 												id="org-name"
 												maxLength={100}
+												onBlur={() => setTouchedFields(prev => ({ ...prev, name: true }))}
 												onChange={(e) =>
 													setFormData((prev) => ({
 														...prev,
@@ -340,16 +351,19 @@ export function CreateOrganizationDialog({
 									const isSlugValid =
 										SLUG_ALLOWED_REGEX.test(formData.slug || '') &&
 										(formData.slug || '').trim().length >= 2;
+									const hasUserTyped = (formData.slug || '').length > 0;
+									const shouldShowError = (touchedFields.slug || hasUserTyped) && !isSlugValid;
 									return (
 										<>
 											<Input
 												aria-describedby="org-slug-help"
-												aria-invalid={!isSlugValid}
+												aria-invalid={shouldShowError}
 												className={`rounded border-border/50 focus:border-primary/50 focus:ring-primary/20 ${
-													isSlugValid ? '' : 'border-destructive'
+													shouldShowError ? 'border-destructive' : ''
 												}`}
 												id="org-slug"
 												maxLength={50}
+												onBlur={() => setTouchedFields(prev => ({ ...prev, slug: true }))}
 												onChange={(e) => handleSlugChange(e.target.value)}
 												placeholder="e.g., acme-corp"
 												value={formData.slug}


### PR DESCRIPTION
Fixes the issue where input fields in the create organization dialog were showing red validation borders immediately when opened, before user interaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced form validation feedback in the organization creation dialog. Validation error messages and visual styling updates now appear only after users interact with specific fields, reducing unnecessary clutter on initial form load. This provides clearer, more contextual feedback based on actual user interaction and field state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->