### PR TITLE
update card border in success

### DIFF
--- a/apps/dashboard/components/analytics/stat-card.tsx
+++ b/apps/dashboard/components/analytics/stat-card.tsx
@@ -206,7 +206,7 @@ export function StatCard({
 	const getVariantClasses = () => {
 		switch (variant) {
 			case "success":
-				return "bg-accent/10 border-accent/20";
+				return "bg-accent/10 border-border/50";
 			case "info":
 				return "bg-accent/10 border-accent/20";
 			case "warning":


### PR DESCRIPTION
# Pull Request

## Description
Fixes #191

The Bounce Rate card was missing a visible border due to the success variant using `border-accent/20`, which was too faint to see.

Changed the success variant border from `border-accent/20` to `border-border/50` to match the other stat cards.

**Before:** Border was nearly invisible on the Bounce Rate box
**After:** Border is now consistent with other metric boxes on the dashboard
<img width="1466" height="221" alt="image" src="https://github.com/user-attachments/assets/754d0abf-d153-4ddf-910d-4c8229787a1c" />


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 