### PR TITLE
fix: prevent sidebar item content shift when active border appears

### DIFF
--- a/apps/dashboard/components/layout/navigation/navigation-item.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-item.tsx
@@ -119,9 +119,9 @@ export function NavigationItem({
 			aria-current={isActive ? "page" : undefined}
 			aria-label={`${name}${isExternal ? " (opens in new tab)" : ""}`}
 			className={cn(
-				"group flex items-center gap-3 px-4 py-2.5 text-sm hover:text-sidebar-accent-foreground",
+				"group flex items-center gap-3 px-4 py-2.5 text-sm hover:text-sidebar-accent-foreground border-r-2 border-transparent",
 				isActive
-					? "border-sidebar-ring border-r-2 bg-sidebar-accent font-medium text-sidebar-accent-foreground"
+					? "border-sidebar-ring bg-sidebar-accent font-medium text-sidebar-accent-foreground"
 					: "text-sidebar-foreground/70 hover:bg-sidebar-accent"
 			)}
 			data-nav-href={href}


### PR DESCRIPTION
# Pull Request

## Description
The sidebar item content shifts when the active border appears to the right side.

### Before:

https://github.com/user-attachments/assets/21a9ee11-a926-4f40-9227-00807fefb97e



### After:


https://github.com/user-attachments/assets/5a78d927-c5fa-4ad8-82f4-06d6d798633b


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation item styling to improve visual alignment and spacing consistency between active and inactive states
  * Enhanced active navigation indicator styling while maintaining interactive behavior

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->