### PR TITLE
fix(docs-sidebar): avoid unwanted text wrapping

### DIFF
--- a/apps/docs/components/custom-sidebar.tsx
+++ b/apps/docs/components/custom-sidebar.tsx
@@ -132,7 +132,7 @@ export default function CustomSidebar() {
 
 function NewBadge({ isSelected }: { isSelected?: boolean }) {
 	return (
-		<div className="flex w-full items-center justify-end">
+		<div className="flex items-center justify-end">
 			<Badge
 				className={cn(
 					"!no-underline !decoration-transparent pointer-events-none border-dashed",


### PR DESCRIPTION
# Pull Request

## Description
Prevents sidebar menu item text from being wrapped

### Before:
<img width="984" height="864" alt="Screenshot 2025-12-09 at 8 25 15 PM" src="https://github.com/user-attachments/assets/16d2e09f-0f68-42ed-9f7d-2007e94f1a1e" />


### After:

<img width="1000" height="859" alt="Screenshot 2025-12-09 at 8 25 45 PM" src="https://github.com/user-attachments/assets/22e6390b-1e27-4124-a653-47261facdf36" />


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted badge container layout to fit content width instead of stretching across full available width.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->