### PR TITLE
Revert "fix(frontend): resolve prettier and react-email version mismatches"

### DIFF
--- a/apps/dashboard/next.config.ts
+++ b/apps/dashboard/next.config.ts
@@ -38,8 +38,6 @@ const nextConfig: NextConfig = {
 		"pino-pretty",
 		"@axiomhq/pino",
 		"thread-stream",
-		"@react-email/render",
-		"prettier",
 	],
 	transpilePackages: [],
 	output: "standalone",

--- a/package.json
+++ b/package.json
@@ -105,9 +105,5 @@
     "prettier": "^3.7.4",
     "react-hotkeys-hook": "^5.2.1",
     "zod": "^4.1.13"
-  },
-  "overrides": {
-    "prettier": "^3.7.4",
-    "@react-email/render": "1.1.3"
   }
 }


### PR DESCRIPTION
Reverts databuddy-analytics/Databuddy#226

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes `@react-email/render`/`prettier` from Next.js `serverExternalPackages` and drops `package.json` overrides for those packages.
> 
> - **Build/Config**:
>   - Update `apps/dashboard/next.config.ts` to remove `@react-email/render` and `prettier` from `serverExternalPackages`.
>   - Clean up `package.json` by removing the `overrides` block for `prettier` and `@react-email/render`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b56aaadccd622e3f4d6479cad324b973ea484aa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed version override configurations for package dependencies, simplifying project dependency management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->