### PR TITLE
fix(chat): prevent delayed render of user messages

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/agent/_components/agent-messages.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/agent/_components/agent-messages.tsx
@@ -139,6 +139,7 @@ function renderMessagePart(
 ) {
 	const key = `${messageId}-${partIndex}`;
 	const isCurrentlyStreaming = isLastMessage && isStreaming;
+	const mode = role === "user" ? "static" : "streaming";
 
 	// Handle grouped tool calls
 	if (Array.isArray(part)) {
@@ -177,11 +178,7 @@ function renderMessagePart(
 		}
 
 		return (
-			<MessageResponse
-				isAnimating={isCurrentlyStreaming}
-				key={key}
-				mode={role === "user" ? "static" : "streaming"}
-			>
+			<MessageResponse isAnimating={isCurrentlyStreaming} key={key} mode={mode}>
 				{textPart.text}
 			</MessageResponse>
 		);


### PR DESCRIPTION
# Pull Request

## Description
Fixes an issue in agent where user messages were displayed with a noticeable delay after sending.

### Before:


https://github.com/user-attachments/assets/36921ae6-0fd7-417d-b159-9b4c4552a31c






### After:
https://github.com/user-attachments/assets/7d6120bd-d6de-437e-a18e-1f203b25e86a


## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message rendering now distinguishes sender role to choose appropriate display mode (static vs. streaming).
  * Message responses receive role-aware rendering, improving animation and streaming behavior.
  * Overall message pipeline improved for more consistent, accurate, and predictable display across message types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->