### PR TITLE
fix: update WebsiteDialog form state handling.

### DIFF
--- a/apps/dashboard/components/website-dialog.tsx
+++ b/apps/dashboard/components/website-dialog.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { WEBSITE_NAME_REGEX } from "@databuddy/validation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect } from "react";
-import { useForm } from "react-hook-form";
+import { type SubmitHandler, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { useOrganizationsContext } from "@/components/providers/organizations-provider";
@@ -41,7 +42,11 @@ const domainRegex =
 const wwwRegex = /^www\./;
 
 const formSchema = z.object({
-	name: z.string().min(1, "Name is required"),
+	name: z
+		.string()
+		.trim()
+		.min(1, "Name is required")
+		.regex(WEBSITE_NAME_REGEX, "Use alphanumeric, spaces, -, _, or ."),
 	domain: z
 		.string()
 		.min(1, "Domain is required")
@@ -72,6 +77,7 @@ export function WebsiteDialog({
 
 	const form = useForm<FormData>({
 		resolver: zodResolver(formSchema),
+		mode: "onBlur",
 		defaultValues: {
 			name: "",
 			domain: "",
@@ -117,8 +123,7 @@ export function WebsiteDialog({
 		return rpcError?.message || defaultMessage;
 	};
 
-	const handleSubmit = async () => {
-		const formData = form.getValues();
+	const handleSubmit: SubmitHandler<FormData> = async (formData) => {
 		const submissionData: CreateWebsiteData = {
 			name: formData.name,
 			domain: formData.domain,


### PR DESCRIPTION
## Description
This pull request updates the website dialog form validation and improves the handling of form state in the `WebsiteDialog` component. The most important changes include enforcing a stricter validation rule for website names, using the correct form state properties for submit button logic, and ensuring validation occurs on blur.

**Validation improvements:**

* Updated the `name` field in the form schema to use the `WEBSITE_NAME_REGEX` pattern, enforcing allowed characters for website names.
* Imported `WEBSITE_NAME_REGEX` from `@databuddy/validation` to centralize validation logic.

**Form state handling:**

* Changed the form validation mode to `"onBlur"` to trigger validation when fields lose focus.
* Refactored the submit button logic to use destructured `isValid` and `isDirty` from `form.formState`, following React Hook Form best practices for triggering re-renders.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Website name field now trims input and enforces a stricter character pattern for more accurate validation.
  * Validation feedback is shown on blur, offering clearer guidance when leaving fields.
  * Submit button enablement now more reliably reflects form validity and whether edits have been made.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->