### PR TITLE
fix: clean up cache by removing stale keys

### DIFF
--- a/packages/sdk/src/core/flags/flags-manager.ts
+++ b/packages/sdk/src/core/flags/flags-manager.ts
@@ -106,6 +106,14 @@ export class CoreFlagsManager implements FlagsManager {
 		};
 	}
 
+	private removeStaleKeys(validCacheKeys: Set<string>): void {
+		for (const key of this.cache.keys()) {
+			if (!validCacheKeys.has(key)) {
+				this.cache.delete(key);
+			}
+		}
+	}
+
 	private async initialize(): Promise<void> {
 		// Load from persistent storage first (instant hydration)
 		if (!this.config.skipStorage && this.storage) {
@@ -303,6 +311,10 @@ export class CoreFlagsManager implements FlagsManager {
 				cacheKey: getCacheKey(key, user ?? this.config.user),
 				cacheEntry: createCacheEntry(result, ttl, staleTime),
 			}));
+
+			this.removeStaleKeys(
+				new Set(flagCacheEntries.map(({ cacheKey }) => cacheKey))
+			);
 
 			for (const { cacheKey, cacheEntry } of flagCacheEntries) {
 				this.cache.set(cacheKey, cacheEntry);


### PR DESCRIPTION
## Description
The change ensures that any keys in the cache that are no longer present in the latest `flags` object are removed, preventing stale or outdated cache entries from persisting.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stale feature-flag cache entries that no longer appear in the latest API response are now removed, ensuring applications read current flag values.
  * Cache population now occurs as a coordinated batch operation, improving consistency and reducing transient inconsistencies and race conditions during updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->