### PR TITLE
fix: Use user's timezone time in uptime table.

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/pulse/_components/recent-activity.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/pulse/_components/recent-activity.tsx
@@ -6,6 +6,8 @@ import {
 	XCircleIcon,
 } from "@phosphor-icons/react";
 import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
 import { Badge } from "@/components/ui/badge";
 import {
 	Table,
@@ -16,6 +18,11 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { cn } from "@/lib/utils";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+const userTimezone = dayjs.tz.guess();
 
 type Check = {
 	timestamp: string;
@@ -123,7 +130,10 @@ export function RecentActivity({ checks, isLoading }: RecentActivityProps) {
 										</div>
 									</TableCell>
 									<TableCell className="text-center text-muted-foreground text-xs">
-										{dayjs(check.timestamp).format("MMM D, HH:mm:ss")}
+										{dayjs
+											.utc(check.timestamp)
+											.tz(userTimezone)
+											.format("MMM D, HH:mm:ss")}
 									</TableCell>
 									<TableCell className="text-center text-muted-foreground text-xs">
 										<Badge className="font-mono text-[10px]" variant="outline">


### PR DESCRIPTION
## Description
The time shown earlier was not in user's timezone.

## Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded activity details now include response metrics and probe info: total response time, HTTP status code, probe region and IP (when available), plus error details.

* **Improvements**
  * Timestamps are converted and displayed in your local timezone for clearer, context-aware activity times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->