### PR TITLE
feat: add alarms system for notifications

### DIFF
--- a/apps/dashboard/app/(main)/settings/alarms/alarm-dialog.tsx
+++ b/apps/dashboard/app/(main)/settings/alarms/alarm-dialog.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { orpc } from "@/lib/orpc";
+import { type Alarm, channelIcons, channelLabels } from "./alarm-settings";
+
+type AlarmChannel = "slack" | "discord" | "email" | "webhook";
+
+interface AlarmDialogProps {
+	open: boolean;
+	onOpenChange: (open: boolean) => void;
+	mode: "create" | "edit";
+	alarm?: Alarm;
+}
+
+const targetPlaceholders: Record<AlarmChannel, string> = {
+	slack: "https://hooks.slack.com/services/...",
+	discord: "https://discord.com/api/webhooks/...",
+	email: "alerts@example.com",
+	webhook: "https://api.example.com/webhook",
+};
+
+const targetLabels: Record<AlarmChannel, string> = {
+	slack: "Webhook URL",
+	discord: "Webhook URL",
+	email: "Email Address",
+	webhook: "Webhook URL",
+};
+
+export function AlarmDialog({
+	open,
+	onOpenChange,
+	mode,
+	alarm,
+}: AlarmDialogProps) {
+	const queryClient = useQueryClient();
+	const [name, setName] = useState("");
+	const [description, setDescription] = useState("");
+	const [channel, setChannel] = useState<AlarmChannel>("slack");
+	const [target, setTarget] = useState("");
+
+	useEffect(() => {
+		if (mode === "edit" && alarm) {
+			setName(alarm.name);
+			setDescription(alarm.description || "");
+			setChannel(alarm.channel);
+			setTarget(alarm.target);
+		} else if (mode === "create") {
+			setName("");
+			setDescription("");
+			setChannel("slack");
+			setTarget("");
+		}
+	}, [mode, alarm, open]);
+
+	const createMutation = useMutation({
+		...orpc.alarms.create.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["alarms"] });
+			onOpenChange(false);
+		},
+	});
+
+	const updateMutation = useMutation({
+		...orpc.alarms.update.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["alarms"] });
+			onOpenChange(false);
+		},
+	});
+
+	const handleSubmit = (e: React.FormEvent) => {
+		e.preventDefault();
+
+		if (mode === "create") {
+			createMutation.mutate({
+				name,
+				description: description || undefined,
+				channel,
+				target,
+			});
+		} else if (alarm) {
+			updateMutation.mutate({
+				alarmId: alarm.id,
+				name,
+				description: description || undefined,
+				channel,
+				target,
+			});
+		}
+	};
+
+	const isPending = createMutation.isPending || updateMutation.isPending;
+	const isValid = name.trim() && target.trim();
+
+	return (
+		<Dialog open={open} onOpenChange={onOpenChange}>
+			<DialogContent className="sm:max-w-[425px]">
+				<form onSubmit={handleSubmit}>
+					<DialogHeader>
+						<DialogTitle>
+							{mode === "create" ? "Create Alarm" : "Edit Alarm"}
+						</DialogTitle>
+						<DialogDescription>
+							{mode === "create"
+								? "Create a new alarm to receive notifications"
+								: "Update alarm settings"}
+						</DialogDescription>
+					</DialogHeader>
+
+					<div className="grid gap-4 py-4">
+						<div className="grid gap-2">
+							<Label htmlFor="name">Name</Label>
+							<Input
+								id="name"
+								value={name}
+								onChange={(e) => setName(e.target.value)}
+								placeholder="Production Down Alert"
+								required
+							/>
+						</div>
+
+						<div className="grid gap-2">
+							<Label htmlFor="description">Description (optional)</Label>
+							<Textarea
+								id="description"
+								value={description}
+								onChange={(e) => setDescription(e.target.value)}
+								placeholder="Alert when production servers are down"
+								rows={2}
+							/>
+						</div>
+
+						<div className="grid gap-2">
+							<Label htmlFor="channel">Channel</Label>
+							<Select
+								value={channel}
+								onValueChange={(v) => setChannel(v as AlarmChannel)}
+							>
+								<SelectTrigger>
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									{(
+										Object.entries(channelLabels) as [AlarmChannel, string][]
+									).map(([key, label]) => {
+										const Icon = channelIcons[key];
+										return (
+											<SelectItem key={key} value={key}>
+												<div className="flex items-center gap-2">
+													<Icon className="size-4" />
+													{label}
+												</div>
+											</SelectItem>
+										);
+									})}
+								</SelectContent>
+							</Select>
+						</div>
+
+						<div className="grid gap-2">
+							<Label htmlFor="target">{targetLabels[channel]}</Label>
+							<Input
+								id="target"
+								value={target}
+								onChange={(e) => setTarget(e.target.value)}
+								placeholder={targetPlaceholders[channel]}
+								required
+							/>
+						</div>
+					</div>
+
+					<DialogFooter>
+						<Button
+							type="button"
+							variant="outline"
+							onClick={() => onOpenChange(false)}
+						>
+							Cancel
+						</Button>
+						<Button type="submit" disabled={isPending || !isValid}>
+							{isPending
+								? mode === "create"
+									? "Creating..."
+									: "Saving..."
+								: mode === "create"
+									? "Create Alarm"
+									: "Save Changes"}
+						</Button>
+					</DialogFooter>
+				</form>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/dashboard/app/(main)/settings/alarms/alarm-row.tsx
+++ b/apps/dashboard/app/(main)/settings/alarms/alarm-row.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import {
+	DotsThreeVerticalIcon,
+	PencilIcon,
+	TestTubeIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
+import { Button } from "@/components/ui/button";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { type Alarm, channelIcons, channelLabels } from "./alarm-settings";
+
+interface AlarmRowProps {
+	alarm: Alarm;
+	onEdit: () => void;
+	onToggle: (enabled: boolean) => void;
+	onDelete: () => void;
+	onTest: () => void;
+	isToggling?: boolean;
+	isDeleting?: boolean;
+	isTesting?: boolean;
+}
+
+export function AlarmRow({
+	alarm,
+	onEdit,
+	onToggle,
+	onDelete,
+	onTest,
+	isToggling,
+	isDeleting,
+	isTesting,
+}: AlarmRowProps) {
+	const ChannelIcon = channelIcons[alarm.channel];
+
+	return (
+		<div
+			className={cn(
+				"grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-4 transition-colors hover:bg-muted/50",
+				!alarm.enabled && "opacity-60"
+			)}
+		>
+			<div className="flex size-10 items-center justify-center rounded bg-muted">
+				<ChannelIcon className="size-5 text-muted-foreground" weight="duotone" />
+			</div>
+
+			<div className="min-w-0 space-y-1">
+				<div className="flex items-center gap-2">
+					<span className="truncate font-medium">{alarm.name}</span>
+					<span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-muted-foreground text-xs">
+						{channelLabels[alarm.channel]}
+					</span>
+				</div>
+				{alarm.description ? (
+					<p className="truncate text-muted-foreground text-sm">
+						{alarm.description}
+					</p>
+				) : (
+					<p className="truncate text-muted-foreground text-sm">
+						{alarm.target.length > 40
+							? `${alarm.target.substring(0, 40)}...`
+							: alarm.target}
+					</p>
+				)}
+			</div>
+
+			<Switch
+				checked={alarm.enabled}
+				onCheckedChange={onToggle}
+				disabled={isToggling}
+			/>
+
+			<DropdownMenu>
+				<DropdownMenuTrigger asChild>
+					<Button variant="ghost" size="icon" className="size-8">
+						<DotsThreeVerticalIcon className="size-4" />
+					</Button>
+				</DropdownMenuTrigger>
+				<DropdownMenuContent align="end">
+					<DropdownMenuItem onClick={onEdit}>
+						<PencilIcon className="mr-2 size-4" />
+						Edit
+					</DropdownMenuItem>
+					<DropdownMenuItem onClick={onTest} disabled={isTesting}>
+						<TestTubeIcon className="mr-2 size-4" />
+						{isTesting ? "Testing..." : "Send Test"}
+					</DropdownMenuItem>
+					<DropdownMenuSeparator />
+					<DropdownMenuItem
+						onClick={onDelete}
+						disabled={isDeleting}
+						className="text-destructive focus:text-destructive"
+					>
+						<TrashIcon className="mr-2 size-4" />
+						{isDeleting ? "Deleting..." : "Delete"}
+					</DropdownMenuItem>
+				</DropdownMenuContent>
+			</DropdownMenu>
+		</div>
+	);
+}

--- a/apps/dashboard/app/(main)/settings/alarms/alarm-settings.tsx
+++ b/apps/dashboard/app/(main)/settings/alarms/alarm-settings.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import {
+	BellRingingIcon,
+	PlusIcon,
+	DiscordLogoIcon,
+	SlackLogoIcon,
+	EnvelopeIcon,
+	LinkIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { EmptyState } from "@/components/empty-state";
+import { RightSidebar } from "@/components/right-sidebar";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { orpc } from "@/lib/orpc";
+import { AlarmRow } from "./alarm-row";
+import { AlarmDialog } from "./alarm-dialog";
+
+export type Alarm = {
+	id: string;
+	name: string;
+	description: string | null;
+	channel: "slack" | "discord" | "email" | "webhook";
+	target: string;
+	enabled: boolean;
+	createdAt: string;
+	updatedAt: string;
+};
+
+function SkeletonRow() {
+	return (
+		<div className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-4">
+			<Skeleton className="size-10 rounded" />
+			<div className="space-y-2">
+				<Skeleton className="h-4 w-32" />
+				<Skeleton className="h-3 w-48" />
+			</div>
+			<Skeleton className="h-6 w-16 rounded-full" />
+			<Skeleton className="size-4" />
+		</div>
+	);
+}
+
+function AlarmsSkeleton() {
+	return (
+		<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+			<div className="divide-y border-b lg:border-b-0">
+				<SkeletonRow />
+				<SkeletonRow />
+				<SkeletonRow />
+			</div>
+			<div className="space-y-4 bg-card p-5">
+				<Skeleton className="h-10 w-full" />
+				<Skeleton className="h-18 w-full rounded" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+		</div>
+	);
+}
+
+export const channelIcons = {
+	slack: SlackLogoIcon,
+	discord: DiscordLogoIcon,
+	email: EnvelopeIcon,
+	webhook: LinkIcon,
+} as const;
+
+export const channelLabels = {
+	slack: "Slack",
+	discord: "Discord",
+	email: "Email",
+	webhook: "Webhook",
+} as const;
+
+export function AlarmSettings() {
+	const queryClient = useQueryClient();
+	const [showCreateDialog, setShowCreateDialog] = useState(false);
+	const [editingAlarm, setEditingAlarm] = useState<Alarm | null>(null);
+
+	const { data, isLoading, isError } = useQuery({
+		...orpc.alarms.list.queryOptions({
+			input: {},
+		}),
+		refetchOnMount: true,
+		refetchOnReconnect: true,
+		staleTime: 0,
+	});
+
+	const toggleMutation = useMutation({
+		...orpc.alarms.toggle.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["alarms"] });
+		},
+	});
+
+	const deleteMutation = useMutation({
+		...orpc.alarms.delete.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({ queryKey: ["alarms"] });
+		},
+	});
+
+	const testMutation = useMutation({
+		...orpc.alarms.test.mutationOptions(),
+	});
+
+	const items = (data ?? []) as Alarm[];
+	const activeCount = items.filter((a) => a.enabled).length;
+	const isEmpty = items.length === 0;
+
+	if (isLoading) {
+		return <AlarmsSkeleton />;
+	}
+
+	if (isError) {
+		return (
+			<EmptyState
+				description="Please try again in a moment"
+				icon={<BellRingingIcon weight="duotone" />}
+				title="Failed to load alarms"
+				variant="error"
+			/>
+		);
+	}
+
+	return (
+		<>
+			<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+				<div className="flex flex-col border-b lg:border-b-0">
+					{isEmpty ? (
+						<EmptyState
+							description="Create alarms to receive notifications when monitors go down or recover"
+							icon={<BellRingingIcon weight="duotone" />}
+							title="No alarms yet"
+						/>
+					) : (
+						<div className="flex-1 divide-y overflow-y-auto">
+							{items.map((alarm) => (
+								<AlarmRow
+									alarm={alarm}
+									key={alarm.id}
+									onEdit={() => setEditingAlarm(alarm)}
+									onToggle={(enabled) =>
+										toggleMutation.mutate({ alarmId: alarm.id, enabled })
+									}
+									onDelete={() => deleteMutation.mutate({ alarmId: alarm.id })}
+									onTest={() => testMutation.mutate({ alarmId: alarm.id })}
+									isToggling={toggleMutation.isPending}
+									isDeleting={deleteMutation.isPending}
+									isTesting={testMutation.isPending}
+								/>
+							))}
+						</div>
+					)}
+				</div>
+
+				<RightSidebar className="gap-4 p-5">
+					<Button className="w-full" onClick={() => setShowCreateDialog(true)}>
+						<PlusIcon size={16} />
+						Create Alarm
+					</Button>
+					{!isEmpty && (
+						<RightSidebar.InfoCard
+							description="Active alarms"
+							icon={BellRingingIcon}
+							title={`${activeCount} / ${items.length}`}
+						/>
+					)}
+					<RightSidebar.Tip
+						description="Alarms notify you when uptime monitors detect issues. Assign alarms to monitors to receive alerts."
+						title="About Alarms"
+					/>
+				</RightSidebar>
+			</div>
+
+			<AlarmDialog
+				open={showCreateDialog}
+				onOpenChange={setShowCreateDialog}
+				mode="create"
+			/>
+
+			{editingAlarm && (
+				<AlarmDialog
+					open={!!editingAlarm}
+					onOpenChange={(open) => !open && setEditingAlarm(null)}
+					mode="edit"
+					alarm={editingAlarm}
+				/>
+			)}
+		</>
+	);
+}

--- a/apps/dashboard/app/(main)/settings/alarms/page.tsx
+++ b/apps/dashboard/app/(main)/settings/alarms/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Suspense } from "react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlarmSettings } from "./alarm-settings";
+
+function SkeletonRow() {
+	return (
+		<div className="grid grid-cols-[auto_1fr_auto_auto] items-center gap-4 px-5 py-4">
+			<Skeleton className="size-10 rounded" />
+			<div className="space-y-2">
+				<Skeleton className="h-4 w-32" />
+				<Skeleton className="h-3 w-48" />
+			</div>
+			<Skeleton className="h-6 w-16 rounded-full" />
+			<Skeleton className="size-4" />
+		</div>
+	);
+}
+
+function PageSkeleton() {
+	return (
+		<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+			<div className="divide-y border-b lg:border-b-0">
+				<SkeletonRow />
+				<SkeletonRow />
+				<SkeletonRow />
+			</div>
+			<div className="space-y-4 bg-card p-5">
+				<Skeleton className="h-10 w-full" />
+				<Skeleton className="h-18 w-full rounded" />
+				<Skeleton className="h-10 w-full" />
+			</div>
+		</div>
+	);
+}
+
+export default function AlarmsSettingsPage() {
+	return (
+		<Suspense fallback={<PageSkeleton />}>
+			<AlarmSettings />
+		</Suspense>
+	);
+}

--- a/apps/dashboard/components/layout/navigation/navigation-config.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-config.tsx
@@ -3,6 +3,7 @@ import {
 	ActivityIcon,
 	ArrowSquareOutIcon,
 	BellIcon,
+	BellRingingIcon,
 	BookOpenIcon,
 	BugIcon,
 	BuildingsIcon,
@@ -143,6 +144,7 @@ export const personalNavigation: NavigationSection[] = [
 		}),
 	]),
 	createNavSection("Preferences", GearIcon, [
+		createNavItem("Alarms", BellRingingIcon, "/settings/alarms"),
 		createNavItem(
 			"Analytics Behavior",
 			ChartLineUpIcon,

--- a/packages/db/src/drizzle/relations.ts
+++ b/packages/db/src/drizzle/relations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm/relations";
 import {
 	account,
+	alarms,
 	apikey,
 	flags,
 	flagsToTargetGroups,
@@ -12,6 +13,7 @@ import {
 	targetGroups,
 	team,
 	twoFactor,
+	uptimeAlarms,
 	uptimeSchedules,
 	user,
 	userPreferences,
@@ -170,7 +172,7 @@ export const flagsToTargetGroupsRelations = relations(
 	})
 );
 
-export const uptimeSchedulesRelations = relations(uptimeSchedules, ({ one }) => ({
+export const uptimeSchedulesRelations = relations(uptimeSchedules, ({ one, many }) => ({
 	website: one(websites, {
 		fields: [uptimeSchedules.websiteId],
 		references: [websites.id],
@@ -178,5 +180,29 @@ export const uptimeSchedulesRelations = relations(uptimeSchedules, ({ one }) => 
 	user: one(user, {
 		fields: [uptimeSchedules.userId],
 		references: [user.id],
+	}),
+	uptimeAlarms: many(uptimeAlarms),
+}));
+
+export const alarmsRelations = relations(alarms, ({ one, many }) => ({
+	organization: one(organization, {
+		fields: [alarms.organizationId],
+		references: [organization.id],
+	}),
+	user: one(user, {
+		fields: [alarms.userId],
+		references: [user.id],
+	}),
+	uptimeAlarms: many(uptimeAlarms),
+}));
+
+export const uptimeAlarmsRelations = relations(uptimeAlarms, ({ one }) => ({
+	schedule: one(uptimeSchedules, {
+		fields: [uptimeAlarms.scheduleId],
+		references: [uptimeSchedules.id],
+	}),
+	alarm: one(alarms, {
+		fields: [uptimeAlarms.alarmId],
+		references: [alarms.id],
 	}),
 }));

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -936,3 +936,77 @@ export const uptimeSchedules = pgTable(
 			.onDelete("cascade"),
 	]
 );
+
+export const alarmChannel = pgEnum("alarm_channel", [
+	"slack",
+	"discord",
+	"email",
+	"webhook",
+]);
+
+export const alarms = pgTable(
+	"alarms",
+	{
+		id: text().primaryKey().notNull(),
+		organizationId: text("organization_id"),
+		userId: text("user_id").notNull(),
+		name: text().notNull(),
+		description: text(),
+		channel: alarmChannel().notNull(),
+		target: text().notNull(),
+		enabled: boolean().default(true).notNull(),
+		createdAt: timestamp("created_at", { precision: 3 }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { precision: 3 }).defaultNow().notNull(),
+	},
+	(table) => [
+		index("alarms_organization_id_idx").using(
+			"btree",
+			table.organizationId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_user_id_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("text_ops")
+		),
+		foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "alarms_organization_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [user.id],
+			name: "alarms_user_id_fkey",
+		}).onDelete("cascade"),
+	]
+);
+
+export const uptimeAlarms = pgTable(
+	"uptime_alarms",
+	{
+		id: text().primaryKey().notNull(),
+		scheduleId: text("schedule_id").notNull(),
+		alarmId: text("alarm_id").notNull(),
+		failureThreshold: integer("failure_threshold").default(3).notNull(),
+		createdAt: timestamp("created_at", { precision: 3 }).defaultNow().notNull(),
+	},
+	(table) => [
+		index("uptime_alarms_schedule_id_idx").using(
+			"btree",
+			table.scheduleId.asc().nullsLast().op("text_ops")
+		),
+		index("uptime_alarms_alarm_id_idx").using(
+			"btree",
+			table.alarmId.asc().nullsLast().op("text_ops")
+		),
+		foreignKey({
+			columns: [table.scheduleId],
+			foreignColumns: [uptimeSchedules.id],
+			name: "uptime_alarms_schedule_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.alarmId],
+			foreignColumns: [alarms.id],
+			name: "uptime_alarms_alarm_id_fkey",
+		}).onDelete("cascade"),
+	]
+);

--- a/packages/rpc/src/root.ts
+++ b/packages/rpc/src/root.ts
@@ -1,4 +1,5 @@
 import { agentRouter } from "./routers/agent";
+import { alarmsRouter } from "./routers/alarms";
 import { annotationsRouter } from "./routers/annotations";
 import { apikeysRouter } from "./routers/apikeys";
 import { autocompleteRouter } from "./routers/autocomplete";
@@ -19,6 +20,7 @@ import { uptimeRouter } from "./routers/uptime";
 import { websitesRouter } from "./routers/websites";
 
 export const appRouter = {
+	alarms: alarmsRouter,
 	annotations: annotationsRouter,
 	websites: websitesRouter,
 	miniCharts: miniChartsRouter,

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -1,0 +1,237 @@
+import { alarms, and, db, eq, or } from "@databuddy/db";
+import {
+	sendDiscordWebhook,
+	sendSlackWebhook,
+	sendWebhook,
+} from "@databuddy/notifications";
+import { logger } from "@databuddy/shared/logger";
+import { ORPCError } from "@orpc/server";
+import { randomUUIDv7 } from "bun";
+import { z } from "zod";
+import { protectedProcedure } from "../orpc";
+
+const alarmChannelEnum = z.enum(["slack", "discord", "email", "webhook"]);
+
+async function getAlarmAndAuthorize(
+	alarmId: string,
+	context: { user: { id: string }; session: { activeOrganizationId?: string | null } }
+) {
+	const alarm = await db.query.alarms.findFirst({
+		where: eq(alarms.id, alarmId),
+	});
+
+	if (!alarm) {
+		throw new ORPCError("NOT_FOUND", { message: "Alarm not found" });
+	}
+
+	const activeOrgId = context.session?.activeOrganizationId;
+
+	// Check if user owns the alarm or if it belongs to their active org
+	const isOwner = alarm.userId === context.user.id;
+	const isOrgAlarm = activeOrgId && alarm.organizationId === activeOrgId;
+
+	if (!isOwner && !isOrgAlarm) {
+		throw new ORPCError("FORBIDDEN", { message: "Access denied" });
+	}
+
+	return alarm;
+}
+
+export const alarmsRouter = {
+	list: protectedProcedure
+		.input(
+			z.object({
+				organizationId: z.string().optional(),
+			})
+		)
+		.handler(async ({ context, input }) => {
+			const activeOrgId =
+				input.organizationId ?? context.session?.activeOrganizationId;
+
+			const conditions = [];
+
+			if (activeOrgId) {
+				// Show org alarms and user's personal alarms
+				conditions.push(
+					or(
+						eq(alarms.organizationId, activeOrgId),
+						and(
+							eq(alarms.userId, context.user.id),
+							eq(alarms.organizationId, null as unknown as string)
+						)
+					)
+				);
+			} else {
+				// Only personal alarms
+				conditions.push(eq(alarms.userId, context.user.id));
+			}
+
+			return await db.query.alarms.findMany({
+				where: and(...conditions),
+				orderBy: (table, { desc }) => [desc(table.createdAt)],
+			});
+		}),
+
+	get: protectedProcedure
+		.input(z.object({ alarmId: z.string() }))
+		.handler(async ({ context, input }) => {
+			return await getAlarmAndAuthorize(input.alarmId, context);
+		}),
+
+	create: protectedProcedure
+		.input(
+			z.object({
+				name: z.string().min(1).max(100),
+				description: z.string().max(500).optional(),
+				channel: alarmChannelEnum,
+				target: z.string().min(1),
+				organizationId: z.string().optional(),
+			})
+		)
+		.handler(async ({ context, input }) => {
+			const alarmId = randomUUIDv7();
+			const activeOrgId =
+				input.organizationId ?? context.session?.activeOrganizationId;
+
+			await db.insert(alarms).values({
+				id: alarmId,
+				userId: context.user.id,
+				organizationId: activeOrgId ?? null,
+				name: input.name,
+				description: input.description ?? null,
+				channel: input.channel,
+				target: input.target,
+				enabled: true,
+			});
+
+			logger.info({ alarmId, channel: input.channel }, "Alarm created");
+
+			return await db.query.alarms.findFirst({
+				where: eq(alarms.id, alarmId),
+			});
+		}),
+
+	update: protectedProcedure
+		.input(
+			z.object({
+				alarmId: z.string(),
+				name: z.string().min(1).max(100).optional(),
+				description: z.string().max(500).optional(),
+				channel: alarmChannelEnum.optional(),
+				target: z.string().min(1).optional(),
+				enabled: z.boolean().optional(),
+			})
+		)
+		.handler(async ({ context, input }) => {
+			await getAlarmAndAuthorize(input.alarmId, context);
+
+			const updateData: Record<string, unknown> = {
+				updatedAt: new Date(),
+			};
+
+			if (input.name !== undefined) updateData.name = input.name;
+			if (input.description !== undefined)
+				updateData.description = input.description;
+			if (input.channel !== undefined) updateData.channel = input.channel;
+			if (input.target !== undefined) updateData.target = input.target;
+			if (input.enabled !== undefined) updateData.enabled = input.enabled;
+
+			await db
+				.update(alarms)
+				.set(updateData)
+				.where(eq(alarms.id, input.alarmId));
+
+			logger.info({ alarmId: input.alarmId }, "Alarm updated");
+
+			return await db.query.alarms.findFirst({
+				where: eq(alarms.id, input.alarmId),
+			});
+		}),
+
+	delete: protectedProcedure
+		.input(z.object({ alarmId: z.string() }))
+		.handler(async ({ context, input }) => {
+			await getAlarmAndAuthorize(input.alarmId, context);
+
+			await db.delete(alarms).where(eq(alarms.id, input.alarmId));
+
+			logger.info({ alarmId: input.alarmId }, "Alarm deleted");
+
+			return { success: true };
+		}),
+
+	test: protectedProcedure
+		.input(z.object({ alarmId: z.string() }))
+		.handler(async ({ context, input }) => {
+			const alarm = await getAlarmAndAuthorize(input.alarmId, context);
+
+			const payload = {
+				title: "Test Notification",
+				message: `This is a test notification from alarm "${alarm.name}"`,
+				priority: "normal" as const,
+				metadata: {
+					alarmId: alarm.id,
+					alarmName: alarm.name,
+					timestamp: new Date().toISOString(),
+					isTest: true,
+				},
+			};
+
+			try {
+				switch (alarm.channel) {
+					case "slack":
+						await sendSlackWebhook(alarm.target, payload);
+						break;
+					case "discord":
+						await sendDiscordWebhook(alarm.target, payload);
+						break;
+					case "webhook":
+						await sendWebhook(alarm.target, payload);
+						break;
+					case "email":
+						// Email requires additional configuration
+						throw new ORPCError("BAD_REQUEST", {
+							message: "Email test notifications are not yet supported",
+						});
+				}
+
+				logger.info(
+					{ alarmId: alarm.id, channel: alarm.channel },
+					"Test notification sent"
+				);
+
+				return { success: true, message: "Test notification sent" };
+			} catch (error) {
+				logger.error(
+					{ alarmId: alarm.id, error },
+					"Failed to send test notification"
+				);
+
+				if (error instanceof ORPCError) {
+					throw error;
+				}
+
+				throw new ORPCError("INTERNAL_SERVER_ERROR", {
+					message: "Failed to send test notification",
+				});
+			}
+		}),
+
+	toggle: protectedProcedure
+		.input(z.object({ alarmId: z.string(), enabled: z.boolean() }))
+		.handler(async ({ context, input }) => {
+			await getAlarmAndAuthorize(input.alarmId, context);
+
+			await db
+				.update(alarms)
+				.set({ enabled: input.enabled, updatedAt: new Date() })
+				.where(eq(alarms.id, input.alarmId));
+
+			logger.info(
+				{ alarmId: input.alarmId, enabled: input.enabled },
+				"Alarm toggled"
+			);
+
+			return { success: true, enabled: input.enabled };
+		}),
+};


### PR DESCRIPTION
## Summary
- Adds a complete alarms system for receiving notifications when monitors detect issues
- Database schema with `alarms` and `uptime_alarms` tables
- Full ORPC API with list, get, create, update, delete, toggle, and test endpoints
- Dashboard settings page for alarm management
- Support for Slack, Discord, Email, and Webhook channels

## Features
- Create and manage notification alarms
- Test alarms with a single click
- Enable/disable alarms on the fly
- Channel-specific configuration (webhook URLs, email addresses)

## Test Plan
- [ ] Create a new alarm for each channel type
- [ ] Edit an existing alarm
- [ ] Toggle alarm enabled state
- [ ] Delete an alarm
- [ ] Test alarm notification delivery

Closes #267

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced comprehensive alarm management system with create, edit, delete, and test functionality
  * Support for multiple notification channels: Slack, Discord, Email, and Webhook
  * Toggle alarms on/off with real-time updates
  * Integration with uptime monitoring schedules
  * New Alarms navigation menu item in settings

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->