### PR TITLE
feat: Feature Flag Folders for Organization

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -248,6 +248,7 @@ export function FlagSheet({
 				dependencies: [],
 				environment: undefined,
 				targetGroupIds: [],
+				folder: "",
 			},
 			schedule: undefined,
 		},
@@ -290,6 +291,7 @@ export function FlagSheet({
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
 					targetGroupIds: extractTargetGroupIds(),
+					folder: flag.folder || "",
 				},
 				schedule: undefined,
 			});
@@ -400,6 +402,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await updateMutation.mutateAsync(updateData);
 			} else {
@@ -418,6 +421,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await createMutation.mutateAsync(createData);
 			}
@@ -543,6 +547,26 @@ export function FlagSheet({
 													className="min-h-16 resize-none"
 													placeholder="What does this flag control?…"
 													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="flag.folder"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel className="text-muted-foreground">
+												Folder (optional)
+											</FormLabel>
+											<FormControl>
+												<Input
+													placeholder="e.g., auth/login, checkout"
+													{...field}
+													value={field.value || ""}
 												/>
 											</FormControl>
 											<FormMessage />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -22,6 +22,7 @@ export interface Flag {
 	variants?: Variant[];
 	dependencies?: string[];
 	environment?: string;
+	folder?: string | null;
 	persistAcrossAuth?: boolean;
 	websiteId?: string | null;
 	organizationId?: string | null;

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -667,6 +667,7 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -82,6 +82,7 @@ const listFlagsSchema = z
 		websiteId: z.string().optional(),
 		organizationId: z.string().optional(),
 		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().optional(),
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
 		message: "Either websiteId or organizationId must be provided",
@@ -116,6 +117,7 @@ const createFlagSchema = z
 		organizationId: z.string().optional(),
 		payload: z.any().optional(),
 		persistAcrossAuth: z.boolean().optional(),
+		folder: z.string().max(200).nullable().optional(),
 		...flagFormSchema.shape,
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
@@ -140,6 +142,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(200).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -278,6 +281,14 @@ export const flagsRouter = {
 
 				if (input.status) {
 					conditions.push(eq(flags.status, input.status));
+				}
+
+				if (input.folder !== undefined) {
+					if (input.folder === null || input.folder === "") {
+						conditions.push(isNull(flags.folder));
+					} else {
+						conditions.push(eq(flags.folder, input.folder));
+					}
 				}
 
 				const flagsList = await context.db.query.flags.findMany({
@@ -556,6 +567,7 @@ export const flagsRouter = {
 							variants: input.variants,
 							dependencies: input.dependencies,
 							environment: input.environment,
+							folder: input.folder || null,
 							deletedAt: null,
 							updatedAt: new Date(),
 						})
@@ -613,6 +625,7 @@ export const flagsRouter = {
 						websiteId: input.websiteId || null,
 						organizationId: input.organizationId || null,
 						environment: input.environment || existingFlag?.[0]?.environment,
+						folder: input.folder || null,
 						userId: input.websiteId ? null : context.user.id,
 						createdBy: context.user.id,
 					})

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -62,6 +62,7 @@ export const flagFormSchema = z
 			.optional(),
 		environment: z.string().nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(200).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {


### PR DESCRIPTION
## What this PR does

Adds folder field support for organizing feature flags in the dashboard UI.

## Changes

### 1. Database Schema
- Added `folder` text field to `flags` table
- Backward compatible - existing flags work without folders

### 2. API Endpoints
- `flags.list` - Added optional `folder` filter parameter
- `flags.create` - Allow setting `folder` on creation
- `flags.update` - Allow updating `folder` field

### 3. Dashboard UI
- Added folder input field in flag create/edit form
- Folder field accepts path-like strings (e.g., `auth/login`, `checkout/payment`)

## How to test
1. Create a new feature flag with a folder value
2. Edit an existing flag to add/update folder
3. Verify folder field is saved and displayed correctly

Closes #271