### PR TITLE
feat: Add folder support to Feature Flags

### DIFF
--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -667,6 +667,7 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text(),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),
@@ -684,6 +685,11 @@ export const flags = pgTable(
 		index("idx_flags_created_by").using(
 			"btree",
 			table.createdBy.asc().nullsLast().op("text_ops")
+		),
+		index("idx_flags_website_folder").using(
+			"btree",
+			table.websiteId.asc().nullsLast().op("text_ops"),
+			table.folder.asc().nullsLast().op("text_ops")
 		),
 		foreignKey({
 			columns: [table.websiteId],

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -82,6 +82,7 @@ const listFlagsSchema = z
 		websiteId: z.string().optional(),
 		organizationId: z.string().optional(),
 		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().optional(),
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
 		message: "Either websiteId or organizationId must be provided",
@@ -116,6 +117,7 @@ const createFlagSchema = z
 		organizationId: z.string().optional(),
 		payload: z.any().optional(),
 		persistAcrossAuth: z.boolean().optional(),
+		folder: z.string().optional(),
 		...flagFormSchema.shape,
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
@@ -140,6 +142,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().optional().nullable(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -278,6 +281,14 @@ export const flagsRouter = {
 
 				if (input.status) {
 					conditions.push(eq(flags.status, input.status));
+				}
+
+				// Filter by folder if provided
+				if (input.folder) {
+					conditions.push(eq(flags.folder, input.folder));
+				} else if (input.folder === "") {
+					// If folder is empty string, show flags without a folder (root level)
+					conditions.push(isNull(flags.folder));
 				}
 
 				const flagsList = await context.db.query.flags.findMany({
@@ -556,6 +567,7 @@ export const flagsRouter = {
 							variants: input.variants,
 							dependencies: input.dependencies,
 							environment: input.environment,
+							folder: input.folder ?? existingFlag[0].folder,
 							deletedAt: null,
 							updatedAt: new Date(),
 						})
@@ -615,6 +627,7 @@ export const flagsRouter = {
 						environment: input.environment || existingFlag?.[0]?.environment,
 						userId: input.websiteId ? null : context.user.id,
 						createdBy: context.user.id,
+						folder: input.folder || null,
 					})
 					.returning();
 


### PR DESCRIPTION
## Summary

Implements folder support for Feature Flags as described in issue #271.

### Database Changes
- Add folder text column to flags table (optional, nullable)
- Add composite index on (websiteId, folder) for optimized list fetching
- Backward compatible with existing flags

### API Changes
- Added folder parameter to listFlagsSchema for filtering
- Added folder to createFlagSchema and updateFlagSchema  
- Implemented folder filtering in list handler
- Supports folder in INSERT and UPDATE operations

### Technical Details
- Approach: Option A (simple string paths like auth/login for nested folders)
- Performance: Index on folder field ensures fast filtering
- Backward Compatible: Existing flags without folder work correctly
- Nullable: Folder can be null (no folder) or a string path

This PR covers the backend requirements. UI components for folder management will follow in subsequent PRs.

### Related
- Closes #271