### PR TITLE
docs: respect accept header in docs

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -1,9 +1,9 @@
 import { createMDX } from "fumadocs-mdx/next";
+import type { NextConfig } from "next";
 
 const withMDX = createMDX();
 
-/** @type {import('next').NextConfig} */
-const config = {
+const config: NextConfig = {
 	reactStrictMode: true,
 	async headers() {
 		return await [
@@ -50,6 +50,17 @@ const config = {
 			{
 				source: "/docs/:path*.md",
 				destination: "/api/docs/raw/:path*",
+			},
+			{
+				source: "/docs/:path*",
+				destination: "/api/docs/raw/:path*",
+				has: [
+					{
+						type: "header",
+						key: "Accept",
+						value: ".*text/markdown.*",
+					},
+				],
 			},
 		];
 	},


### PR DESCRIPTION
Helps AI agents crawl the page, also fixed the types otherwise fumadocs cries

<details>
<summary>Checklist</summary>

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 

</details>