### PR TITLE
feat(flags): folder organization support (schema + api + dashboard)

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -247,6 +247,7 @@ export function FlagSheet({
 				variants: [],
 				dependencies: [],
 				environment: undefined,
+				folder: "",
 				targetGroupIds: [],
 			},
 			schedule: undefined,
@@ -289,6 +290,7 @@ export function FlagSheet({
 					variants: flag.variants ?? [],
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
+					folder: flag.folder || "",
 					targetGroupIds: extractTargetGroupIds(),
 				},
 				schedule: undefined,
@@ -310,6 +312,7 @@ export function FlagSheet({
 					rules: template.rules ?? [],
 					variants: template.type === "multivariant" ? template.variants : [],
 					dependencies: [],
+					folder: "",
 					targetGroupIds: [],
 				},
 				schedule: undefined,
@@ -331,6 +334,7 @@ export function FlagSheet({
 					rules: [],
 					variants: [],
 					dependencies: [],
+					folder: "",
 					targetGroupIds: [],
 				},
 				schedule: undefined,
@@ -396,6 +400,7 @@ export function FlagSheet({
 					variants: data.variants || [],
 					dependencies: data.dependencies || [],
 					environment: data.environment?.trim() || undefined,
+					folder: data.folder?.trim() || null,
 					defaultValue: data.defaultValue,
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
@@ -414,6 +419,7 @@ export function FlagSheet({
 					variants: data.variants || [],
 					dependencies: data.dependencies || [],
 					environment: data.environment?.trim() || undefined,
+					folder: data.folder?.trim() || null,
 					defaultValue: data.defaultValue,
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
@@ -542,6 +548,25 @@ export function FlagSheet({
 												<Textarea
 													className="min-h-16 resize-none"
 													placeholder="What does this flag control?…"
+													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="flag.folder"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel className="text-muted-foreground">
+												Folder (optional)
+											</FormLabel>
+											<FormControl>
+												<Input
+													placeholder="e.g. Growth/Checkout"
 													{...field}
 												/>
 											</FormControl>

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -41,6 +41,7 @@ interface FlagsListProps {
 	groups: Map<string, TargetGroup[]>;
 	onEdit: (flag: Flag) => void;
 	onDelete: (flagId: string) => void;
+	groupByFolder?: boolean;
 }
 
 const TYPE_CONFIG = {
@@ -52,6 +53,16 @@ const TYPE_CONFIG = {
 		color: "text-pink-500",
 	},
 } as const;
+
+const UNASSIGNED_FOLDER = "__unassigned__";
+
+const normalizeFolderKey = (folder?: string | null) => {
+	const trimmed = (folder || "").trim();
+	return trimmed.length > 0 ? trimmed : UNASSIGNED_FOLDER;
+};
+
+const formatFolderLabel = (key: string) =>
+	key === UNASSIGNED_FOLDER ? "Unassigned" : key;
 
 function GroupsDisplay({ groups }: { groups: TargetGroup[] }) {
 	if (groups.length === 0) {
@@ -404,7 +415,13 @@ function FlagRow({
 	);
 }
 
-export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
+export function FlagsList({
+	flags,
+	groups,
+	onEdit,
+	onDelete,
+	groupByFolder = false,
+}: FlagsListProps) {
 	const flagMap = useMemo(() => {
 		const map = new Map<string, Flag>();
 		for (const f of flags) {
@@ -427,19 +444,66 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 		return map;
 	}, [flags]);
 
+	const groupedFlags = useMemo(() => {
+		const map = new Map<string, Flag[]>();
+		for (const flag of flags) {
+			const key = normalizeFolderKey(flag.folder);
+			const existing = map.get(key) || [];
+			existing.push(flag);
+			map.set(key, existing);
+		}
+		const keys = Array.from(map.keys()).sort((a, b) => {
+			if (a === UNASSIGNED_FOLDER) return 1;
+			if (b === UNASSIGNED_FOLDER) return -1;
+			return a.localeCompare(b);
+		});
+		return { map, keys };
+	}, [flags]);
+
+	if (!groupByFolder) {
+		return (
+			<div className="w-full overflow-x-auto">
+				{flags.map((flag) => (
+					<FlagRow
+						dependents={dependentsMap.get(flag.key) ?? []}
+						flag={flag}
+						flagMap={flagMap}
+						groups={groups.get(flag.id) ?? []}
+						key={flag.id}
+						onDelete={onDelete}
+						onEdit={onEdit}
+					/>
+				))}
+			</div>
+		);
+	}
+
 	return (
 		<div className="w-full overflow-x-auto">
-			{flags.map((flag) => (
-				<FlagRow
-					dependents={dependentsMap.get(flag.key) ?? []}
-					flag={flag}
-					flagMap={flagMap}
-					groups={groups.get(flag.id) ?? []}
-					key={flag.id}
-					onDelete={onDelete}
-					onEdit={onEdit}
-				/>
-			))}
+			{groupedFlags.keys.map((key) => {
+				const group = groupedFlags.map.get(key) ?? [];
+				return (
+					<div key={key}>
+						<div className="flex items-center justify-between border-b bg-background px-4 py-2 text-muted-foreground text-xs uppercase tracking-wide">
+							<span>{formatFolderLabel(key)}</span>
+							<span className="rounded bg-muted px-2 py-0.5 text-[10px]">
+								{group.length} flag{group.length === 1 ? "" : "s"}
+							</span>
+						</div>
+						{group.map((flag) => (
+							<FlagRow
+								dependents={dependentsMap.get(flag.key) ?? []}
+								flag={flag}
+								flagMap={flagMap}
+								groups={groups.get(flag.id) ?? []}
+								key={flag.id}
+								onDelete={onDelete}
+								onEdit={onEdit}
+							/>
+						))}
+					</div>
+				);
+			})}
 		</div>
 	);
 }

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -22,6 +22,7 @@ export interface Flag {
 	variants?: Variant[];
 	dependencies?: string[];
 	environment?: string;
+	folder?: string | null;
 	persistAcrossAuth?: boolean;
 	websiteId?: string | null;
 	organizationId?: string | null;

--- a/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
@@ -10,11 +10,21 @@ import { EmptyState } from "@/components/empty-state";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { FeatureGate } from "@/components/feature-gate";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from "@/components/ui/select";
 import { orpc } from "@/lib/orpc";
 import { isFlagSheetOpenAtom } from "@/stores/jotai/flagsAtoms";
 import { FlagSheet } from "./_components/flag-sheet";
 import { FlagsList, FlagsListSkeleton } from "./_components/flags-list";
 import type { Flag, TargetGroup } from "./_components/types";
+
+const ALL_FOLDERS = "__all__";
+const UNASSIGNED_FOLDER = "__unassigned__";
 
 export default function FlagsPage() {
 	const { id } = useParams();
@@ -23,6 +33,7 @@ export default function FlagsPage() {
 	const [isFlagSheetOpen, setIsFlagSheetOpen] = useAtom(isFlagSheetOpenAtom);
 	const [editingFlag, setEditingFlag] = useState<Flag | null>(null);
 	const [flagToDelete, setFlagToDelete] = useState<Flag | null>(null);
+	const [selectedFolder, setSelectedFolder] = useState<string>(ALL_FOLDERS);
 
 	const { data: flags, isLoading: flagsLoading } = useQuery({
 		...orpc.flags.list.queryOptions({ input: { websiteId } }),
@@ -32,6 +43,35 @@ export default function FlagsPage() {
 		() => flags?.filter((f) => f.status !== "archived") ?? [],
 		[flags]
 	);
+
+	const folderData = useMemo(() => {
+		const folderCounts = new Map<string, number>();
+		for (const flag of activeFlags) {
+			const normalized = (flag.folder || "").trim();
+			const key = normalized.length > 0 ? normalized : UNASSIGNED_FOLDER;
+			folderCounts.set(key, (folderCounts.get(key) ?? 0) + 1);
+		}
+
+		const folderKeys = Array.from(folderCounts.keys()).sort((a, b) => {
+			if (a === UNASSIGNED_FOLDER) return 1;
+			if (b === UNASSIGNED_FOLDER) return -1;
+			return a.localeCompare(b);
+		});
+
+		return { folderCounts, folderKeys };
+	}, [activeFlags]);
+
+	const filteredFlags = useMemo(() => {
+		if (selectedFolder === ALL_FOLDERS) {
+			return activeFlags;
+		}
+		if (selectedFolder === UNASSIGNED_FOLDER) {
+			return activeFlags.filter((flag) => !flag.folder?.trim());
+		}
+		return activeFlags.filter(
+			(flag) => (flag.folder || "").trim() === selectedFolder
+		);
+	}, [activeFlags, selectedFolder]);
 
 	const groupsMap = useMemo(() => {
 		const map = new Map<string, TargetGroup[]>();
@@ -92,13 +132,13 @@ export default function FlagsPage() {
 			<ErrorBoundary>
 				<div className="h-full overflow-y-auto">
 					<Suspense fallback={<FlagsListSkeleton />}>
-						{flagsLoading ? (
-							<FlagsListSkeleton />
-						) : activeFlags.length === 0 ? (
-							<div className="flex flex-1 items-center justify-center py-16">
-								<EmptyState
-									action={{
-										label: "Create Your First Flag",
+					{flagsLoading ? (
+						<FlagsListSkeleton />
+					) : activeFlags.length === 0 ? (
+						<div className="flex flex-1 items-center justify-center py-16">
+							<EmptyState
+								action={{
+									label: "Create Your First Flag",
 										onClick: handleCreateFlag,
 									}}
 									description="Create your first feature flag to start controlling feature rollouts and A/B testing across your application."
@@ -107,15 +147,48 @@ export default function FlagsPage() {
 									variant="minimal"
 								/>
 							</div>
-						) : (
+					) : (
+						<div className="space-y-3">
+							<div className="flex flex-wrap items-center gap-3 px-4 pt-2">
+								<div className="text-muted-foreground text-xs uppercase tracking-wide">
+									Folders
+								</div>
+								<Select
+									onValueChange={setSelectedFolder}
+									value={selectedFolder}
+								>
+									<SelectTrigger className="h-8 w-[220px]" size="sm">
+										<SelectValue placeholder="All folders" />
+									</SelectTrigger>
+									<SelectContent>
+										<SelectItem value={ALL_FOLDERS}>All folders</SelectItem>
+										{folderData.folderCounts.has(UNASSIGNED_FOLDER) && (
+											<SelectItem value={UNASSIGNED_FOLDER}>
+												Unassigned (
+												{folderData.folderCounts.get(UNASSIGNED_FOLDER) ?? 0})
+											</SelectItem>
+										)}
+										{folderData.folderKeys
+											.filter((key) => key !== UNASSIGNED_FOLDER)
+											.map((folder) => (
+												<SelectItem key={folder} value={folder}>
+													{folder} ({folderData.folderCounts.get(folder) ?? 0})
+												</SelectItem>
+											))}
+									</SelectContent>
+								</Select>
+							</div>
+
 							<FlagsList
-								flags={activeFlags as Flag[]}
+								flags={filteredFlags as Flag[]}
+								groupByFolder
 								groups={groupsMap}
 								onDelete={handleDeleteFlagRequest}
 								onEdit={handleEditFlag}
 							/>
-						)}
-					</Suspense>
+						</div>
+					)}
+				</Suspense>
 
 					{isFlagSheetOpen && (
 						<Suspense fallback={null}>

--- a/packages/db/migrations/20260213_add_flags_folder.sql
+++ b/packages/db/migrations/20260213_add_flags_folder.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "flags" ADD COLUMN IF NOT EXISTS "folder" text;
+
+CREATE INDEX IF NOT EXISTS "idx_flags_website_folder"
+	ON "flags" USING btree ("website_id", "folder");

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -669,6 +669,7 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),
@@ -686,6 +687,11 @@ export const flags = pgTable(
 		index("idx_flags_created_by").using(
 			"btree",
 			table.createdBy.asc().nullsLast().op("text_ops")
+		),
+		index("idx_flags_website_folder").using(
+			"btree",
+			table.websiteId.asc().nullsLast().op("text_ops"),
+			table.folder.asc().nullsLast().op("text_ops")
 		),
 		foreignKey({
 			columns: [table.websiteId],

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -84,6 +84,7 @@ const listFlagsSchema = z
 		websiteId: z.string().optional(),
 		organizationId: z.string().optional(),
 		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().max(200).nullable().optional(),
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
 		message: "Either websiteId or organizationId must be provided",
@@ -141,6 +142,7 @@ const updateFlagSchema = z
 		variants: z.array(variantSchema).optional(),
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
+		folder: z.string().max(200).nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
 	})
 	.superRefine((data, ctx) => {
@@ -271,7 +273,9 @@ export const flagsRouter = {
 		.output(z.array(flagOutputSchema))
 		.handler(({ context, input }) => {
 			const scope = getScope(input.websiteId, input.organizationId);
-			const cacheKey = `list:${scope}:${input.status || "all"}`;
+			const folderKey =
+				input.folder === null ? "unassigned" : input.folder || "all";
+			const cacheKey = `list:${scope}:${input.status || "all"}:${folderKey}`;
 
 			return flagsCache.withCache({
 				key: cacheKey,
@@ -292,6 +296,15 @@ export const flagsRouter = {
 
 					if (input.status) {
 						conditions.push(eq(flags.status, input.status));
+					}
+
+					const folderFilter =
+						typeof input.folder === "string" ? input.folder.trim() : input.folder;
+
+					if (folderFilter === null) {
+						conditions.push(isNull(flags.folder));
+					} else if (folderFilter) {
+						conditions.push(eq(flags.folder, folderFilter));
 					}
 
 					const flagsList = await context.db.query.flags.findMany({
@@ -619,6 +632,7 @@ export const flagsRouter = {
 							status: finalStatus,
 							defaultValue: input.defaultValue,
 							rules: input.rules,
+							folder: input.folder?.trim() || null,
 							persistAcrossAuth:
 								input.persistAcrossAuth ??
 								existingFlag[0].persistAcrossAuth ??
@@ -662,6 +676,7 @@ export const flagsRouter = {
 			}
 
 			const flagId = randomUUIDv7();
+			const normalizedFolder = input.folder?.trim() || null;
 
 			// Use transaction to ensure flag + target group associations are atomic
 			const newFlag = await withTransaction(async (tx) => {
@@ -677,6 +692,7 @@ export const flagsRouter = {
 						defaultValue: input.defaultValue,
 						payload: input.payload || null,
 						rules: input.rules || [],
+						folder: normalizedFolder,
 						persistAcrossAuth: input.persistAcrossAuth ?? false,
 						rolloutPercentage: input.rolloutPercentage || 0,
 						rolloutBy: input.rolloutBy || null,
@@ -831,6 +847,9 @@ export const flagsRouter = {
 			}
 
 			const { id, targetGroupIds, ...updates } = input;
+			if (updates.folder !== undefined) {
+				updates.folder = updates.folder?.trim() || null;
+			}
 
 			// Use transaction to ensure flag update + target group associations are atomic
 			const updatedFlag = await withTransaction(async (tx) => {

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -61,6 +61,7 @@ export const flagFormSchema = z
 			.array(z.string().min(1, "Invalid dependency value"))
 			.optional(),
 		environment: z.string().nullable().optional(),
+		folder: z.string().max(200, "Folder too long").nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
 	})
 	.superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary
Implements #271 with a minimal, shippable scope focused on folder organization (without changing flag evaluation logic).

### What’s included
- Add optional `folder` field for flags in DB schema + migration (backward compatible)
- Extend flags API to support:
  - create with `folder`
  - update with `folder`
  - list filter by `folder`
- Dashboard flags UX for folder organization:
  - folder-based grouping/filtering
  - folder path editable in relevant flag flows

### Explicitly unchanged
- No changes to flag evaluation/business logic, dependencies, SDK behavior

## Acceptance checklist
- [x] Schema includes optional folder support
- [x] Backward compatibility preserved for existing flags
- [x] API supports folder create/update/list filtering
- [x] Dashboard has practical folder organization UX
- [x] No business logic changes to flag evaluation
- [ ] Full lint/test suite in this environment

## Verification notes
- Attempted local checks, but this runtime does not have `bun` available for project scripts (`bun run lint` failed due to missing bun).
- Please run full project checks in CI/maintainer environment.
