### PR TITLE
feat(alarms): add alarms system (db + rpc + settings ui) [v2]

### DIFF
--- a/apps/dashboard/app/(main)/settings/notifications/page.tsx
+++ b/apps/dashboard/app/(main)/settings/notifications/page.tsx
@@ -1,39 +1,676 @@
 "use client";
 
-import { BellIcon } from "@phosphor-icons/react";
+import {
+	BellIcon,
+	PencilSimpleIcon,
+	PlusIcon,
+	PaperPlaneTiltIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { EmptyState } from "@/components/empty-state";
 import { RightSidebar } from "@/components/right-sidebar";
-import { ComingSoon } from "../_components/settings-section";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { DeleteDialog } from "@/components/ui/delete-dialog";
+import { FormDialog } from "@/components/ui/form-dialog";
+import { Input } from "@/components/ui/input";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { useOrganizationsContext } from "@/components/providers/organizations-provider";
+import { orpc } from "@/lib/orpc";
 
-export default function NotificationsSettingsPage() {
+const CHANNELS = ["slack", "discord", "email", "webhook"] as const;
+
+type AlarmChannel = (typeof CHANNELS)[number];
+
+type Alarm = {
+	id: string;
+	organizationId: string;
+	userId: string | null;
+	websiteId: string | null;
+	name: string;
+	description: string | null;
+	enabled: boolean;
+	notificationChannels: AlarmChannel[];
+	slackWebhookUrl: string | null;
+	discordWebhookUrl: string | null;
+	emailAddresses: string[];
+	webhookUrl: string | null;
+	webhookHeaders: Record<string, unknown> | null;
+	conditions: Record<string, unknown> | null;
+	createdAt: Date;
+	updatedAt: Date;
+};
+
+const emptyFormState = {
+	name: "",
+	description: "",
+	enabled: true,
+	notificationChannels: [] as AlarmChannel[],
+	slackWebhookUrl: "",
+	discordWebhookUrl: "",
+	emailAddresses: "",
+	webhookUrl: "",
+	webhookHeaders: "",
+	conditions: "",
+};
+
+function parseList(value: string) {
+	return value
+		.split(/\n|,/g)
+		.map((entry) => entry.trim())
+		.filter(Boolean);
+}
+
+function parseJsonField(value: string, label: string) {
+	if (!value.trim()) {
+		return {} as Record<string, unknown>;
+	}
+	try {
+		return JSON.parse(value) as Record<string, unknown>;
+	} catch {
+		throw new Error(`${label} must be valid JSON`);
+	}
+}
+
+function AlarmSkeleton() {
 	return (
 		<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
-			<div className="flex flex-col">
-				<ComingSoon
-					description="Configure email alerts, push notifications, and weekly reports. Stay informed about your analytics and account activity."
-					icon={
-						<BellIcon
-							className="size-8 text-muted-foreground"
-							weight="duotone"
+			<div className="divide-y border-b lg:border-b-0">
+				{Array.from({ length: 3 }).map((_, index) => (
+					<div
+						className="grid grid-cols-[1fr_auto] items-center gap-4 px-5 py-4"
+						key={`alarm-skeleton-${index}`}
+					>
+						<div className="space-y-2">
+							<Skeleton className="h-4 w-44" />
+							<Skeleton className="h-3 w-64" />
+						</div>
+						<div className="flex items-center gap-2">
+							<Skeleton className="h-8 w-20" />
+							<Skeleton className="h-8 w-20" />
+							<Skeleton className="h-6 w-10" />
+						</div>
+					</div>
+				))}
+			</div>
+			<RightSidebar.Skeleton />
+		</div>
+	);
+}
+
+export default function NotificationsSettingsPage() {
+	const queryClient = useQueryClient();
+	const { activeOrganization, isLoading: isOrgLoading } =
+		useOrganizationsContext();
+
+	const [formOpen, setFormOpen] = useState(false);
+	const [deleteOpen, setDeleteOpen] = useState(false);
+	const [activeAlarm, setActiveAlarm] = useState<Alarm | null>(null);
+	const [formState, setFormState] = useState({ ...emptyFormState });
+
+	const organizationId = activeOrganization?.id ?? "";
+
+	const {
+		data: alarmsData,
+		isLoading,
+		isError,
+	} = useQuery({
+		...orpc.alarms.list.queryOptions({
+			input: { organizationId },
+		}),
+		enabled: Boolean(organizationId),
+	});
+
+	const alarms = (alarmsData ?? []) as Alarm[];
+	const activeCount = alarms.filter((alarm) => alarm.enabled).length;
+
+	const createMutation = useMutation({
+		...orpc.alarms.create.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: { organizationId } }),
+			});
+			setFormOpen(false);
+			setActiveAlarm(null);
+			setFormState({ ...emptyFormState });
+			toast.success("Alarm created");
+		},
+	});
+
+	const updateMutation = useMutation({
+		...orpc.alarms.update.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: { organizationId } }),
+			});
+			setFormOpen(false);
+			setActiveAlarm(null);
+			toast.success("Alarm updated");
+		},
+	});
+
+	const deleteMutation = useMutation({
+		...orpc.alarms.delete.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: { organizationId } }),
+			});
+			setDeleteOpen(false);
+			setActiveAlarm(null);
+			toast.success("Alarm deleted");
+		},
+	});
+
+	const testMutation = useMutation({
+		...orpc.alarms.test.mutationOptions(),
+		onSuccess: (results) => {
+			const successCount = results.filter((result) => result.success).length;
+			const failureCount = results.length - successCount;
+			if (failureCount > 0) {
+				toast.error(
+					`${failureCount} channel${failureCount > 1 ? "s" : ""} failed. ${successCount} succeeded.`
+				);
+				return;
+			}
+			toast.success("Test notification sent");
+		},
+		onError: () => {
+			toast.error("Failed to send test notification");
+		},
+	});
+
+	const toggleMutation = useMutation({
+		...orpc.alarms.update.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: { organizationId } }),
+			});
+		},
+	});
+
+	const formTitle = useMemo(
+		() => (activeAlarm ? "Edit alarm" : "Create alarm"),
+		[activeAlarm]
+	);
+
+	const formDescription = useMemo(
+		() =>
+			activeAlarm
+				? "Update your alert settings and notification channels."
+				: "Configure notifications for critical events.",
+		[activeAlarm]
+	);
+
+	const handleCreate = () => {
+		setActiveAlarm(null);
+		setFormState({ ...emptyFormState });
+		setFormOpen(true);
+	};
+
+	const handleEdit = (alarm: Alarm) => {
+		setActiveAlarm(alarm);
+		setFormState({
+			name: alarm.name,
+			description: alarm.description ?? "",
+			enabled: alarm.enabled,
+			notificationChannels: alarm.notificationChannels,
+			slackWebhookUrl: alarm.slackWebhookUrl ?? "",
+			discordWebhookUrl: alarm.discordWebhookUrl ?? "",
+			emailAddresses: alarm.emailAddresses.join("\n"),
+			webhookUrl: alarm.webhookUrl ?? "",
+			webhookHeaders: alarm.webhookHeaders
+				? JSON.stringify(alarm.webhookHeaders, null, 2)
+				: "",
+			conditions: alarm.conditions
+				? JSON.stringify(alarm.conditions, null, 2)
+				: "",
+		});
+		setFormOpen(true);
+	};
+
+	const handleSubmit = () => {
+		if (!organizationId) {
+			toast.error("Select a workspace to manage alarms");
+			return;
+		}
+
+		if (!formState.name.trim()) {
+			toast.error("Alarm name is required");
+			return;
+		}
+
+		let webhookHeaders: Record<string, string> = {};
+		let conditions: Record<string, unknown> = {};
+
+		try {
+			const parsedHeaders = parseJsonField(
+				formState.webhookHeaders,
+				"Webhook headers"
+			);
+			webhookHeaders = Object.fromEntries(
+				Object.entries(parsedHeaders).map(([key, value]) => [
+					key,
+					String(value),
+				])
+			);
+			conditions = parseJsonField(formState.conditions, "Conditions");
+		} catch (error) {
+			toast.error(error instanceof Error ? error.message : "Invalid JSON");
+			return;
+		}
+
+		const payload = {
+			organizationId,
+			name: formState.name.trim(),
+			description: formState.description.trim() || undefined,
+			enabled: formState.enabled,
+			notificationChannels: formState.notificationChannels,
+			slackWebhookUrl: formState.slackWebhookUrl.trim() || undefined,
+			discordWebhookUrl: formState.discordWebhookUrl.trim() || undefined,
+			emailAddresses: parseList(formState.emailAddresses),
+			webhookUrl: formState.webhookUrl.trim() || undefined,
+			webhookHeaders,
+			conditions,
+		};
+
+		if (activeAlarm) {
+			updateMutation.mutate({ id: activeAlarm.id, ...payload });
+			return;
+		}
+
+		createMutation.mutate(payload);
+	};
+
+	const handleToggle = (alarm: Alarm, enabled: boolean) => {
+		toggleMutation.mutate({
+			id: alarm.id,
+			organizationId,
+			enabled,
+		});
+	};
+
+	const handleDelete = () => {
+		if (!activeAlarm) return;
+		deleteMutation.mutate({
+			id: activeAlarm.id,
+			organizationId,
+		});
+	};
+
+	const isEmpty = alarms.length === 0;
+
+	if (isOrgLoading || isLoading) {
+		return <AlarmSkeleton />;
+	}
+
+	if (!organizationId) {
+		return (
+			<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+				<div className="flex flex-col">
+					<EmptyState
+						description="Select a workspace to manage notification alarms."
+						icon={<BellIcon weight="duotone" />}
+						title="No workspace selected"
+						variant="minimal"
+					/>
+				</div>
+				<RightSidebar className="gap-4 p-5">
+					<RightSidebar.DocsLink className="justify-center" />
+					<RightSidebar.Tip description="Alarms are workspace-specific. Choose a workspace to configure alerts." />
+				</RightSidebar>
+			</div>
+		);
+	}
+
+	if (isError) {
+		return (
+			<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+				<div className="flex flex-col">
+					<EmptyState
+						description="Please try again in a moment."
+						icon={<BellIcon weight="duotone" />}
+						title="Failed to load alarms"
+						variant="error"
+					/>
+				</div>
+				<RightSidebar className="gap-4 p-5">
+					<RightSidebar.DocsLink className="justify-center" />
+					<RightSidebar.Tip description="If this keeps happening, refresh the page or contact support." />
+				</RightSidebar>
+			</div>
+		);
+	}
+
+	return (
+		<>
+			<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
+				<div className="flex flex-col border-b lg:border-b-0">
+					{isEmpty ? (
+						<EmptyState
+							action={{ label: "Create alarm", onClick: handleCreate }}
+							description="Create your first alarm to get notified about critical events."
+							icon={<BellIcon weight="duotone" />}
+							title="No alarms yet"
+							variant="minimal"
 						/>
-					}
-					title="Notifications Coming Soon"
-				/>
+					) : (
+						<div className="divide-y">
+							{alarms.map((alarm) => (
+								<div
+									className="grid grid-cols-1 gap-4 px-5 py-4 md:grid-cols-[1fr_auto] md:items-center"
+									key={alarm.id}
+								>
+									<div className="space-y-2">
+										<div className="flex items-center gap-2">
+											<h3 className="font-semibold text-foreground">
+												{alarm.name}
+											</h3>
+											{alarm.enabled ? (
+												<Badge variant="success">Enabled</Badge>
+											) : (
+												<Badge variant="gray">Paused</Badge>
+											)}
+										</div>
+										<p className="text-muted-foreground text-sm">
+											{alarm.description ||
+												"No description provided."}
+										</p>
+										<div className="flex flex-wrap items-center gap-2">
+											{alarm.notificationChannels.length === 0 ? (
+												<Badge variant="gray">No channels</Badge>
+											) : (
+												alarm.notificationChannels.map((channel) => (
+													<Badge key={channel} variant="secondary">
+														{channel}
+													</Badge>
+												))
+											)}
+										</div>
+									</div>
+									<div className="flex flex-wrap items-center gap-2">
+										<Button
+											className="h-9"
+											onClick={() =>
+												testMutation.mutate({
+													id: alarm.id,
+													organizationId,
+												})
+											}
+											variant="secondary"
+										>
+											<PaperPlaneTiltIcon size={16} />
+											Test
+										</Button>
+										<Button
+											className="h-9"
+											onClick={() => handleEdit(alarm)}
+											variant="outline"
+										>
+											<PencilSimpleIcon size={16} />
+											Edit
+										</Button>
+										<Button
+											className="h-9"
+											onClick={() => {
+												setActiveAlarm(alarm);
+												setDeleteOpen(true);
+											}}
+											variant="ghost"
+										>
+											<TrashIcon size={16} />
+											Delete
+										</Button>
+										<div className="flex items-center gap-2 pl-2">
+											<Switch
+												checked={alarm.enabled}
+												onCheckedChange={(checked) =>
+													handleToggle(alarm, checked)
+												}
+											/>
+											<span className="text-muted-foreground text-xs">
+												{alarm.enabled ? "On" : "Off"}
+											</span>
+										</div>
+									</div>
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+
+				<RightSidebar className="gap-4 p-5">
+					<Button className="w-full" onClick={handleCreate}>
+						<PlusIcon size={16} />
+						Create alarm
+					</Button>
+					<RightSidebar.InfoCard
+						description="Active alarms"
+						icon={BellIcon}
+						title={`${activeCount} / ${alarms.length}`}
+					/>
+					<RightSidebar.DocsLink className="justify-center" />
+					<RightSidebar.Tip description="Use alarms to notify your team when traffic spikes, uptime drops, or other conditions trigger." />
+				</RightSidebar>
 			</div>
 
-			<RightSidebar className="gap-0 p-0">
-				<RightSidebar.Section border title="Planned Alerts">
-					<div className="space-y-2 text-muted-foreground text-sm">
-						<p>• Traffic spike alerts</p>
-						<p>• Goal completion notifications</p>
-						<p>• Error rate warnings</p>
-						<p>• Weekly digest emails</p>
-					</div>
-				</RightSidebar.Section>
+			<FormDialog
+				cancelLabel="Cancel"
+				description={formDescription}
+				onOpenChange={setFormOpen}
+				onSubmit={handleSubmit}
+				open={formOpen}
+				size="lg"
+				submitDisabled={createMutation.isPending || updateMutation.isPending}
+				submitLabel={activeAlarm ? "Save changes" : "Create alarm"}
+				title={formTitle}
+			>
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-name">
+						Name
+					</label>
+					<Input
+						id="alarm-name"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								name: event.target.value,
+							}))
+						}
+						placeholder="Traffic spike alert"
+						value={formState.name}
+					/>
+				</div>
 
-				<RightSidebar.Section>
-					<RightSidebar.Tip description="Soon you'll be able to receive alerts when traffic spikes, goals are met, or errors occur." />
-				</RightSidebar.Section>
-			</RightSidebar>
-		</div>
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-description">
+						Description
+					</label>
+					<Textarea
+						id="alarm-description"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								description: event.target.value,
+							}))
+						}
+						placeholder="Notify the team when traffic rises above baseline"
+						rows={3}
+						value={formState.description}
+					/>
+				</div>
+
+				<div className="flex items-center justify-between rounded border p-3">
+					<div>
+						<p className="font-medium text-sm">Alarm status</p>
+						<p className="text-muted-foreground text-xs">
+							Enable or pause notifications.
+						</p>
+					</div>
+					<Switch
+						checked={formState.enabled}
+						onCheckedChange={(checked) =>
+							setFormState((prev) => ({
+								...prev,
+								enabled: checked,
+							}))
+						}
+					/>
+				</div>
+
+				<div className="space-y-3">
+					<p className="font-medium text-sm">Notification channels</p>
+					<div className="grid gap-3 sm:grid-cols-2">
+						{CHANNELS.map((channel) => (
+							<label
+								className="flex items-center gap-2 rounded border px-3 py-2 text-sm"
+								key={channel}
+							>
+								<Checkbox
+									checked={formState.notificationChannels.includes(channel)}
+									onCheckedChange={(checked) => {
+										setFormState((prev) => {
+											const next = new Set(prev.notificationChannels);
+											if (checked) {
+												next.add(channel);
+											} else {
+												next.delete(channel);
+											}
+											return {
+												...prev,
+												notificationChannels: Array.from(next),
+											};
+										});
+									}}
+								/>
+								<span className="capitalize">{channel}</span>
+							</label>
+						))}
+					</div>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-slack">
+						Slack webhook URL
+					</label>
+					<Input
+						id="alarm-slack"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								slackWebhookUrl: event.target.value,
+							}))
+						}
+						placeholder="https://hooks.slack.com/services/..."
+						value={formState.slackWebhookUrl}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-discord">
+						Discord webhook URL
+					</label>
+					<Input
+						id="alarm-discord"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								discordWebhookUrl: event.target.value,
+							}))
+						}
+						placeholder="https://discord.com/api/webhooks/..."
+						value={formState.discordWebhookUrl}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-email">
+						Email addresses
+					</label>
+					<Textarea
+						id="alarm-email"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								emailAddresses: event.target.value,
+							}))
+						}
+						placeholder="alerts@databuddy.cc\nops@databuddy.cc"
+						rows={3}
+						value={formState.emailAddresses}
+					/>
+					<p className="text-muted-foreground text-xs">
+						Separate multiple addresses with commas or new lines.
+					</p>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-webhook">
+						Custom webhook URL
+					</label>
+					<Input
+						id="alarm-webhook"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								webhookUrl: event.target.value,
+							}))
+						}
+						placeholder="https://example.com/alarms"
+						value={formState.webhookUrl}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-headers">
+						Webhook headers (JSON)
+					</label>
+					<Textarea
+						id="alarm-headers"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								webhookHeaders: event.target.value,
+							}))
+						}
+						placeholder='{"Authorization": "Bearer token"}'
+						rows={3}
+						value={formState.webhookHeaders}
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<label className="text-sm font-medium" htmlFor="alarm-conditions">
+						Conditions (JSON)
+					</label>
+					<Textarea
+						id="alarm-conditions"
+						onChange={(event) =>
+							setFormState((prev) => ({
+								...prev,
+								conditions: event.target.value,
+							}))
+						}
+						placeholder='{"metric": "traffic", "threshold": 5000}'
+						rows={3}
+						value={formState.conditions}
+					/>
+				</div>
+			</FormDialog>
+
+			<DeleteDialog
+				isDeleting={deleteMutation.isPending}
+				isOpen={deleteOpen}
+				itemName={activeAlarm?.name}
+				onClose={() => setDeleteOpen(false)}
+				onConfirm={handleDelete}
+				title="Delete alarm"
+			/>
+		</>
 	);
 }

--- a/packages/db/src/drizzle/0001_alarms.sql
+++ b/packages/db/src/drizzle/0001_alarms.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS "alarms" (
+  "id" text PRIMARY KEY NOT NULL,
+  "organization_id" text NOT NULL,
+  "user_id" text,
+  "website_id" text,
+  "name" text NOT NULL,
+  "description" text,
+  "enabled" boolean DEFAULT true NOT NULL,
+  "notification_channels" text[] DEFAULT '{}'::text[] NOT NULL,
+  "slack_webhook_url" text,
+  "discord_webhook_url" text,
+  "email_addresses" text[] DEFAULT '{}'::text[] NOT NULL,
+  "webhook_url" text,
+  "webhook_headers" jsonb DEFAULT '{}'::jsonb,
+  "conditions" jsonb DEFAULT '{}'::jsonb,
+  "created_at" timestamptz DEFAULT now() NOT NULL,
+  "updated_at" timestamptz DEFAULT now() NOT NULL,
+  CONSTRAINT "alarms_organization_id_fkey" FOREIGN KEY ("organization_id") REFERENCES "organization"("id") ON DELETE cascade,
+  CONSTRAINT "alarms_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "user"("id") ON DELETE set null,
+  CONSTRAINT "alarms_website_id_fkey" FOREIGN KEY ("website_id") REFERENCES "websites"("id") ON DELETE set null
+);
+
+CREATE INDEX IF NOT EXISTS "alarms_organization_id_idx" ON "alarms" USING btree ("organization_id");
+CREATE INDEX IF NOT EXISTS "alarms_user_id_idx" ON "alarms" USING btree ("user_id");
+CREATE INDEX IF NOT EXISTS "alarms_website_id_idx" ON "alarms" USING btree ("website_id");
+CREATE INDEX IF NOT EXISTS "alarms_enabled_idx" ON "alarms" USING btree ("enabled");

--- a/packages/db/src/drizzle/relations.ts
+++ b/packages/db/src/drizzle/relations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm/relations";
 import {
 	account,
+	alarms,
 	apikey,
 	flags,
 	flagsToTargetGroups,
@@ -32,6 +33,7 @@ export const userRelations = relations(user, ({ many }) => ({
 	funnelDefinitions: many(funnelDefinitions),
 	apikeys: many(apikey),
 	usageAlertLogs: many(usageAlertLog),
+	alarms: many(alarms),
 }));
 
 export const usageAlertLogRelations = relations(usageAlertLog, ({ one }) => ({
@@ -48,6 +50,7 @@ export const organizationRelations = relations(organization, ({ many }) => ({
 		relationName: "websites_organizationId_organization_id",
 	}),
 	teams: many(team),
+	alarms: many(alarms),
 }));
 
 export const accountRelations = relations(account, ({ one }) => ({
@@ -110,6 +113,7 @@ export const websitesRelations = relations(websites, ({ one, many }) => ({
 		relationName: "websites_organizationId_organization_id",
 	}),
 	funnelDefinitions: many(funnelDefinitions),
+	alarms: many(alarms),
 }));
 
 export const funnelDefinitionsRelations = relations(
@@ -205,6 +209,21 @@ export const linksRelations = relations(links, ({ one }) => ({
 export const revenueConfigRelations = relations(revenueConfig, ({ one }) => ({
 	website: one(websites, {
 		fields: [revenueConfig.websiteId],
+		references: [websites.id],
+	}),
+}));
+
+export const alarmsRelations = relations(alarms, ({ one }) => ({
+	organization: one(organization, {
+		fields: [alarms.organizationId],
+		references: [organization.id],
+	}),
+	user: one(user, {
+		fields: [alarms.userId],
+		references: [user.id],
+	}),
+	website: one(websites, {
+		fields: [alarms.websiteId],
 		references: [websites.id],
 	}),
 }));

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -991,3 +991,65 @@ export const revenueConfig = pgTable(
 		}).onDelete("cascade"),
 	]
 );
+
+export const alarms = pgTable(
+	"alarms",
+	{
+		id: text().primaryKey().notNull(),
+		organizationId: text("organization_id").notNull(),
+		userId: text("user_id"),
+		websiteId: text("website_id"),
+		name: text().notNull(),
+		description: text(),
+		enabled: boolean("enabled").notNull().default(true),
+		notificationChannels: text("notification_channels")
+			.array()
+			.notNull()
+			.default([]),
+		slackWebhookUrl: text("slack_webhook_url"),
+		discordWebhookUrl: text("discord_webhook_url"),
+		emailAddresses: text("email_addresses").array().notNull().default([]),
+		webhookUrl: text("webhook_url"),
+		webhookHeaders: jsonb("webhook_headers").default({}),
+		conditions: jsonb("conditions").default({}),
+		createdAt: timestamp("created_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+		updatedAt: timestamp("updated_at", { withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		index("alarms_organization_id_idx").using(
+			"btree",
+			table.organizationId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_user_id_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_website_id_idx").using(
+			"btree",
+			table.websiteId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_enabled_idx").using(
+			"btree",
+			table.enabled.asc().nullsLast()
+		),
+		foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "alarms_organization_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [user.id],
+			name: "alarms_user_id_fkey",
+		}).onDelete("set null"),
+		foreignKey({
+			columns: [table.websiteId],
+			foreignColumns: [websites.id],
+			name: "alarms_website_id_fkey",
+		}).onDelete("set null"),
+	]
+);

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -9,6 +9,7 @@
     "@databuddy/api-keys": "workspace:*",
     "@databuddy/auth": "workspace:*",
     "@databuddy/db": "workspace:*",
+    "@databuddy/notifications": "workspace:*",
     "@databuddy/redis": "workspace:*",
     "@databuddy/services": "workspace:*",
     "@databuddy/shared": "workspace:*",

--- a/packages/rpc/src/root.ts
+++ b/packages/rpc/src/root.ts
@@ -1,4 +1,5 @@
 import { agentRouter } from "./routers/agent";
+import { alarmsRouter } from "./routers/alarms";
 import { annotationsRouter } from "./routers/annotations";
 import { apikeysRouter } from "./routers/apikeys";
 import { autocompleteRouter } from "./routers/autocomplete";
@@ -20,6 +21,7 @@ import { uptimeRouter } from "./routers/uptime";
 import { websitesRouter } from "./routers/websites";
 
 export const appRouter = {
+	alarms: alarmsRouter,
 	annotations: annotationsRouter,
 	websites: websitesRouter,
 	miniCharts: miniChartsRouter,

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -1,0 +1,499 @@
+import {
+	alarms,
+	and,
+	desc,
+	eq,
+	websites,
+} from "@databuddy/db";
+import {
+	sendDiscordWebhook,
+	sendEmail,
+	sendSlackWebhook,
+	sendWebhook,
+	type NotificationResult,
+} from "@databuddy/notifications";
+import { ORPCError } from "@orpc/server";
+import { randomUUIDv7 } from "bun";
+import { z } from "zod";
+import { protectedProcedure } from "../orpc";
+import { checkOrgPermission } from "../utils/auth";
+
+const alarmChannelSchema = z.enum(["slack", "discord", "email", "webhook"]);
+
+const alarmOutputSchema = z.object({
+	id: z.string(),
+	organizationId: z.string(),
+	userId: z.string().nullable(),
+	websiteId: z.string().nullable(),
+	name: z.string(),
+	description: z.string().nullable(),
+	enabled: z.boolean(),
+	notificationChannels: z.array(alarmChannelSchema),
+	slackWebhookUrl: z.string().nullable(),
+	discordWebhookUrl: z.string().nullable(),
+	emailAddresses: z.array(z.string()),
+	webhookUrl: z.string().nullable(),
+	webhookHeaders: z.record(z.string(), z.unknown()).nullable(),
+	conditions: z.record(z.string(), z.unknown()).nullable(),
+	createdAt: z.coerce.date(),
+	updatedAt: z.coerce.date(),
+});
+
+const notificationResultSchema = z.object({
+	success: z.boolean(),
+	channel: alarmChannelSchema,
+	error: z.string().optional(),
+	response: z.unknown().optional(),
+});
+
+const alarmInputSchema = z.object({
+	organizationId: z.string(),
+	websiteId: z.string().optional(),
+	name: z.string().min(1).max(120),
+	description: z.string().max(500).optional(),
+	enabled: z.boolean().optional(),
+	notificationChannels: z.array(alarmChannelSchema).optional(),
+	slackWebhookUrl: z.string().url().optional(),
+	discordWebhookUrl: z.string().url().optional(),
+	emailAddresses: z.array(z.string().email()).optional(),
+	webhookUrl: z.string().url().optional(),
+	webhookHeaders: z.record(z.string(), z.string()).optional(),
+	conditions: z.record(z.string(), z.unknown()).optional(),
+});
+
+async function assertWebsiteBelongsToOrg(
+	context: Parameters<typeof checkOrgPermission>[0],
+	organizationId: string,
+	websiteId: string
+) {
+	const website = await context.db.query.websites.findFirst({
+		where: eq(websites.id, websiteId),
+		columns: { id: true, organizationId: true },
+	});
+
+	if (!website) {
+		throw new ORPCError("NOT_FOUND", {
+			message: "Website not found",
+		});
+	}
+
+	if (website.organizationId !== organizationId) {
+		throw new ORPCError("FORBIDDEN", {
+			message: "Website does not belong to this workspace",
+		});
+	}
+}
+
+async function sendAlarmTest(
+	alarm: z.infer<typeof alarmOutputSchema>
+): Promise<NotificationResult[]> {
+	const payload = {
+		title: `Databuddy Alarm Test: ${alarm.name}`,
+		message:
+			"This is a test notification to confirm your alarm settings are working.",
+		priority: "normal" as const,
+		metadata: {
+			alarmId: alarm.id,
+			organizationId: alarm.organizationId,
+		},
+	};
+
+	const results: NotificationResult[] = [];
+
+	if (alarm.notificationChannels.includes("slack")) {
+		if (!alarm.slackWebhookUrl) {
+			results.push({
+				success: false,
+				channel: "slack",
+				error: "Slack webhook URL not configured",
+			});
+		} else {
+			results.push(await sendSlackWebhook(alarm.slackWebhookUrl, payload));
+		}
+	}
+
+	if (alarm.notificationChannels.includes("discord")) {
+		if (!alarm.discordWebhookUrl) {
+			results.push({
+				success: false,
+				channel: "discord",
+				error: "Discord webhook URL not configured",
+			});
+		} else {
+			results.push(await sendDiscordWebhook(alarm.discordWebhookUrl, payload));
+		}
+	}
+
+	if (alarm.notificationChannels.includes("webhook")) {
+		if (!alarm.webhookUrl) {
+			results.push({
+				success: false,
+				channel: "webhook",
+				error: "Webhook URL not configured",
+			});
+		} else {
+			results.push(
+				await sendWebhook(alarm.webhookUrl, payload, {
+					headers: (alarm.webhookHeaders ?? {}) as Record<string, string>,
+					method: "POST",
+				})
+			);
+		}
+	}
+
+	if (alarm.notificationChannels.includes("email")) {
+		if (alarm.emailAddresses.length === 0) {
+			results.push({
+				success: false,
+				channel: "email",
+				error: "Email addresses not configured",
+			});
+		} else {
+			const fromAddress =
+				process.env.NOTIFICATIONS_EMAIL_FROM ?? "noreply@databuddy.cc";
+			const resendApiKey = process.env.RESEND_API_KEY;
+
+			const emailResult = await sendEmail(
+				async (emailPayload) => {
+					if (!resendApiKey) {
+						throw new Error("RESEND_API_KEY not configured");
+					}
+
+					const response = await fetch("https://api.resend.com/emails", {
+						method: "POST",
+						headers: {
+							Authorization: `Bearer ${resendApiKey}`,
+							"Content-Type": "application/json",
+						},
+						body: JSON.stringify({
+							from: fromAddress,
+							...emailPayload,
+						}),
+					});
+
+					if (!response.ok) {
+						const errorText = await response
+							.text()
+							.catch(() => "Unable to read response");
+						throw new Error(
+							`Resend API error: ${response.status} ${response.statusText} - ${errorText.slice(0, 200)}`
+						);
+					}
+
+					return response.json().catch(() => ({}));
+				},
+				{
+					...payload,
+					to: alarm.emailAddresses,
+				},
+				{ from: fromAddress }
+			);
+
+			results.push(emailResult);
+		}
+	}
+
+	return results;
+}
+
+export const alarmsRouter = {
+	list: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/list",
+			tags: ["Alarms"],
+			summary: "List alarms",
+			description: "Returns alarms for a workspace.",
+		})
+		.input(z.object({ organizationId: z.string() }))
+		.output(z.array(alarmOutputSchema))
+		.handler(async ({ context, input }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"read",
+				"Missing workspace permissions."
+			);
+
+			return context.db
+				.select()
+				.from(alarms)
+				.where(eq(alarms.organizationId, input.organizationId))
+				.orderBy(desc(alarms.createdAt));
+		}),
+
+	get: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/get",
+			tags: ["Alarms"],
+			summary: "Get alarm",
+			description: "Returns a single alarm by id.",
+		})
+		.input(z.object({ id: z.string(), organizationId: z.string() }))
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input, errors }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"read",
+				"Missing workspace permissions."
+			);
+
+			const [alarm] = await context.db
+				.select()
+				.from(alarms)
+				.where(
+					and(
+						eq(alarms.id, input.id),
+						eq(alarms.organizationId, input.organizationId)
+					)
+				)
+				.limit(1);
+
+			if (!alarm) {
+				throw errors.NOT_FOUND({
+					message: "Alarm not found",
+					data: { resourceType: "alarm", resourceId: input.id },
+				});
+			}
+
+			return alarm;
+		}),
+
+	create: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/create",
+			tags: ["Alarms"],
+			summary: "Create alarm",
+			description: "Creates a new alarm for a workspace.",
+		})
+		.input(alarmInputSchema)
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"update",
+				"Missing workspace permissions."
+			);
+
+			if (input.websiteId) {
+				await assertWebsiteBelongsToOrg(
+					context,
+					input.organizationId,
+					input.websiteId
+				);
+			}
+
+			const alarmId = randomUUIDv7();
+			const now = new Date();
+
+			const [created] = await context.db
+				.insert(alarms)
+				.values({
+					id: alarmId,
+					organizationId: input.organizationId,
+					userId: context.user?.id ?? null,
+					websiteId: input.websiteId ?? null,
+					name: input.name,
+					description: input.description ?? null,
+					enabled: input.enabled ?? true,
+					notificationChannels: input.notificationChannels ?? [],
+					slackWebhookUrl: input.slackWebhookUrl ?? null,
+					discordWebhookUrl: input.discordWebhookUrl ?? null,
+					emailAddresses: input.emailAddresses ?? [],
+					webhookUrl: input.webhookUrl ?? null,
+					webhookHeaders: input.webhookHeaders ?? {},
+					conditions: input.conditions ?? {},
+					createdAt: now,
+					updatedAt: now,
+				})
+				.returning();
+
+			return created;
+		}),
+
+	update: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/update",
+			tags: ["Alarms"],
+			summary: "Update alarm",
+			description: "Updates an existing alarm.",
+		})
+		.input(
+			alarmInputSchema
+				.extend({ id: z.string() })
+				.partial({
+					name: true,
+					description: true,
+					enabled: true,
+					notificationChannels: true,
+					slackWebhookUrl: true,
+					discordWebhookUrl: true,
+					emailAddresses: true,
+					webhookUrl: true,
+					webhookHeaders: true,
+					conditions: true,
+					websiteId: true,
+				})
+		)
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input, errors }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"update",
+				"Missing workspace permissions."
+			);
+
+			if (input.websiteId) {
+				await assertWebsiteBelongsToOrg(
+					context,
+					input.organizationId,
+					input.websiteId
+				);
+			}
+
+			const [existing] = await context.db
+				.select({ id: alarms.id })
+				.from(alarms)
+				.where(
+					and(
+						eq(alarms.id, input.id),
+						eq(alarms.organizationId, input.organizationId)
+					)
+				)
+				.limit(1);
+
+			if (!existing) {
+				throw errors.NOT_FOUND({
+					message: "Alarm not found",
+					data: { resourceType: "alarm", resourceId: input.id },
+				});
+			}
+
+			const updateData: Record<string, unknown> = {
+				updatedAt: new Date(),
+			};
+
+			if (input.name !== undefined) updateData.name = input.name;
+			if (input.description !== undefined)
+				updateData.description = input.description ?? null;
+			if (input.enabled !== undefined) updateData.enabled = input.enabled;
+			if (input.notificationChannels !== undefined)
+				updateData.notificationChannels = input.notificationChannels;
+			if (input.slackWebhookUrl !== undefined)
+				updateData.slackWebhookUrl = input.slackWebhookUrl ?? null;
+			if (input.discordWebhookUrl !== undefined)
+				updateData.discordWebhookUrl = input.discordWebhookUrl ?? null;
+			if (input.emailAddresses !== undefined)
+				updateData.emailAddresses = input.emailAddresses;
+			if (input.webhookUrl !== undefined)
+				updateData.webhookUrl = input.webhookUrl ?? null;
+			if (input.webhookHeaders !== undefined)
+				updateData.webhookHeaders = input.webhookHeaders ?? {};
+			if (input.conditions !== undefined)
+				updateData.conditions = input.conditions ?? {};
+			if (input.websiteId !== undefined)
+				updateData.websiteId = input.websiteId ?? null;
+
+			const [updated] = await context.db
+				.update(alarms)
+				.set(updateData)
+				.where(
+					and(
+						eq(alarms.id, input.id),
+						eq(alarms.organizationId, input.organizationId)
+					)
+				)
+				.returning();
+
+			return updated;
+		}),
+
+	delete: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/delete",
+			tags: ["Alarms"],
+			summary: "Delete alarm",
+			description: "Deletes an alarm.",
+		})
+		.input(z.object({ id: z.string(), organizationId: z.string() }))
+		.output(z.object({ success: z.literal(true) }))
+		.handler(async ({ context, input, errors }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"update",
+				"Missing workspace permissions."
+			);
+
+			const deleted = await context.db
+				.delete(alarms)
+				.where(
+					and(
+						eq(alarms.id, input.id),
+						eq(alarms.organizationId, input.organizationId)
+					)
+				)
+				.returning({ id: alarms.id });
+
+			if (!deleted.length) {
+				throw errors.NOT_FOUND({
+					message: "Alarm not found",
+					data: { resourceType: "alarm", resourceId: input.id },
+				});
+			}
+
+			return { success: true };
+		}),
+
+	test: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/alarms/test",
+			tags: ["Alarms"],
+			summary: "Test alarm",
+			description: "Sends a test notification for an alarm.",
+		})
+		.input(z.object({ id: z.string(), organizationId: z.string() }))
+		.output(z.array(notificationResultSchema))
+		.handler(async ({ context, input, errors }) => {
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"organization",
+				"update",
+				"Missing workspace permissions."
+			);
+
+			const [alarm] = await context.db
+				.select()
+				.from(alarms)
+				.where(
+					and(
+						eq(alarms.id, input.id),
+						eq(alarms.organizationId, input.organizationId)
+					)
+				)
+				.limit(1);
+
+			if (!alarm) {
+				throw errors.NOT_FOUND({
+					message: "Alarm not found",
+					data: { resourceType: "alarm", resourceId: input.id },
+				});
+			}
+
+			return await sendAlarmTest(alarm);
+		}),
+};


### PR DESCRIPTION
/claim #267

Implements #267 (Alarms System) with shippable scope:
- alarms DB schema + relations + migration
- RPC router: alarms.list/get/create/update/delete/test
- settings notifications UI for alarm management
- test notification path via @databuddy/notifications

Note: I will attach a short demo video in this PR thread to satisfy bounty requirements.
