### PR TITLE
feat: Alarms System - Database, API & Dashboard UI (#267)

### DIFF
--- a/apps/dashboard/app/(main)/settings/notifications/_components/alarm-dialog.tsx
+++ b/apps/dashboard/app/(main)/settings/notifications/_components/alarm-dialog.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import {
+	BellIcon,
+	SpinnerGapIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { orpc } from "@/lib/orpc";
+import { cn } from "@/lib/utils";
+import { activeOrganizationAtom } from "@/stores/jotai/organizationsAtoms";
+
+interface Alarm {
+	id: string;
+	name: string;
+	description: string | null;
+	enabled: boolean;
+	notificationChannels: string[];
+	triggerType: string;
+	slackWebhookUrl: string | null;
+	discordWebhookUrl: string | null;
+	emailAddresses: string[] | null;
+	webhookUrl: string | null;
+	webhookHeaders: Record<string, string> | null;
+	triggerConditions: Record<string, unknown> | null;
+	websiteId: string | null;
+	organizationId: string | null;
+}
+
+interface AlarmDialogProps {
+	alarm: Alarm | null;
+	isOpen: boolean;
+	onCloseAction: () => void;
+}
+
+const TRIGGER_TYPES = [
+	{ value: "uptime", label: "Uptime" },
+	{ value: "traffic_spike", label: "Traffic Spike" },
+	{ value: "error_rate", label: "Error Rate" },
+	{ value: "goal", label: "Goal" },
+	{ value: "custom", label: "Custom" },
+] as const;
+
+const CHANNELS = [
+	{ value: "slack", label: "Slack" },
+	{ value: "discord", label: "Discord" },
+	{ value: "email", label: "Email" },
+	{ value: "webhook", label: "Webhook" },
+] as const;
+
+type TriggerType = (typeof TRIGGER_TYPES)[number]["value"];
+type Channel = (typeof CHANNELS)[number]["value"];
+
+export function AlarmDialog({ alarm, isOpen, onCloseAction }: AlarmDialogProps) {
+	const queryClient = useQueryClient();
+	const activeOrganization = useAtomValue(activeOrganizationAtom);
+	const isEditing = Boolean(alarm);
+
+	const [name, setName] = useState(alarm?.name ?? "");
+	const [description, setDescription] = useState(alarm?.description ?? "");
+	const [enabled, setEnabled] = useState(alarm?.enabled ?? true);
+	const [triggerType, setTriggerType] = useState<TriggerType>(
+		(alarm?.triggerType as TriggerType) ?? "uptime"
+	);
+	const [channels, setChannels] = useState<Channel[]>(
+		(alarm?.notificationChannels as Channel[]) ?? []
+	);
+	const [slackUrl, setSlackUrl] = useState(alarm?.slackWebhookUrl ?? "");
+	const [discordUrl, setDiscordUrl] = useState(alarm?.discordWebhookUrl ?? "");
+	const [emailAddresses, setEmailAddresses] = useState(
+		alarm?.emailAddresses?.join(", ") ?? ""
+	);
+	const [webhookUrl, setWebhookUrl] = useState(alarm?.webhookUrl ?? "");
+
+	const createMutation = useMutation({
+		...orpc.alarms.create.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: {} }),
+			});
+			toast.success("Alarm created");
+			onCloseAction();
+		},
+		onError: () => {
+			toast.error("Failed to create alarm");
+		},
+	});
+
+	const updateMutation = useMutation({
+		...orpc.alarms.update.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: {} }),
+			});
+			toast.success("Alarm updated");
+			onCloseAction();
+		},
+		onError: () => {
+			toast.error("Failed to update alarm");
+		},
+	});
+
+	const toggleChannel = (channel: Channel) => {
+		setChannels((prev) =>
+			prev.includes(channel)
+				? prev.filter((c) => c !== channel)
+				: [...prev, channel]
+		);
+	};
+
+	const handleSubmit = () => {
+		if (!name.trim()) {
+			toast.error("Name is required");
+			return;
+		}
+
+		if (channels.length === 0) {
+			toast.error("Select at least one notification channel");
+			return;
+		}
+
+		if (!activeOrganization?.id && !isEditing) {
+			toast.error("No active workspace found");
+			return;
+		}
+
+		const emails = emailAddresses
+			.split(",")
+			.map((e) => e.trim())
+			.filter(Boolean);
+
+		if (isEditing && alarm) {
+			updateMutation.mutate({
+				id: alarm.id,
+				name: name.trim(),
+				description: description.trim() || undefined,
+				enabled,
+				notificationChannels: channels,
+				triggerType,
+				slackWebhookUrl: slackUrl.trim() || null,
+				discordWebhookUrl: discordUrl.trim() || null,
+				emailAddresses: emails.length > 0 ? emails : null,
+				webhookUrl: webhookUrl.trim() || null,
+			});
+		} else {
+			createMutation.mutate({
+				organizationId: activeOrganization?.id ?? "",
+				name: name.trim(),
+				description: description.trim() || undefined,
+				enabled,
+				notificationChannels: channels,
+				triggerType,
+				slackWebhookUrl: slackUrl.trim() || undefined,
+				discordWebhookUrl: discordUrl.trim() || undefined,
+				emailAddresses: emails.length > 0 ? emails : undefined,
+				webhookUrl: webhookUrl.trim() || undefined,
+			});
+		}
+	};
+
+	const isLoading = createMutation.isPending || updateMutation.isPending;
+
+	return (
+		<Dialog onOpenChange={(open) => !open && onCloseAction()} open={isOpen}>
+			<DialogContent className="sm:max-w-lg">
+				<DialogHeader>
+					<div className="flex items-center gap-3">
+						<div className="flex size-10 items-center justify-center rounded border bg-secondary">
+							<BellIcon className="text-primary" size={18} weight="duotone" />
+						</div>
+						<div>
+							<DialogTitle>
+								{isEditing ? "Edit Alarm" : "Create Alarm"}
+							</DialogTitle>
+							<DialogDescription>
+								{isEditing
+									? `Editing ${alarm?.name}`
+									: "Set up a notification alarm"}
+							</DialogDescription>
+						</div>
+					</div>
+				</DialogHeader>
+
+				<div className="space-y-5 py-2">
+					<div className="space-y-2">
+						<Label htmlFor="alarm-name">
+							Name <span className="text-destructive">*</span>
+						</Label>
+						<Input
+							id="alarm-name"
+							onChange={(e) => setName(e.target.value)}
+							placeholder="Site Down Alert"
+							value={name}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="alarm-description">Description</Label>
+						<Textarea
+							className="min-h-16 resize-none"
+							id="alarm-description"
+							onChange={(e) => setDescription(e.target.value)}
+							placeholder="What should this alarm notify you about?"
+							value={description}
+						/>
+					</div>
+
+					<div className="space-y-2">
+						<Label>Trigger Type</Label>
+						<div className="flex flex-wrap gap-2">
+							{TRIGGER_TYPES.map((type) => (
+								<button
+									className={cn(
+										"cursor-pointer rounded border px-3 py-1.5 text-sm transition-colors",
+										triggerType === type.value
+											? "border-primary bg-primary/5 font-medium text-foreground"
+											: "border-transparent bg-secondary text-muted-foreground hover:border-border hover:text-foreground"
+									)}
+									key={type.value}
+									onClick={() => setTriggerType(type.value)}
+									type="button"
+								>
+									{type.label}
+								</button>
+							))}
+						</div>
+					</div>
+
+					<div className="h-px bg-border" />
+
+					<div className="space-y-2">
+						<Label>
+							Notification Channels{" "}
+							<span className="text-destructive">*</span>
+						</Label>
+						<div className="flex flex-wrap gap-2">
+							{CHANNELS.map((ch) => (
+								<button
+									className={cn(
+										"cursor-pointer rounded border px-3 py-1.5 text-sm transition-colors",
+										channels.includes(ch.value)
+											? "border-primary bg-primary/5 font-medium text-foreground"
+											: "border-transparent bg-secondary text-muted-foreground hover:border-border hover:text-foreground"
+									)}
+									key={ch.value}
+									onClick={() => toggleChannel(ch.value)}
+									type="button"
+								>
+									{ch.label}
+								</button>
+							))}
+						</div>
+					</div>
+
+					{channels.includes("slack") && (
+						<div className="space-y-2">
+							<Label htmlFor="slack-url">Slack Webhook URL</Label>
+							<Input
+								id="slack-url"
+								onChange={(e) => setSlackUrl(e.target.value)}
+								placeholder="https://hooks.slack.com/services/..."
+								value={slackUrl}
+							/>
+						</div>
+					)}
+
+					{channels.includes("discord") && (
+						<div className="space-y-2">
+							<Label htmlFor="discord-url">Discord Webhook URL</Label>
+							<Input
+								id="discord-url"
+								onChange={(e) => setDiscordUrl(e.target.value)}
+								placeholder="https://discord.com/api/webhooks/..."
+								value={discordUrl}
+							/>
+						</div>
+					)}
+
+					{channels.includes("email") && (
+						<div className="space-y-2">
+							<Label htmlFor="email-addresses">
+								Email Addresses (comma-separated)
+							</Label>
+							<Input
+								id="email-addresses"
+								onChange={(e) => setEmailAddresses(e.target.value)}
+								placeholder="admin@example.com, team@example.com"
+								value={emailAddresses}
+							/>
+						</div>
+					)}
+
+					{channels.includes("webhook") && (
+						<div className="space-y-2">
+							<Label htmlFor="webhook-url">Webhook URL</Label>
+							<Input
+								id="webhook-url"
+								onChange={(e) => setWebhookUrl(e.target.value)}
+								placeholder="https://example.com/webhook"
+								value={webhookUrl}
+							/>
+						</div>
+					)}
+
+					<div className="flex items-center justify-between">
+						<div>
+							<Label>Enabled</Label>
+							<p className="text-muted-foreground text-xs">
+								Alarm will trigger notifications when enabled
+							</p>
+						</div>
+						<Switch checked={enabled} onCheckedChange={setEnabled} />
+					</div>
+				</div>
+
+				<DialogFooter>
+					<Button onClick={onCloseAction} type="button" variant="ghost">
+						Cancel
+					</Button>
+					<Button
+						className="min-w-24"
+						disabled={isLoading}
+						onClick={handleSubmit}
+						type="button"
+					>
+						{isLoading ? (
+							<>
+								<SpinnerGapIcon className="animate-spin" size={16} />
+								{isEditing ? "Saving..." : "Creating..."}
+							</>
+						) : isEditing ? (
+							"Save Changes"
+						) : (
+							"Create Alarm"
+						)}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}

--- a/apps/dashboard/app/(main)/settings/notifications/page.tsx
+++ b/apps/dashboard/app/(main)/settings/notifications/page.tsx
@@ -161,6 +161,9 @@ export default function NotificationsSettingsPage() {
 			});
 			toast.success("Alarm deleted");
 		},
+		onError: () => {
+			toast.error("Failed to delete alarm");
+		},
 	});
 
 	const updateMutation = useMutation({
@@ -231,8 +234,12 @@ export default function NotificationsSettingsPage() {
 
 	const handleConfirmDelete = async () => {
 		if (alarmToDelete) {
-			await deleteMutation.mutateAsync({ id: alarmToDelete.id });
-			setAlarmToDelete(null);
+			try {
+				await deleteMutation.mutateAsync({ id: alarmToDelete.id });
+				setAlarmToDelete(null);
+			} catch {
+				toast.error("Failed to delete alarm");
+			}
 		}
 	};
 

--- a/apps/dashboard/app/(main)/settings/notifications/page.tsx
+++ b/apps/dashboard/app/(main)/settings/notifications/page.tsx
@@ -1,39 +1,361 @@
 "use client";
 
-import { BellIcon } from "@phosphor-icons/react";
+import {
+	BellIcon,
+	PlusIcon,
+	SpinnerGapIcon,
+	TrashIcon,
+	PencilSimpleIcon,
+	TestTubeIcon,
+	CheckCircleIcon,
+	XCircleIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
 import { RightSidebar } from "@/components/right-sidebar";
-import { ComingSoon } from "../_components/settings-section";
+import { EmptyState } from "@/components/empty-state";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { DeleteDialog } from "@/components/ui/delete-dialog";
+import { Switch } from "@/components/ui/switch";
+import { orpc } from "@/lib/orpc";
+import { cn } from "@/lib/utils";
+import { AlarmDialog } from "./_components/alarm-dialog";
+
+interface Alarm {
+	id: string;
+	name: string;
+	description: string | null;
+	enabled: boolean;
+	notificationChannels: string[];
+	triggerType: string;
+	slackWebhookUrl: string | null;
+	discordWebhookUrl: string | null;
+	emailAddresses: string[] | null;
+	webhookUrl: string | null;
+	webhookHeaders: Record<string, string> | null;
+	triggerConditions: Record<string, unknown> | null;
+	websiteId: string | null;
+	organizationId: string | null;
+	createdAt: string;
+	updatedAt: string;
+}
+
+const TRIGGER_LABELS: Record<string, string> = {
+	uptime: "Uptime",
+	traffic_spike: "Traffic Spike",
+	error_rate: "Error Rate",
+	goal: "Goal",
+	custom: "Custom",
+};
+
+const CHANNEL_LABELS: Record<string, string> = {
+	slack: "Slack",
+	discord: "Discord",
+	email: "Email",
+	webhook: "Webhook",
+};
+
+function AlarmCard({
+	alarm,
+	onEditAction,
+	onDeleteAction,
+	onTestAction,
+	onToggleAction,
+	isToggling,
+	isTesting,
+}: {
+	alarm: Alarm;
+	onEditAction: () => void;
+	onDeleteAction: () => void;
+	onTestAction: () => void;
+	onToggleAction: (enabled: boolean) => void;
+	isToggling: boolean;
+	isTesting: boolean;
+}) {
+	return (
+		<div className="flex items-center justify-between border-b px-5 py-4 last:border-b-0">
+			<div className="min-w-0 flex-1">
+				<div className="flex items-center gap-2">
+					<p className="truncate font-medium text-sm">{alarm.name}</p>
+					<Badge variant="gray">
+						{TRIGGER_LABELS[alarm.triggerType] ?? alarm.triggerType}
+					</Badge>
+				</div>
+				{alarm.description && (
+					<p className="mt-0.5 truncate text-muted-foreground text-xs">
+						{alarm.description}
+					</p>
+				)}
+				<div className="mt-1 flex items-center gap-1.5">
+					{alarm.notificationChannels.map((ch) => (
+						<span
+							className="rounded bg-secondary px-1.5 py-0.5 text-muted-foreground text-xs"
+							key={ch}
+						>
+							{CHANNEL_LABELS[ch] ?? ch}
+						</span>
+					))}
+				</div>
+			</div>
+			<div className="flex shrink-0 items-center gap-2">
+				<Button
+					aria-label="Test alarm"
+					disabled={isTesting}
+					onClick={onTestAction}
+					size="sm"
+					variant="ghost"
+				>
+					{isTesting ? (
+						<SpinnerGapIcon className="animate-spin" size={16} />
+					) : (
+						<TestTubeIcon size={16} weight="duotone" />
+					)}
+				</Button>
+				<Button
+					aria-label="Edit alarm"
+					onClick={onEditAction}
+					size="sm"
+					variant="ghost"
+				>
+					<PencilSimpleIcon size={16} weight="duotone" />
+				</Button>
+				<Button
+					aria-label="Delete alarm"
+					onClick={onDeleteAction}
+					size="sm"
+					variant="ghost"
+				>
+					<TrashIcon size={16} weight="duotone" />
+				</Button>
+				<Switch
+					checked={alarm.enabled}
+					disabled={isToggling}
+					onCheckedChange={onToggleAction}
+				/>
+			</div>
+		</div>
+	);
+}
 
 export default function NotificationsSettingsPage() {
+	const queryClient = useQueryClient();
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [editingAlarm, setEditingAlarm] = useState<Alarm | null>(null);
+	const [alarmToDelete, setAlarmToDelete] = useState<Alarm | null>(null);
+	const [togglingId, setTogglingId] = useState<string | null>(null);
+	const [testingId, setTestingId] = useState<string | null>(null);
+
+	const { data: alarmsList, isLoading } = useQuery({
+		...orpc.alarms.list.queryOptions({ input: {} }),
+	});
+
+	const alarms = (alarmsList ?? []) as Alarm[];
+
+	const deleteMutation = useMutation({
+		...orpc.alarms.delete.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: {} }),
+			});
+			toast.success("Alarm deleted");
+		},
+	});
+
+	const updateMutation = useMutation({
+		...orpc.alarms.update.mutationOptions(),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: orpc.alarms.list.key({ input: {} }),
+			});
+		},
+	});
+
+	const testMutation = useMutation({
+		...orpc.alarms.test.mutationOptions(),
+	});
+
+	const handleCreate = () => {
+		setEditingAlarm(null);
+		setIsDialogOpen(true);
+	};
+
+	const handleEdit = (alarm: Alarm) => {
+		setEditingAlarm(alarm);
+		setIsDialogOpen(true);
+	};
+
+	const handleToggle = async (alarm: Alarm, enabled: boolean) => {
+		setTogglingId(alarm.id);
+		try {
+			await updateMutation.mutateAsync({
+				id: alarm.id,
+				enabled,
+			});
+			toast.success(`Alarm ${enabled ? "enabled" : "disabled"}`);
+		} catch {
+			toast.error("Failed to update alarm");
+		} finally {
+			setTogglingId(null);
+		}
+	};
+
+	const handleTest = async (alarm: Alarm) => {
+		setTestingId(alarm.id);
+		try {
+			const result = await testMutation.mutateAsync({ id: alarm.id });
+			const typedResult = result as {
+				success: boolean;
+				results: Array<{
+					channel: string;
+					success: boolean;
+					error?: string;
+				}>;
+			};
+			if (typedResult.success) {
+				toast.success("Test notification sent successfully");
+			} else {
+				const failedChannels = typedResult.results
+					.filter((r) => !r.success)
+					.map((r) => `${r.channel}: ${r.error ?? "failed"}`)
+					.join(", ");
+				toast.error(`Some channels failed: ${failedChannels}`);
+			}
+		} catch {
+			toast.error("Failed to send test notification");
+		} finally {
+			setTestingId(null);
+		}
+	};
+
+	const handleConfirmDelete = async () => {
+		if (alarmToDelete) {
+			await deleteMutation.mutateAsync({ id: alarmToDelete.id });
+			setAlarmToDelete(null);
+		}
+	};
+
+	const handleDialogClose = () => {
+		setIsDialogOpen(false);
+		setEditingAlarm(null);
+	};
+
 	return (
 		<div className="h-full lg:grid lg:grid-cols-[1fr_18rem]">
 			<div className="flex flex-col">
-				<ComingSoon
-					description="Configure email alerts, push notifications, and weekly reports. Stay informed about your analytics and account activity."
-					icon={
-						<BellIcon
-							className="size-8 text-muted-foreground"
-							weight="duotone"
+				<div className="flex items-center justify-between border-b px-5 py-4">
+					<div>
+						<h2 className="font-semibold text-sm">Alarms</h2>
+						<p className="text-muted-foreground text-xs">
+							Configure notification alarms for your websites
+						</p>
+					</div>
+					<Button onClick={handleCreate} size="sm">
+						<PlusIcon size={16} />
+						New Alarm
+					</Button>
+				</div>
+
+				{isLoading ? (
+					<div className="flex items-center justify-center py-16">
+						<SpinnerGapIcon
+							className="animate-spin text-muted-foreground"
+							size={24}
 						/>
-					}
-					title="Notifications Coming Soon"
-				/>
+					</div>
+				) : alarms.length === 0 ? (
+					<div className="flex flex-1 items-center justify-center py-16">
+						<EmptyState
+							action={{
+								label: "Create Your First Alarm",
+								onClick: handleCreate,
+							}}
+							description="Set up alarms to get notified via Slack, Discord, email, or webhooks when events occur."
+							icon={<BellIcon weight="duotone" />}
+							title="No alarms yet"
+							variant="minimal"
+						/>
+					</div>
+				) : (
+					<div>
+						{alarms.map((alarm) => (
+							<AlarmCard
+								alarm={alarm}
+								isTesting={testingId === alarm.id}
+								isToggling={togglingId === alarm.id}
+								key={alarm.id}
+								onDeleteAction={() => setAlarmToDelete(alarm)}
+								onEditAction={() => handleEdit(alarm)}
+								onTestAction={() => handleTest(alarm)}
+								onToggleAction={(enabled) =>
+									handleToggle(alarm, enabled)
+								}
+							/>
+						))}
+					</div>
+				)}
 			</div>
 
 			<RightSidebar className="gap-0 p-0">
-				<RightSidebar.Section border title="Planned Alerts">
+				<RightSidebar.Section border title="Notification Channels">
 					<div className="space-y-2 text-muted-foreground text-sm">
-						<p>• Traffic spike alerts</p>
-						<p>• Goal completion notifications</p>
-						<p>• Error rate warnings</p>
-						<p>• Weekly digest emails</p>
+						<div className="flex items-center gap-2">
+							<CheckCircleIcon
+								className="text-success"
+								size={16}
+								weight="fill"
+							/>
+							<span>Slack webhooks</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<CheckCircleIcon
+								className="text-success"
+								size={16}
+								weight="fill"
+							/>
+							<span>Discord webhooks</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<XCircleIcon
+								className="text-muted-foreground"
+								size={16}
+								weight="fill"
+							/>
+							<span>Email (coming soon)</span>
+						</div>
+						<div className="flex items-center gap-2">
+							<CheckCircleIcon
+								className="text-success"
+								size={16}
+								weight="fill"
+							/>
+							<span>Custom webhooks</span>
+						</div>
 					</div>
 				</RightSidebar.Section>
 
 				<RightSidebar.Section>
-					<RightSidebar.Tip description="Soon you'll be able to receive alerts when traffic spikes, goals are met, or errors occur." />
+					<RightSidebar.Tip description="Create alarms and assign them to trigger on uptime events, traffic spikes, error rates, or custom conditions." />
 				</RightSidebar.Section>
 			</RightSidebar>
+
+			{isDialogOpen && (
+				<AlarmDialog
+					alarm={editingAlarm}
+					isOpen={isDialogOpen}
+					onCloseAction={handleDialogClose}
+				/>
+			)}
+
+			<DeleteDialog
+				isDeleting={deleteMutation.isPending}
+				isOpen={alarmToDelete !== null}
+				itemName={alarmToDelete?.name}
+				onClose={() => setAlarmToDelete(null)}
+				onConfirm={handleConfirmDelete}
+				title="Delete Alarm"
+			/>
 		</div>
 	);
 }

--- a/packages/db/src/drizzle/relations.ts
+++ b/packages/db/src/drizzle/relations.ts
@@ -1,6 +1,7 @@
 import { relations } from "drizzle-orm/relations";
 import {
 	account,
+	alarms,
 	apikey,
 	flags,
 	flagsToTargetGroups,
@@ -205,6 +206,21 @@ export const linksRelations = relations(links, ({ one }) => ({
 export const revenueConfigRelations = relations(revenueConfig, ({ one }) => ({
 	website: one(websites, {
 		fields: [revenueConfig.websiteId],
+		references: [websites.id],
+	}),
+}));
+
+export const alarmsRelations = relations(alarms, ({ one }) => ({
+	user: one(user, {
+		fields: [alarms.userId],
+		references: [user.id],
+	}),
+	organization: one(organization, {
+		fields: [alarms.organizationId],
+		references: [organization.id],
+	}),
+	website: one(websites, {
+		fields: [alarms.websiteId],
 		references: [websites.id],
 	}),
 }));

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -1094,6 +1094,72 @@ export const feedbackRedemptions = pgTable(
 	]
 );
 
+export const alarmTriggerType = pgEnum("alarm_trigger_type", [
+	"uptime",
+	"traffic_spike",
+	"error_rate",
+	"goal",
+	"custom",
+]);
+
+export const alarms = pgTable(
+	"alarms",
+	{
+		id: text().primaryKey().notNull(),
+		userId: text("user_id"),
+		organizationId: text("organization_id"),
+		websiteId: text("website_id"),
+		name: text().notNull(),
+		description: text(),
+		enabled: boolean().default(true).notNull(),
+		notificationChannels: text("notification_channels").array().notNull(),
+		slackWebhookUrl: text("slack_webhook_url"),
+		discordWebhookUrl: text("discord_webhook_url"),
+		emailAddresses: text("email_addresses").array(),
+		webhookUrl: text("webhook_url"),
+		webhookHeaders: jsonb("webhook_headers"),
+		triggerType: alarmTriggerType("trigger_type").notNull(),
+		triggerConditions: jsonb("trigger_conditions"),
+		createdAt: timestamp("created_at", { precision: 3 }).defaultNow().notNull(),
+		updatedAt: timestamp("updated_at", { precision: 3 }).defaultNow().notNull(),
+	},
+	(table) => [
+		index("alarms_user_id_idx").using(
+			"btree",
+			table.userId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_organization_id_idx").using(
+			"btree",
+			table.organizationId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_website_id_idx").using(
+			"btree",
+			table.websiteId.asc().nullsLast().op("text_ops")
+		),
+		index("alarms_enabled_idx").using(
+			"btree",
+			table.enabled.asc().nullsLast()
+		),
+		foreignKey({
+			columns: [table.userId],
+			foreignColumns: [user.id],
+			name: "alarms_user_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.organizationId],
+			foreignColumns: [organization.id],
+			name: "alarms_organization_id_fkey",
+		}).onDelete("cascade"),
+		foreignKey({
+			columns: [table.websiteId],
+			foreignColumns: [websites.id],
+			name: "alarms_website_id_fkey",
+		})
+			.onUpdate("cascade")
+			.onDelete("cascade"),
+	]
+);
+
 export type Website = typeof websites.$inferSelect;
 export type WebsiteInsert = typeof websites.$inferInsert;
 export type Organization = typeof organization.$inferSelect;
@@ -1116,3 +1182,5 @@ export type Feedback = typeof feedback.$inferSelect;
 export type FeedbackInsert = typeof feedback.$inferInsert;
 export type FeedbackRedemption = typeof feedbackRedemptions.$inferSelect;
 export type FeedbackRedemptionInsert = typeof feedbackRedemptions.$inferInsert;
+export type Alarm = typeof alarms.$inferSelect;
+export type AlarmInsert = typeof alarms.$inferInsert;

--- a/packages/rpc/src/root.ts
+++ b/packages/rpc/src/root.ts
@@ -1,3 +1,4 @@
+import { alarmsRouter } from "./routers/alarms";
 import { annotationsRouter } from "./routers/annotations";
 import { apikeysRouter } from "./routers/apikeys";
 import { autocompleteRouter } from "./routers/autocomplete";
@@ -15,6 +16,7 @@ import { uptimeRouter } from "./routers/uptime";
 import { websitesRouter } from "./routers/websites";
 
 export const appRouter = {
+	alarms: alarmsRouter,
 	annotations: annotationsRouter,
 	websites: websitesRouter,
 	funnels: funnelsRouter,

--- a/packages/rpc/src/routers/alarms.test.ts
+++ b/packages/rpc/src/routers/alarms.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+
+const notificationChannelSchema = z.enum([
+	"slack",
+	"discord",
+	"email",
+	"webhook",
+]);
+
+const triggerTypeSchema = z.enum([
+	"uptime",
+	"traffic_spike",
+	"error_rate",
+	"goal",
+	"custom",
+]);
+
+const createAlarmSchema = z.object({
+	organizationId: z.string(),
+	websiteId: z.string().optional(),
+	name: z.string().min(1).max(200),
+	description: z.string().max(1000).optional(),
+	enabled: z.boolean().optional(),
+	notificationChannels: z.array(notificationChannelSchema).min(1),
+	slackWebhookUrl: z.string().url().optional(),
+	discordWebhookUrl: z.string().url().optional(),
+	emailAddresses: z.array(z.string().email()).optional(),
+	webhookUrl: z.string().url().optional(),
+	webhookHeaders: z.record(z.string(), z.string()).optional(),
+	triggerType: triggerTypeSchema,
+	triggerConditions: z.record(z.string(), z.unknown()).optional(),
+});
+
+const updateAlarmSchema = z.object({
+	id: z.string(),
+	name: z.string().min(1).max(200).optional(),
+	description: z.string().max(1000).optional(),
+	enabled: z.boolean().optional(),
+	websiteId: z.string().nullish(),
+	notificationChannels: z.array(notificationChannelSchema).min(1).optional(),
+	slackWebhookUrl: z.string().url().nullish(),
+	discordWebhookUrl: z.string().url().nullish(),
+	emailAddresses: z.array(z.string().email()).nullish(),
+	webhookUrl: z.string().url().nullish(),
+	webhookHeaders: z.record(z.string(), z.string()).nullish(),
+	triggerType: triggerTypeSchema.optional(),
+	triggerConditions: z.record(z.string(), z.unknown()).nullish(),
+});
+
+describe("Alarm validation schemas", () => {
+	describe("createAlarmSchema", () => {
+		it("should validate a valid alarm creation payload", () => {
+			const valid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Site Down Alert",
+				notificationChannels: ["slack"],
+				slackWebhookUrl: "https://hooks.slack.com/services/T/B/X",
+				triggerType: "uptime",
+				triggerConditions: { consecutiveFailures: 3 },
+			});
+			expect(valid.success).toBe(true);
+		});
+
+		it("should reject empty name", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "",
+				notificationChannels: ["slack"],
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject name exceeding max length", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "a".repeat(201),
+				notificationChannels: ["slack"],
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject empty notification channels", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Test Alarm",
+				notificationChannels: [],
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject invalid notification channel", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Test Alarm",
+				notificationChannels: ["sms"],
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject invalid trigger type", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Test Alarm",
+				notificationChannels: ["slack"],
+				triggerType: "invalid_type",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject invalid webhook URLs", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Test Alarm",
+				notificationChannels: ["slack"],
+				slackWebhookUrl: "not-a-url",
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should reject invalid email addresses", () => {
+			const invalid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Test Alarm",
+				notificationChannels: ["email"],
+				emailAddresses: ["not-an-email"],
+				triggerType: "uptime",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should accept multiple notification channels", () => {
+			const valid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				name: "Multi-Channel Alert",
+				notificationChannels: ["slack", "discord", "email", "webhook"],
+				slackWebhookUrl: "https://hooks.slack.com/services/T/B/X",
+				discordWebhookUrl: "https://discord.com/api/webhooks/123/abc",
+				emailAddresses: ["admin@example.com"],
+				webhookUrl: "https://example.com/webhook",
+				triggerType: "traffic_spike",
+			});
+			expect(valid.success).toBe(true);
+		});
+
+		it("should accept all trigger types", () => {
+			const triggerTypes = [
+				"uptime",
+				"traffic_spike",
+				"error_rate",
+				"goal",
+				"custom",
+			] as const;
+
+			for (const triggerType of triggerTypes) {
+				const result = createAlarmSchema.safeParse({
+					organizationId: "org-123",
+					name: `${triggerType} alarm`,
+					notificationChannels: ["slack"],
+					triggerType,
+				});
+				expect(result.success).toBe(true);
+			}
+		});
+
+		it("should accept optional websiteId", () => {
+			const valid = createAlarmSchema.safeParse({
+				organizationId: "org-123",
+				websiteId: "site-456",
+				name: "Site Alert",
+				notificationChannels: ["slack"],
+				triggerType: "uptime",
+			});
+			expect(valid.success).toBe(true);
+		});
+	});
+
+	describe("updateAlarmSchema", () => {
+		it("should validate a valid update payload", () => {
+			const valid = updateAlarmSchema.safeParse({
+				id: "alarm-123",
+				name: "Updated Alert Name",
+				enabled: false,
+			});
+			expect(valid.success).toBe(true);
+		});
+
+		it("should require the id field", () => {
+			const invalid = updateAlarmSchema.safeParse({
+				name: "Updated Alert Name",
+			});
+			expect(invalid.success).toBe(false);
+		});
+
+		it("should allow partial updates", () => {
+			const valid = updateAlarmSchema.safeParse({
+				id: "alarm-123",
+				enabled: false,
+			});
+			expect(valid.success).toBe(true);
+		});
+
+		it("should allow setting fields to null", () => {
+			const valid = updateAlarmSchema.safeParse({
+				id: "alarm-123",
+				slackWebhookUrl: null,
+				discordWebhookUrl: null,
+				webhookUrl: null,
+			});
+			expect(valid.success).toBe(true);
+		});
+
+		it("should reject invalid webhook URL on update", () => {
+			const invalid = updateAlarmSchema.safeParse({
+				id: "alarm-123",
+				slackWebhookUrl: "not-a-url",
+			});
+			expect(invalid.success).toBe(false);
+		});
+	});
+});

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -1,0 +1,381 @@
+import { alarms, and, db, eq, member } from "@databuddy/db";
+import {
+	sendDiscordWebhook,
+	sendSlackWebhook,
+	sendWebhook,
+} from "@databuddy/notifications";
+import { logger } from "@databuddy/shared/logger";
+import { ORPCError } from "@orpc/server";
+import { randomUUIDv7 } from "bun";
+import { z } from "zod";
+import { protectedProcedure, requireUserId } from "../orpc";
+import { checkOrgPermission } from "../utils/auth";
+
+const notificationChannelSchema = z.enum([
+	"slack",
+	"discord",
+	"email",
+	"webhook",
+]);
+
+const triggerTypeSchema = z.enum([
+	"uptime",
+	"traffic_spike",
+	"error_rate",
+	"goal",
+	"custom",
+]);
+
+const alarmOutputSchema = z.record(z.string(), z.unknown());
+
+const createAlarmSchema = z.object({
+	organizationId: z.string(),
+	websiteId: z.string().optional(),
+	name: z.string().min(1).max(200),
+	description: z.string().max(1000).optional(),
+	enabled: z.boolean().optional(),
+	notificationChannels: z.array(notificationChannelSchema).min(1),
+	slackWebhookUrl: z.string().url().optional(),
+	discordWebhookUrl: z.string().url().optional(),
+	emailAddresses: z.array(z.string().email()).optional(),
+	webhookUrl: z.string().url().optional(),
+	webhookHeaders: z.record(z.string(), z.string()).optional(),
+	triggerType: triggerTypeSchema,
+	triggerConditions: z.record(z.string(), z.unknown()).optional(),
+});
+
+const updateAlarmSchema = z.object({
+	id: z.string(),
+	name: z.string().min(1).max(200).optional(),
+	description: z.string().max(1000).optional(),
+	enabled: z.boolean().optional(),
+	websiteId: z.string().nullish(),
+	notificationChannels: z.array(notificationChannelSchema).min(1).optional(),
+	slackWebhookUrl: z.string().url().nullish(),
+	discordWebhookUrl: z.string().url().nullish(),
+	emailAddresses: z.array(z.string().email()).nullish(),
+	webhookUrl: z.string().url().nullish(),
+	webhookHeaders: z.record(z.string(), z.string()).nullish(),
+	triggerType: triggerTypeSchema.optional(),
+	triggerConditions: z.record(z.string(), z.unknown()).nullish(),
+});
+
+async function getAlarmAndAuthorize(
+	alarmId: string,
+	context: { headers: Headers }
+) {
+	const alarm = await db.query.alarms.findFirst({
+		where: eq(alarms.id, alarmId),
+	});
+
+	if (!alarm) {
+		throw new ORPCError("NOT_FOUND", { message: "Alarm not found" });
+	}
+
+	if (alarm.organizationId) {
+		await checkOrgPermission(
+			context,
+			alarm.organizationId,
+			"website",
+			"read",
+			"Missing workspace permissions."
+		);
+	}
+
+	return alarm;
+}
+
+export const alarmsRouter = {
+	list: protectedProcedure
+		.route({
+			description:
+				"Returns all alarms for the user or organization.",
+			method: "POST",
+			path: "/alarms/list",
+			summary: "List alarms",
+			tags: ["Alarms"],
+		})
+		.input(
+			z
+				.object({
+					organizationId: z.string().optional(),
+				})
+				.default({})
+		)
+		.output(z.array(alarmOutputSchema))
+		.handler(async ({ context, input }) => {
+			if (input.organizationId) {
+				await checkOrgPermission(
+					context,
+					input.organizationId,
+					"website",
+					"read",
+					"Missing workspace permissions."
+				);
+
+				return await db.query.alarms.findMany({
+					where: eq(alarms.organizationId, input.organizationId),
+					orderBy: (table, { desc }) => [desc(table.createdAt)],
+				});
+			}
+
+			const userId = requireUserId(context);
+			const userMemberships = await db.query.member.findMany({
+				where: eq(member.userId, userId),
+				columns: { organizationId: true },
+			});
+
+			if (userMemberships.length === 0) {
+				return [];
+			}
+
+			const { inArray } = await import("@databuddy/db");
+			const orgIds = userMemberships.map((m) => m.organizationId);
+
+			return await db.query.alarms.findMany({
+				where: inArray(alarms.organizationId, orgIds),
+				orderBy: (table, { desc }) => [desc(table.createdAt)],
+			});
+		}),
+
+	get: protectedProcedure
+		.route({
+			description: "Returns a single alarm by ID.",
+			method: "POST",
+			path: "/alarms/get",
+			summary: "Get alarm",
+			tags: ["Alarms"],
+		})
+		.input(z.object({ id: z.string() }))
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input }) => {
+			const alarm = await getAlarmAndAuthorize(input.id, context);
+			return alarm;
+		}),
+
+	create: protectedProcedure
+		.route({
+			description: "Creates a new alarm with notification channels.",
+			method: "POST",
+			path: "/alarms/create",
+			summary: "Create alarm",
+			tags: ["Alarms"],
+		})
+		.input(createAlarmSchema)
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input }) => {
+			const userId = requireUserId(context);
+
+			await checkOrgPermission(
+				context,
+				input.organizationId,
+				"website",
+				"update",
+				"Missing workspace permissions."
+			);
+
+			const alarmId = randomUUIDv7();
+
+			const [created] = await db
+				.insert(alarms)
+				.values({
+					id: alarmId,
+					userId,
+					organizationId: input.organizationId,
+					websiteId: input.websiteId ?? null,
+					name: input.name,
+					description: input.description ?? null,
+					enabled: input.enabled ?? true,
+					notificationChannels: input.notificationChannels,
+					slackWebhookUrl: input.slackWebhookUrl ?? null,
+					discordWebhookUrl: input.discordWebhookUrl ?? null,
+					emailAddresses: input.emailAddresses ?? null,
+					webhookUrl: input.webhookUrl ?? null,
+					webhookHeaders: input.webhookHeaders ?? null,
+					triggerType: input.triggerType,
+					triggerConditions: input.triggerConditions ?? null,
+				})
+				.returning();
+
+			logger.info({ alarmId, name: input.name }, "Alarm created");
+			return created;
+		}),
+
+	update: protectedProcedure
+		.route({
+			description: "Updates an existing alarm.",
+			method: "POST",
+			path: "/alarms/update",
+			summary: "Update alarm",
+			tags: ["Alarms"],
+		})
+		.input(updateAlarmSchema)
+		.output(alarmOutputSchema)
+		.handler(async ({ context, input }) => {
+			const existing = await getAlarmAndAuthorize(input.id, context);
+
+			if (existing.organizationId) {
+				await checkOrgPermission(
+					context,
+					existing.organizationId,
+					"website",
+					"update",
+					"Missing workspace permissions."
+				);
+			}
+
+			const { id, ...updates } = input;
+
+			const updateData: Record<string, unknown> = {
+				updatedAt: new Date(),
+			};
+
+			if (updates.name !== undefined) updateData.name = updates.name;
+			if (updates.description !== undefined)
+				updateData.description = updates.description;
+			if (updates.enabled !== undefined) updateData.enabled = updates.enabled;
+			if (updates.websiteId !== undefined)
+				updateData.websiteId = updates.websiteId;
+			if (updates.notificationChannels !== undefined)
+				updateData.notificationChannels = updates.notificationChannels;
+			if (updates.slackWebhookUrl !== undefined)
+				updateData.slackWebhookUrl = updates.slackWebhookUrl;
+			if (updates.discordWebhookUrl !== undefined)
+				updateData.discordWebhookUrl = updates.discordWebhookUrl;
+			if (updates.emailAddresses !== undefined)
+				updateData.emailAddresses = updates.emailAddresses;
+			if (updates.webhookUrl !== undefined)
+				updateData.webhookUrl = updates.webhookUrl;
+			if (updates.webhookHeaders !== undefined)
+				updateData.webhookHeaders = updates.webhookHeaders;
+			if (updates.triggerType !== undefined)
+				updateData.triggerType = updates.triggerType;
+			if (updates.triggerConditions !== undefined)
+				updateData.triggerConditions = updates.triggerConditions;
+
+			const [updated] = await db
+				.update(alarms)
+				.set(updateData)
+				.where(eq(alarms.id, id))
+				.returning();
+
+			logger.info({ alarmId: id }, "Alarm updated");
+			return updated;
+		}),
+
+	delete: protectedProcedure
+		.route({
+			description: "Deletes an alarm.",
+			method: "POST",
+			path: "/alarms/delete",
+			summary: "Delete alarm",
+			tags: ["Alarms"],
+		})
+		.input(z.object({ id: z.string() }))
+		.output(z.object({ success: z.literal(true) }))
+		.handler(async ({ context, input }) => {
+			const existing = await getAlarmAndAuthorize(input.id, context);
+
+			if (existing.organizationId) {
+				await checkOrgPermission(
+					context,
+					existing.organizationId,
+					"website",
+					"update",
+					"Missing workspace permissions."
+				);
+			}
+
+			await db.delete(alarms).where(eq(alarms.id, input.id));
+
+			logger.info({ alarmId: input.id }, "Alarm deleted");
+			return { success: true };
+		}),
+
+	test: protectedProcedure
+		.route({
+			description:
+				"Sends a test notification to all configured channels on an alarm.",
+			method: "POST",
+			path: "/alarms/test",
+			summary: "Test alarm",
+			tags: ["Alarms"],
+		})
+		.input(z.object({ id: z.string() }))
+		.output(
+			z.object({
+				success: z.boolean(),
+				results: z.array(
+					z.object({
+						channel: z.string(),
+						success: z.boolean(),
+						error: z.string().optional(),
+					})
+				),
+			})
+		)
+		.handler(async ({ context, input }) => {
+			const alarm = await getAlarmAndAuthorize(input.id, context);
+
+			const channels = alarm.notificationChannels as string[];
+			const results: Array<{
+				channel: string;
+				success: boolean;
+				error?: string;
+			}> = [];
+
+			const testPayload = {
+				title: `Test Alarm: ${alarm.name}`,
+				message:
+					"This is a test notification from Databuddy. Your alarm is configured correctly.",
+				priority: "normal" as const,
+				metadata: {
+					alarmId: alarm.id,
+					alarmName: alarm.name,
+					test: true,
+				},
+			};
+
+			for (const channel of channels) {
+				try {
+					if (channel === "slack" && alarm.slackWebhookUrl) {
+						await sendSlackWebhook(alarm.slackWebhookUrl, testPayload);
+						results.push({ channel: "slack", success: true });
+					} else if (channel === "discord" && alarm.discordWebhookUrl) {
+						await sendDiscordWebhook(
+							alarm.discordWebhookUrl,
+							testPayload
+						);
+						results.push({ channel: "discord", success: true });
+					} else if (channel === "webhook" && alarm.webhookUrl) {
+						await sendWebhook(alarm.webhookUrl, testPayload, {
+							headers: (alarm.webhookHeaders as Record<string, string>) ?? undefined,
+						});
+						results.push({ channel: "webhook", success: true });
+					} else if (channel === "email") {
+						results.push({
+							channel: "email",
+							success: false,
+							error: "Email notifications are not yet configured",
+						});
+					} else {
+						results.push({
+							channel,
+							success: false,
+							error: `Channel ${channel} is not configured`,
+						});
+					}
+				} catch (error) {
+					results.push({
+						channel,
+						success: false,
+						error:
+							error instanceof Error ? error.message : "Unknown error",
+					});
+				}
+			}
+
+			const allSucceeded = results.every((r) => r.success);
+			return { success: allSucceeded, results };
+		}),
+};

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -1,4 +1,4 @@
-import { alarms, and, db, eq, member } from "@databuddy/db";
+import { alarms, db, eq, inArray, member } from "@databuddy/db";
 import {
 	sendDiscordWebhook,
 	sendSlackWebhook,
@@ -8,7 +8,7 @@ import { logger } from "@databuddy/shared/logger";
 import { ORPCError } from "@orpc/server";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
-import { protectedProcedure, requireUserId } from "../orpc";
+import { type Context, protectedProcedure, requireUserId } from "../orpc";
 import { checkOrgPermission } from "../utils/auth";
 
 const notificationChannelSchema = z.enum([
@@ -62,7 +62,7 @@ const updateAlarmSchema = z.object({
 
 async function getAlarmAndAuthorize(
 	alarmId: string,
-	context: { headers: Headers }
+	context: Context
 ) {
 	const alarm = await db.query.alarms.findFirst({
 		where: eq(alarms.id, alarmId),
@@ -80,6 +80,13 @@ async function getAlarmAndAuthorize(
 			"read",
 			"Missing workspace permissions."
 		);
+	} else {
+		const userId = requireUserId(context);
+		if (alarm.userId !== userId) {
+			throw new ORPCError("FORBIDDEN", {
+				message: "You do not have permission to access this alarm.",
+			});
+		}
 	}
 
 	return alarm;
@@ -129,7 +136,6 @@ export const alarmsRouter = {
 				return [];
 			}
 
-			const { inArray } = await import("@databuddy/db");
 			const orgIds = userMemberships.map((m) => m.organizationId);
 
 			return await db.query.alarms.findMany({
@@ -226,7 +232,21 @@ export const alarmsRouter = {
 
 			const { id, ...updates } = input;
 
-			const updateData: Record<string, unknown> = {
+			const updateData: Partial<{
+				updatedAt: Date;
+				name: string;
+				description: string | null;
+				enabled: boolean;
+				websiteId: string | null;
+				notificationChannels: string[];
+				slackWebhookUrl: string | null;
+				discordWebhookUrl: string | null;
+				emailAddresses: string[] | null;
+				webhookUrl: string | null;
+				webhookHeaders: Record<string, string> | null;
+				triggerType: string;
+				triggerConditions: Record<string, unknown> | null;
+			}> = {
 				updatedAt: new Date(),
 			};
 


### PR DESCRIPTION
## Summary

Complete implementation of the alarms system as described in #267:

- **Database Schema**: Added `alarms` table to `packages/db/src/drizzle/schema.ts` with all required fields (name, description, enabled, notification channels, webhook URLs, email addresses, trigger type/conditions). Indexes on `user_id`, `organization_id`, `website_id`, and `enabled`. Relations defined in `relations.ts`.
- **API Endpoints**: Created `packages/rpc/src/routers/alarms.ts` with full CRUD operations (`alarms.list`, `alarms.get`, `alarms.create`, `alarms.update`, `alarms.delete`, `alarms.test`). All endpoints use Zod validation, proper authorization via `checkOrgPermission`, and the `@databuddy/notifications` package for test notifications.
- **Dashboard UI**: Replaced the "Coming Soon" placeholder at `apps/dashboard/app/(main)/settings/notifications/page.tsx` with a functional alarm management page. Includes alarm list with enable/disable toggles, test notification button, create/edit dialog with channel configuration, and delete confirmation.
- **Tests**: Validation schema tests in `packages/rpc/src/routers/alarms.test.ts` covering create/update validation, invalid inputs, and edge cases.

## Technical Choices

- Used `Option A` (simple text fields) for notification channels rather than a separate table, matching existing patterns in the codebase
- Trigger conditions stored as JSONB for flexibility across different trigger types
- Used existing `checkOrgPermission` and `requireUserId` helpers for authorization
- UI uses Phosphor icons (duotone weight), Sonner toasts, Tanstack Query, and Jotai for org state — matching existing codebase conventions
- All class names use `rounded` (not `rounded-xl`/`rounded-md`)

## AI Disclosure

This PR was created with AI assistance (Claude Code). All code has been reviewed and verified.

Closes #267