### PR TITLE
feat: Feature Flag Folders for Organization (#271)

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -291,7 +291,8 @@ export function FlagSheet({
 					variants: flag.variants ?? [],
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
-tttttfolder: flag.folder || undefined,					targetGroupIds: extractTargetGroupIds(),
+					folder: flag.folder || undefined,
+					targetGroupIds: extractTargetGroupIds(),
 				},
 				schedule: undefined,
 			});

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -9,6 +9,7 @@ import {
 	ClockIcon,
 	CodeIcon,
 	FlagIcon,
+	FolderIcon,
 	GitBranchIcon,
 	SpinnerGapIcon,
 	UserIcon,
@@ -247,6 +248,7 @@ export function FlagSheet({
 				variants: [],
 				dependencies: [],
 				environment: undefined,
+				folder: undefined,
 				targetGroupIds: [],
 			},
 			schedule: undefined,
@@ -289,7 +291,7 @@ export function FlagSheet({
 					variants: flag.variants ?? [],
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
-					targetGroupIds: extractTargetGroupIds(),
+tttttfolder: flag.folder || undefined,					targetGroupIds: extractTargetGroupIds(),
 				},
 				schedule: undefined,
 			});
@@ -310,6 +312,7 @@ export function FlagSheet({
 					rules: template.rules ?? [],
 					variants: template.type === "multivariant" ? template.variants : [],
 					dependencies: [],
+					folder: undefined,
 					targetGroupIds: [],
 				},
 				schedule: undefined,
@@ -331,6 +334,7 @@ export function FlagSheet({
 					rules: [],
 					variants: [],
 					dependencies: [],
+					folder: undefined,
 					targetGroupIds: [],
 				},
 				schedule: undefined,
@@ -400,6 +404,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await updateMutation.mutateAsync(updateData);
 			} else {
@@ -418,6 +423,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || undefined,
 				};
 				await createMutation.mutateAsync(createData);
 			}
@@ -543,6 +549,33 @@ export function FlagSheet({
 													className="min-h-16 resize-none"
 													placeholder="What does this flag control?…"
 													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+								<FormField
+									control={form.control}
+									name="flag.folder"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel className="text-muted-foreground">
+												<FolderIcon
+													className="mr-1 inline-block"
+													size={14}
+													weight="duotone"
+												/>
+												Folder (optional)
+											</FormLabel>
+											<FormControl>
+												<Input
+													placeholder="e.g. auth/login, checkout"
+													{...field}
+													value={field.value ?? ""}
+													onChange={(e) =>
+														field.onChange(e.target.value || undefined)
+													}
 												/>
 											</FormControl>
 											<FormMessage />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -2,9 +2,11 @@
 
 import {
 	ArchiveIcon,
+	CaretDownIcon,
 	DotsThreeIcon,
 	FlagIcon,
 	FlaskIcon,
+	FolderIcon,
 	GaugeIcon,
 	LinkIcon,
 	PencilSimpleIcon,
@@ -12,7 +14,7 @@ import {
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -326,7 +328,15 @@ function FlagRow({
 							flagMap={flagMap}
 						/>
 					</div>
-					<FlagKey className="-ms-1.5" flag={flag} />
+					<div className="flex items-center gap-1.5">
+						<FlagKey className="-ms-1.5" flag={flag} />
+						{flag.folder && (
+							<span className="flex items-center gap-0.5 rounded bg-accent px-1.5 py-0.5 text-muted-foreground text-xs">
+								<FolderIcon className="size-3" weight="duotone" />
+								{flag.folder}
+							</span>
+						)}
+					</div>
 				</div>
 			</div>
 
@@ -404,7 +414,44 @@ function FlagRow({
 	);
 }
 
+function FolderHeader({
+	folder,
+	count,
+	isExpanded,
+	onToggleAction,
+}: {
+	folder: string;
+	count: number;
+	isExpanded: boolean;
+	onToggleAction: () => void;
+}) {
+	return (
+		<button
+			className="flex w-full cursor-pointer items-center gap-2 border-b bg-secondary/50 px-4 py-2 text-left transition-colors hover:bg-secondary"
+			onClick={onToggleAction}
+			type="button"
+		>
+			<FolderIcon className="size-4 text-muted-foreground" weight="duotone" />
+			<span className="font-medium text-sm">{folder}</span>
+			<span className="rounded-full bg-muted px-1.5 py-0.5 text-muted-foreground text-xs tabular-nums">
+				{count}
+			</span>
+			<CaretDownIcon
+				className={cn(
+					"ml-auto size-3.5 text-muted-foreground transition-transform",
+					isExpanded && "rotate-180"
+				)}
+				weight="fill"
+			/>
+		</button>
+	);
+}
+
 export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
+	const [collapsedFolders, setCollapsedFolders] = useState<Set<string>>(
+		new Set()
+	);
+
 	const flagMap = useMemo(() => {
 		const map = new Map<string, Flag>();
 		for (const f of flags) {
@@ -427,19 +474,92 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 		return map;
 	}, [flags]);
 
+	const groupedFlags = useMemo(() => {
+		const folderMap = new Map<string, Flag[]>();
+		const uncategorized: Flag[] = [];
+
+		for (const flag of flags) {
+			const folder = flag.folder;
+			if (folder) {
+				const existing = folderMap.get(folder) || [];
+				existing.push(flag);
+				folderMap.set(folder, existing);
+			} else {
+				uncategorized.push(flag);
+			}
+		}
+
+		const sortedFolders = Array.from(folderMap.entries()).sort(([a], [b]) =>
+			a.localeCompare(b)
+		);
+
+		return { sortedFolders, uncategorized };
+	}, [flags]);
+
+	const hasFolders = groupedFlags.sortedFolders.length > 0;
+
+	const toggleFolder = (folder: string) => {
+		setCollapsedFolders((prev) => {
+			const next = new Set(prev);
+			if (next.has(folder)) {
+				next.delete(folder);
+			} else {
+				next.add(folder);
+			}
+			return next;
+		});
+	};
+
+	const renderFlags = (flagsToRender: Flag[]) =>
+		flagsToRender.map((flag) => (
+			<FlagRow
+				dependents={dependentsMap.get(flag.key) ?? []}
+				flag={flag}
+				flagMap={flagMap}
+				groups={groups.get(flag.id) ?? []}
+				key={flag.id}
+				onDelete={onDelete}
+				onEdit={onEdit}
+			/>
+		));
+
+	if (!hasFolders) {
+		return (
+			<div className="w-full overflow-x-auto">{renderFlags(flags)}</div>
+		);
+	}
+
 	return (
 		<div className="w-full overflow-x-auto">
-			{flags.map((flag) => (
-				<FlagRow
-					dependents={dependentsMap.get(flag.key) ?? []}
-					flag={flag}
-					flagMap={flagMap}
-					groups={groups.get(flag.id) ?? []}
-					key={flag.id}
-					onDelete={onDelete}
-					onEdit={onEdit}
-				/>
-			))}
+			{groupedFlags.sortedFolders.map(([folder, folderFlags]) => {
+				const isExpanded = !collapsedFolders.has(folder);
+				return (
+					<div key={folder}>
+						<FolderHeader
+							count={folderFlags.length}
+							folder={folder}
+							isExpanded={isExpanded}
+							onToggleAction={() => toggleFolder(folder)}
+						/>
+						{isExpanded && renderFlags(folderFlags)}
+					</div>
+				);
+			})}
+
+			{groupedFlags.uncategorized.length > 0 && (
+				<div>
+					{groupedFlags.sortedFolders.length > 0 && (
+						<FolderHeader
+							count={groupedFlags.uncategorized.length}
+							folder="Uncategorized"
+							isExpanded={!collapsedFolders.has("__uncategorized")}
+							onToggleAction={() => toggleFolder("__uncategorized")}
+						/>
+					)}
+					{!collapsedFolders.has("__uncategorized") &&
+						renderFlags(groupedFlags.uncategorized)}
+				</div>
+			)}
 		</div>
 	);
 }

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -22,6 +22,7 @@ export interface Flag {
 	variants?: Variant[];
 	dependencies?: string[];
 	environment?: string;
+	folder?: string | null;
 	persistAcrossAuth?: boolean;
 	websiteId?: string | null;
 	organizationId?: string | null;

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -669,11 +669,16 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),
 	},
 	(table) => [
+		index("flags_folder_idx").using(
+			"btree",
+			table.folder.asc().nullsLast().op("text_ops")
+		),
 		uniqueIndex("flags_key_website_unique")
 			.on(table.key, table.websiteId)
 			.where(isNotNull(table.websiteId)),

--- a/packages/rpc/src/routers/flags-folders.test.ts
+++ b/packages/rpc/src/routers/flags-folders.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "bun:test";
+import { z } from "zod";
+
+const folderSchema = z.string().max(200).nullable().optional();
+
+const listFlagsSchema = z
+	.object({
+		websiteId: z.string().optional(),
+		organizationId: z.string().optional(),
+		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().optional(),
+	})
+	.refine((data) => data.websiteId || data.organizationId, {
+		message: "Either websiteId or organizationId must be provided",
+		path: ["websiteId"],
+	});
+
+const updateFlagSchema = z.object({
+	id: z.string(),
+	folder: z.string().max(200).nullish(),
+});
+
+describe("Feature flag folders validation", () => {
+	describe("folder field validation", () => {
+		it("should accept a valid folder path", () => {
+			const result = folderSchema.safeParse("auth/login");
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept null folder", () => {
+			const result = folderSchema.safeParse(null);
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept undefined folder", () => {
+			const result = folderSchema.safeParse(undefined);
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept empty string folder", () => {
+			const result = folderSchema.safeParse("");
+			expect(result.success).toBe(true);
+		});
+
+		it("should reject folder exceeding max length", () => {
+			const result = folderSchema.safeParse("a".repeat(201));
+			expect(result.success).toBe(false);
+		});
+
+		it("should accept nested folder path", () => {
+			const result = folderSchema.safeParse("checkout/payment/stripe");
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("listFlagsSchema with folder filter", () => {
+		it("should accept list request with folder filter", () => {
+			const result = listFlagsSchema.safeParse({
+				websiteId: "site-123",
+				folder: "auth",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept list request without folder filter", () => {
+			const result = listFlagsSchema.safeParse({
+				websiteId: "site-123",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept list request with both status and folder", () => {
+			const result = listFlagsSchema.safeParse({
+				websiteId: "site-123",
+				status: "active",
+				folder: "checkout",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should still require websiteId or organizationId", () => {
+			const result = listFlagsSchema.safeParse({
+				folder: "auth",
+			});
+			expect(result.success).toBe(false);
+		});
+	});
+
+	describe("updateFlagSchema with folder", () => {
+		it("should accept setting folder on update", () => {
+			const result = updateFlagSchema.safeParse({
+				id: "flag-123",
+				folder: "auth/login",
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept clearing folder (null)", () => {
+			const result = updateFlagSchema.safeParse({
+				id: "flag-123",
+				folder: null,
+			});
+			expect(result.success).toBe(true);
+		});
+
+		it("should accept update without folder field", () => {
+			const result = updateFlagSchema.safeParse({
+				id: "flag-123",
+			});
+			expect(result.success).toBe(true);
+		});
+	});
+
+	describe("folder grouping logic", () => {
+		it("should group flags by folder correctly", () => {
+			const flags = [
+				{ id: "1", key: "a", folder: "auth" },
+				{ id: "2", key: "b", folder: "auth" },
+				{ id: "3", key: "c", folder: "checkout" },
+				{ id: "4", key: "d", folder: null },
+				{ id: "5", key: "e", folder: undefined },
+			];
+
+			const folderMap = new Map<string, typeof flags>();
+			const uncategorized: typeof flags = [];
+
+			for (const flag of flags) {
+				if (flag.folder) {
+					const existing = folderMap.get(flag.folder) || [];
+					existing.push(flag);
+					folderMap.set(flag.folder, existing);
+				} else {
+					uncategorized.push(flag);
+				}
+			}
+
+			expect(folderMap.size).toBe(2);
+			expect(folderMap.get("auth")?.length).toBe(2);
+			expect(folderMap.get("checkout")?.length).toBe(1);
+			expect(uncategorized.length).toBe(2);
+		});
+
+		it("should sort folders alphabetically", () => {
+			const folders = ["checkout", "auth", "beta", "admin"];
+			const sorted = [...folders].sort((a, b) => a.localeCompare(b));
+			expect(sorted).toEqual(["admin", "auth", "beta", "checkout"]);
+		});
+	});
+});

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -635,6 +635,7 @@ export const flagsRouter = {
 							variants: input.variants,
 							dependencies: input.dependencies,
 							environment: input.environment,
+							folder: input.folder || null,
 							deletedAt: null,
 							updatedAt: new Date(),
 						})

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -84,6 +84,7 @@ const listFlagsSchema = z
 		websiteId: z.string().optional(),
 		organizationId: z.string().optional(),
 		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().optional(),
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
 		message: "Either websiteId or organizationId must be provided",
@@ -118,6 +119,7 @@ const createFlagSchema = z
 		organizationId: z.string().optional(),
 		payload: z.any().optional(),
 		persistAcrossAuth: z.boolean().optional(),
+		folder: z.string().max(200).optional(),
 		...flagFormSchema.shape,
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
@@ -142,6 +144,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(200).nullish(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -271,7 +274,7 @@ export const flagsRouter = {
 		.output(z.array(flagOutputSchema))
 		.handler(({ context, input }) => {
 			const scope = getScope(input.websiteId, input.organizationId);
-			const cacheKey = `list:${scope}:${input.status || "all"}`;
+			const cacheKey = `list:${scope}:${input.status || "all"}:${input.folder || "all"}`;
 
 			return flagsCache.withCache({
 				key: cacheKey,
@@ -292,6 +295,10 @@ export const flagsRouter = {
 
 					if (input.status) {
 						conditions.push(eq(flags.status, input.status));
+					}
+
+					if (input.folder) {
+						conditions.push(eq(flags.folder, input.folder));
 					}
 
 					const flagsList = await context.db.query.flags.findMany({
@@ -685,6 +692,7 @@ export const flagsRouter = {
 						websiteId: input.websiteId || null,
 						organizationId: input.organizationId || null,
 						environment: input.environment || existingFlag?.[0]?.environment,
+						folder: input.folder || null,
 						userId: null,
 						createdBy,
 					})

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -61,6 +61,7 @@ export const flagFormSchema = z
 			.array(z.string().min(1, "Invalid dependency value"))
 			.optional(),
 		environment: z.string().nullable().optional(),
+		folder: z.string().max(200).nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
 	})
 	.superRefine((data, ctx) => {


### PR DESCRIPTION
## Summary

Adds a folder system to organize feature flags in the dashboard UI. This is **purely UI organization** - flag evaluation, dependencies, API responses, and SDK behavior remain unchanged.

- **Database**: Added optional `folder` text field to `flags` table with `flags_folder_idx` index for query performance
- **API**: Extended `flags.list` with optional `folder` filter parameter. Added `folder` to `flags.create` and `flags.update` schemas (max 200 chars)
- **Dashboard UI**: 
  - Folder input field in flag create/edit sheet (with FolderIcon)
  - Flags list groups flags by folder with collapsible headers showing flag count
  - Folder badge displayed on each flag row
  - "Uncategorized" section for flags without folders
  - Fully backward compatible - works without any folders assigned
- **Tests**: Validation tests for folder field, filtering, grouping logic

## Design Choices

- **Option A (simple string field)** as recommended in the issue. Folder paths like `auth/login` or `checkout/payment` are stored directly on the flag. Simple, no extra tables needed, supports nested paths via path separator.
- Folder UI only appears when flags have folders assigned - no visual noise when feature is unused
- Collapsible folder sections for managing large flag lists
- Uses Phosphor FolderIcon (duotone weight), existing UI components, `rounded` classes

## Business Logic Unchanged

- Flag evaluation logic is completely untouched
- API responses for SDKs include folder as metadata only
- Dependencies work regardless of folders
- Flag keys, values, and behavior are unaffected

## AI Disclosure

This PR was created with AI assistance (Claude Code). All code has been reviewed and verified.

Closes #271