### PR TITLE
feat: Add folder system for feature flag organization

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -9,11 +9,13 @@ import {
 	ClockIcon,
 	CodeIcon,
 	FlagIcon,
+	FolderIcon,
 	GitBranchIcon,
 	SpinnerGapIcon,
 	UserIcon,
 	UsersIcon,
 	UsersThreeIcon,
+	XIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "framer-motion";
@@ -26,6 +28,14 @@ import {
 } from "@/components/ai-elements/code-block";
 import { Button } from "@/components/ui/button";
 import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+} from "@/components/ui/command";
+import {
 	Form,
 	FormControl,
 	FormField,
@@ -35,6 +45,11 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { LineSlider } from "@/components/ui/line-slider";
+import {
+	Popover,
+	PopoverContent,
+	PopoverTrigger,
+} from "@/components/ui/popover";
 import {
 	Sheet,
 	SheetBody,
@@ -206,6 +221,128 @@ function MyComponent() {
 	);
 }
 
+function FolderCombobox({
+	value,
+	onChange,
+	existingFolders,
+}: {
+	value?: string | null;
+	onChange: (folder: string | null) => void;
+	existingFolders: string[];
+}) {
+	const [open, setOpen] = useState(false);
+	const [inputValue, setInputValue] = useState(value ?? "");
+
+	// Sync input when value changes externally
+	useEffect(() => {
+		setInputValue(value ?? "");
+	}, [value]);
+
+	const filtered = existingFolders.filter(
+		(f) =>
+			f.toLowerCase().includes(inputValue.toLowerCase()) && f !== inputValue
+	);
+
+	const handleSelect = (folder: string) => {
+		onChange(folder);
+		setInputValue(folder);
+		setOpen(false);
+	};
+
+	const handleInputChange = (val: string) => {
+		setInputValue(val);
+		onChange(val || null);
+	};
+
+	const handleClear = () => {
+		setInputValue("");
+		onChange(null);
+	};
+
+	return (
+		<Popover onOpenChange={setOpen} open={open}>
+			<div className="flex items-center gap-1">
+				<PopoverTrigger asChild>
+					<button
+						className={cn(
+							"flex h-9 flex-1 items-center gap-2 rounded border border-input bg-background px-3 py-2 text-left text-sm ring-offset-background transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+							!value && "text-muted-foreground"
+						)}
+						onClick={() => setOpen(true)}
+						type="button"
+					>
+						<FolderIcon className="size-4 shrink-0 text-muted-foreground" weight="duotone" />
+						<span className="flex-1 truncate">{value || "No folder"}</span>
+					</button>
+				</PopoverTrigger>
+				{value && (
+					<button
+						aria-label="Clear folder"
+						className="flex size-9 shrink-0 items-center justify-center rounded border border-input bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+						onClick={handleClear}
+						type="button"
+					>
+						<XIcon className="size-3.5" />
+					</button>
+				)}
+			</div>
+			<PopoverContent
+				align="start"
+				className="w-64 p-0"
+				onOpenAutoFocus={(e) => e.preventDefault()}
+			>
+				<Command shouldFilter={false}>
+					<CommandInput
+						onValueChange={handleInputChange}
+						placeholder="Type folder name…"
+						value={inputValue}
+					/>
+					<CommandList>
+						{filtered.length === 0 && inputValue.trim() === "" ? (
+							<CommandEmpty>
+								{existingFolders.length === 0
+									? "No folders yet. Type to create one."
+									: "Type to search or create a folder."}
+							</CommandEmpty>
+						) : (
+							<>
+								{inputValue.trim() !== "" && !existingFolders.includes(inputValue.trim()) && (
+									<CommandGroup heading="Create new">
+										<CommandItem
+											onSelect={() => handleSelect(inputValue.trim())}
+											value={`__create__${inputValue.trim()}`}
+										>
+											<FolderIcon className="mr-2 size-4" weight="duotone" />
+											<span className="font-medium">{inputValue.trim()}</span>
+											<span className="ml-1 text-muted-foreground text-xs">
+												(new folder)
+											</span>
+										</CommandItem>
+									</CommandGroup>
+								)}
+								{filtered.length > 0 && (
+									<CommandGroup heading="Existing folders">
+										{filtered.map((folder) => (
+											<CommandItem
+												key={folder}
+												onSelect={() => handleSelect(folder)}
+												value={folder}
+											>
+												<FolderIcon className="mr-2 size-4" weight="duotone" />
+												{folder}
+											</CommandItem>
+										))}
+									</CommandGroup>
+								)}
+							</>
+						)}
+					</CommandList>
+				</Command>
+			</PopoverContent>
+		</Popover>
+	);
+}
+
 export function FlagSheet({
 	isOpen,
 	onCloseAction,
@@ -248,6 +385,7 @@ export function FlagSheet({
 				dependencies: [],
 				environment: undefined,
 				targetGroupIds: [],
+				folder: undefined,
 			},
 			schedule: undefined,
 		},
@@ -290,6 +428,7 @@ export function FlagSheet({
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
 					targetGroupIds: extractTargetGroupIds(),
+					folder: flag.folder ?? undefined,
 				},
 				schedule: undefined,
 			});
@@ -311,6 +450,7 @@ export function FlagSheet({
 					variants: template.type === "multivariant" ? template.variants : [],
 					dependencies: [],
 					targetGroupIds: [],
+					folder: undefined,
 				},
 				schedule: undefined,
 			});
@@ -332,6 +472,7 @@ export function FlagSheet({
 					variants: [],
 					dependencies: [],
 					targetGroupIds: [],
+					folder: undefined,
 				},
 				schedule: undefined,
 			});
@@ -400,6 +541,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await updateMutation.mutateAsync(updateData);
 			} else {
@@ -418,6 +560,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await createMutation.mutateAsync(createData);
 			}
@@ -437,6 +580,16 @@ export function FlagSheet({
 	const isLoading = createMutation.isPending || updateMutation.isPending;
 	const isRollout = watchedType === "rollout";
 	const isMultivariant = watchedType === "multivariant";
+
+	const existingFolders = useMemo(() => {
+		const folders = new Set<string>();
+		for (const f of flagsList ?? []) {
+			if (f.folder && typeof f.folder === "string") {
+				folders.add(f.folder);
+			}
+		}
+		return Array.from(folders).sort();
+	}, [flagsList]);
 
 	return (
 		<Sheet onOpenChange={handleOpenChange} open={isOpen}>
@@ -543,6 +696,26 @@ export function FlagSheet({
 													className="min-h-16 resize-none"
 													placeholder="What does this flag control?…"
 													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="flag.folder"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel className="text-muted-foreground">
+												Folder (optional)
+											</FormLabel>
+											<FormControl>
+												<FolderCombobox
+													existingFolders={existingFolders}
+													onChange={(val) => field.onChange(val ?? undefined)}
+													value={field.value ?? null}
 												/>
 											</FormControl>
 											<FormMessage />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -268,7 +268,6 @@ function FolderCombobox({
 							"flex h-9 flex-1 items-center gap-2 rounded border border-input bg-background px-3 py-2 text-left text-sm ring-offset-background transition-colors hover:bg-accent/50 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
 							!value && "text-muted-foreground"
 						)}
-						onClick={() => setOpen(true)}
 						type="button"
 					>
 						<FolderIcon className="size-4 shrink-0 text-muted-foreground" weight="duotone" />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -2,9 +2,11 @@
 
 import {
 	ArchiveIcon,
+	CaretDownIcon,
 	DotsThreeIcon,
 	FlagIcon,
 	FlaskIcon,
+	FolderIcon,
 	GaugeIcon,
 	LinkIcon,
 	PencilSimpleIcon,
@@ -12,7 +14,7 @@ import {
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -41,6 +43,7 @@ interface FlagsListProps {
 	groups: Map<string, TargetGroup[]>;
 	onEdit: (flag: Flag) => void;
 	onDelete: (flagId: string) => void;
+	groupByFolder?: boolean;
 }
 
 const TYPE_CONFIG = {
@@ -404,7 +407,73 @@ function FlagRow({
 	);
 }
 
-export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
+function FolderSection({
+	folderName,
+	flags,
+	groups,
+	dependentsMap,
+	flagMap,
+	onEdit,
+	onDelete,
+}: {
+	folderName: string | null;
+	flags: Flag[];
+	groups: Map<string, TargetGroup[]>;
+	dependentsMap: Map<string, Flag[]>;
+	flagMap: Map<string, Flag>;
+	onEdit: (flag: Flag) => void;
+	onDelete: (flagId: string) => void;
+}) {
+	const [isCollapsed, setIsCollapsed] = useState(false);
+	const label = folderName ?? "Uncategorized";
+
+	return (
+		<div>
+			<button
+				className="flex w-full items-center gap-2 border-b bg-accent/30 px-4 py-2 text-left text-muted-foreground text-xs transition-colors hover:bg-accent/50"
+				onClick={() => setIsCollapsed((c) => !c)}
+				type="button"
+			>
+				{folderName ? (
+					<FolderIcon className="size-3.5 shrink-0" weight="duotone" />
+				) : (
+					<FolderIcon className="size-3.5 shrink-0 opacity-40" weight="duotone" />
+				)}
+				<span className="font-medium">{label}</span>
+				<span className="ml-1 text-muted-foreground/60">
+					{flags.length} {flags.length !== 1 ? "flags" : "flag"}
+				</span>
+				<CaretDownIcon
+					className={cn(
+						"ml-auto size-3.5 transition-transform duration-200",
+						isCollapsed && "-rotate-90"
+					)}
+					weight="fill"
+				/>
+			</button>
+			{!isCollapsed &&
+				flags.map((flag) => (
+					<FlagRow
+						dependents={dependentsMap.get(flag.key) ?? []}
+						flag={flag}
+						flagMap={flagMap}
+						groups={groups.get(flag.id) ?? []}
+						key={flag.id}
+						onDelete={onDelete}
+						onEdit={onEdit}
+					/>
+				))}
+		</div>
+	);
+}
+
+export function FlagsList({
+	flags,
+	groups,
+	onEdit,
+	onDelete,
+	groupByFolder = false,
+}: FlagsListProps) {
 	const flagMap = useMemo(() => {
 		const map = new Map<string, Flag>();
 		for (const f of flags) {
@@ -426,6 +495,42 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 		}
 		return map;
 	}, [flags]);
+
+	if (groupByFolder) {
+		// Group flags by folder
+		const folderMap = new Map<string | null, Flag[]>();
+		for (const flag of flags) {
+			const key = flag.folder ?? null;
+			const existing = folderMap.get(key) ?? [];
+			existing.push(flag);
+			folderMap.set(key, existing);
+		}
+
+		// Sort: named folders first (alphabetically), then null (uncategorized)
+		const sortedFolders: Array<string | null> = [
+			...Array.from(folderMap.keys())
+				.filter((k): k is string => k !== null)
+				.sort(),
+			...(folderMap.has(null) ? [null] : []),
+		];
+
+		return (
+			<div className="w-full overflow-x-auto">
+				{sortedFolders.map((folder) => (
+					<FolderSection
+						dependentsMap={dependentsMap}
+						flagMap={flagMap}
+						flags={folderMap.get(folder) ?? []}
+						folderName={folder}
+						groups={groups}
+						key={folder ?? "__uncategorized__"}
+						onDelete={onDelete}
+						onEdit={onEdit}
+					/>
+				))}
+			</div>
+		);
+	}
 
 	return (
 		<div className="w-full overflow-x-auto">

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/folder-sidebar.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/folder-sidebar.tsx
@@ -226,37 +226,53 @@ function FolderRow({
 	const isRenaming = updateMutation.isPending;
 
 	const handleRename = async (newName: string) => {
-		try {
-			await Promise.all(
-				flagsInFolder.map((flag) =>
-					updateMutation.mutateAsync({ id: flag.id, folder: newName })
-				)
-			);
-			queryClient.invalidateQueries({
-				queryKey: orpc.flags.list.key({ input: { websiteId } }),
-			});
+		const results = await Promise.allSettled(
+			flagsInFolder.map((flag) =>
+				updateMutation.mutateAsync({ id: flag.id, folder: newName })
+			)
+		);
+		const failed = results.filter((r) => r.status === "rejected").length;
+		const succeeded = results.length - failed;
+		queryClient.invalidateQueries({
+			queryKey: orpc.flags.list.key({ input: { websiteId } }),
+		});
+		if (failed === 0) {
 			toast.success(`Folder renamed to "${newName}"`);
 			onRenamedAction(name, newName);
 			setShowRename(false);
-		} catch {
+		} else if (succeeded > 0) {
+			toast.error(
+				`Partially renamed: ${succeeded} flag(s) updated, ${failed} failed`
+			);
+			onRenamedAction(name, newName);
+			setShowRename(false);
+		} else {
 			toast.error("Failed to rename folder");
 		}
 	};
 
 	const handleDelete = async () => {
-		try {
-			await Promise.all(
-				flagsInFolder.map((flag) =>
-					updateMutation.mutateAsync({ id: flag.id, folder: null })
-				)
-			);
-			queryClient.invalidateQueries({
-				queryKey: orpc.flags.list.key({ input: { websiteId } }),
-			});
+		const results = await Promise.allSettled(
+			flagsInFolder.map((flag) =>
+				updateMutation.mutateAsync({ id: flag.id, folder: null })
+			)
+		);
+		const failed = results.filter((r) => r.status === "rejected").length;
+		const succeeded = results.length - failed;
+		queryClient.invalidateQueries({
+			queryKey: orpc.flags.list.key({ input: { websiteId } }),
+		});
+		if (failed === 0) {
 			toast.success(`Folder "${name}" deleted`);
 			onDeletedAction(name);
 			setShowDelete(false);
-		} catch {
+		} else if (succeeded > 0) {
+			toast.error(
+				`Partially deleted: ${succeeded} flag(s) removed from folder, ${failed} failed`
+			);
+			onDeletedAction(name);
+			setShowDelete(false);
+		} else {
 			toast.error("Failed to delete folder");
 		}
 	};

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/folder-sidebar.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/folder-sidebar.tsx
@@ -1,0 +1,489 @@
+"use client";
+
+import {
+	DotsThreeIcon,
+	FolderIcon,
+	FolderOpenIcon,
+	FolderPlusIcon,
+	FlagIcon,
+	PencilSimpleIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { DeleteDialog } from "@/components/ui/delete-dialog";
+import {
+	Dialog,
+	DialogContent,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from "@/components/ui/dialog";
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { orpc } from "@/lib/orpc";
+import { cn } from "@/lib/utils";
+import type { Flag } from "./types";
+
+export type FolderSelection = "all" | "uncategorized" | string;
+
+interface FolderSidebarProps {
+	flags: Flag[];
+	websiteId: string;
+	selectedFolder: FolderSelection;
+	onSelectFolder: (folder: FolderSelection) => void;
+}
+
+function CreateFolderDialog({
+	isOpen,
+	onClose,
+	existingFolders,
+	onCreateAction,
+}: {
+	isOpen: boolean;
+	onClose: () => void;
+	existingFolders: string[];
+	onCreateAction: (name: string) => void;
+}) {
+	const [name, setName] = useState("");
+	const trimmed = name.trim();
+	const isValid = trimmed.length > 0 && trimmed.length <= 100;
+	const isDuplicate = existingFolders.includes(trimmed);
+
+	const handleCreate = () => {
+		if (!isValid || isDuplicate) return;
+		onCreateAction(trimmed);
+		setName("");
+		onClose();
+	};
+
+	const handleOpenChange = (open: boolean) => {
+		if (!open) {
+			setName("");
+			onClose();
+		}
+	};
+
+	return (
+		<Dialog onOpenChange={handleOpenChange} open={isOpen}>
+			<DialogContent className="sm:max-w-sm">
+				<DialogHeader>
+					<DialogTitle>Create Folder</DialogTitle>
+				</DialogHeader>
+				<div className="space-y-2 py-2">
+					<Input
+						autoFocus
+						maxLength={100}
+						onChange={(e) => setName(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleCreate();
+						}}
+						placeholder="Folder name…"
+						value={name}
+					/>
+					{isDuplicate && (
+						<p className="text-destructive text-xs">
+							A folder with this name already exists.
+						</p>
+					)}
+				</div>
+				<DialogFooter>
+					<Button onClick={onClose} type="button" variant="ghost">
+						Cancel
+					</Button>
+					<Button
+						disabled={!isValid || isDuplicate}
+						onClick={handleCreate}
+						type="button"
+					>
+						Create
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+function RenameFolderDialog({
+	isOpen,
+	onClose,
+	currentName,
+	existingFolders,
+	flagsInFolder: flagsInFolderCount,
+	onRenameAction,
+	isRenaming,
+}: {
+	isOpen: boolean;
+	onClose: () => void;
+	currentName: string;
+	existingFolders: string[];
+	flagsInFolder: number;
+	onRenameAction: (newName: string) => void;
+	isRenaming: boolean;
+}) {
+	const [name, setName] = useState(currentName);
+	const trimmed = name.trim();
+	const isChanged = trimmed !== currentName;
+	const isValid = trimmed.length > 0 && trimmed.length <= 100;
+	const isDuplicate = isChanged && existingFolders.includes(trimmed);
+
+	const handleRename = () => {
+		if (!isChanged || !isValid || isDuplicate) return;
+		onRenameAction(trimmed);
+	};
+
+	const handleOpenChange = (open: boolean) => {
+		if (!open) {
+			setName(currentName);
+			onClose();
+		}
+	};
+
+	return (
+		<Dialog onOpenChange={handleOpenChange} open={isOpen}>
+			<DialogContent className="sm:max-w-sm">
+				<DialogHeader>
+					<DialogTitle>Rename Folder</DialogTitle>
+				</DialogHeader>
+				<div className="space-y-2 py-2">
+					<Input
+						autoFocus
+						maxLength={100}
+						onChange={(e) => setName(e.target.value)}
+						onKeyDown={(e) => {
+							if (e.key === "Enter") handleRename();
+						}}
+						value={name}
+					/>
+					{isDuplicate && (
+						<p className="text-destructive text-xs">
+							A folder with this name already exists.
+						</p>
+					)}
+					{flagsInFolderCount > 0 && (
+						<p className="text-muted-foreground text-xs">
+							This will update {flagsInFolderCount} flag
+							{flagsInFolderCount !== 1 ? "s" : ""}.
+						</p>
+					)}
+				</div>
+				<DialogFooter>
+					<Button onClick={onClose} type="button" variant="ghost">
+						Cancel
+					</Button>
+					<Button
+						disabled={!isChanged || !isValid || isDuplicate || isRenaming}
+						onClick={handleRename}
+						type="button"
+					>
+						{isRenaming ? "Renaming…" : "Rename"}
+					</Button>
+				</DialogFooter>
+			</DialogContent>
+		</Dialog>
+	);
+}
+
+interface FolderRowProps {
+	name: string;
+	count: number;
+	isSelected: boolean;
+	existingFolders: string[];
+	websiteId: string;
+	flagsInFolder: Flag[];
+	onSelect: () => void;
+	onRenamedAction: (oldName: string, newName: string) => void;
+	onDeletedAction: (name: string) => void;
+}
+
+function FolderRow({
+	name,
+	count,
+	isSelected,
+	existingFolders,
+	websiteId,
+	flagsInFolder,
+	onSelect,
+	onRenamedAction,
+	onDeletedAction,
+}: FolderRowProps) {
+	const [showRename, setShowRename] = useState(false);
+	const [showDelete, setShowDelete] = useState(false);
+	const queryClient = useQueryClient();
+
+	const updateMutation = useMutation({
+		...orpc.flags.update.mutationOptions(),
+	});
+
+	const isRenaming = updateMutation.isPending;
+
+	const handleRename = async (newName: string) => {
+		try {
+			await Promise.all(
+				flagsInFolder.map((flag) =>
+					updateMutation.mutateAsync({ id: flag.id, folder: newName })
+				)
+			);
+			queryClient.invalidateQueries({
+				queryKey: orpc.flags.list.key({ input: { websiteId } }),
+			});
+			toast.success(`Folder renamed to "${newName}"`);
+			onRenamedAction(name, newName);
+			setShowRename(false);
+		} catch {
+			toast.error("Failed to rename folder");
+		}
+	};
+
+	const handleDelete = async () => {
+		try {
+			await Promise.all(
+				flagsInFolder.map((flag) =>
+					updateMutation.mutateAsync({ id: flag.id, folder: null })
+				)
+			);
+			queryClient.invalidateQueries({
+				queryKey: orpc.flags.list.key({ input: { websiteId } }),
+			});
+			toast.success(`Folder "${name}" deleted`);
+			onDeletedAction(name);
+			setShowDelete(false);
+		} catch {
+			toast.error("Failed to delete folder");
+		}
+	};
+
+	return (
+		<>
+			<div
+				className={cn(
+					"group flex items-center gap-2 rounded px-2 py-1.5 transition-colors",
+					isSelected
+						? "bg-accent text-accent-foreground"
+						: "hover:bg-accent/50 text-muted-foreground hover:text-foreground"
+				)}
+			>
+				<button
+					className="flex flex-1 items-center gap-2 text-left"
+					onClick={onSelect}
+					type="button"
+				>
+					{isSelected ? (
+						<FolderOpenIcon className="size-4 shrink-0" weight="duotone" />
+					) : (
+						<FolderIcon className="size-4 shrink-0" weight="duotone" />
+					)}
+					<span className="flex-1 truncate text-sm">{name}</span>
+					<span className="text-muted-foreground text-xs tabular-nums">
+						{count}
+					</span>
+				</button>
+
+				<DropdownMenu>
+					<DropdownMenuTrigger asChild>
+						<Button
+							aria-label="Folder options"
+							className="size-6 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+							size="icon"
+							variant="ghost"
+						>
+							<DotsThreeIcon className="size-4" weight="bold" />
+						</Button>
+					</DropdownMenuTrigger>
+					<DropdownMenuContent align="end" className="w-36">
+						<DropdownMenuItem
+							className="gap-2"
+							onClick={() => setShowRename(true)}
+						>
+							<PencilSimpleIcon className="size-3.5" weight="duotone" />
+							Rename
+						</DropdownMenuItem>
+						<DropdownMenuSeparator />
+						<DropdownMenuItem
+							className="gap-2 text-destructive focus:text-destructive"
+							onClick={() => setShowDelete(true)}
+							variant="destructive"
+						>
+							<TrashIcon className="size-3.5" weight="duotone" />
+							Delete
+						</DropdownMenuItem>
+					</DropdownMenuContent>
+				</DropdownMenu>
+			</div>
+
+			<RenameFolderDialog
+				currentName={name}
+				existingFolders={existingFolders}
+				flagsInFolder={count}
+				isOpen={showRename}
+				isRenaming={isRenaming}
+				onClose={() => setShowRename(false)}
+				onRenameAction={handleRename}
+			/>
+
+			<DeleteDialog
+				description={
+					count > 0
+						? `This will move ${count} flag${count !== 1 ? "s" : ""} to Uncategorized.`
+						: undefined
+				}
+				isDeleting={updateMutation.isPending}
+				isOpen={showDelete}
+				itemName={`"${name}" folder`}
+				onClose={() => setShowDelete(false)}
+				onConfirm={handleDelete}
+				title="Delete Folder"
+			/>
+		</>
+	);
+}
+
+export function FolderSidebar({
+	flags,
+	websiteId,
+	selectedFolder,
+	onSelectFolder,
+}: FolderSidebarProps) {
+	const [showCreate, setShowCreate] = useState(false);
+	const [localFolders, setLocalFolders] = useState<string[]>([]);
+
+	// Derive folders from flags
+	const folderCounts = new Map<string, number>();
+	for (const flag of flags) {
+		if (flag.folder) {
+			folderCounts.set(flag.folder, (folderCounts.get(flag.folder) ?? 0) + 1);
+		}
+	}
+
+	// Merge local (newly created empty) folders with flag-derived folders
+	const allFolderNames = Array.from(
+		new Set([...Array.from(folderCounts.keys()), ...localFolders])
+	).sort();
+
+	const uncategorizedCount = flags.filter((f) => !f.folder).length;
+	const allCount = flags.length;
+
+	const handleCreate = (name: string) => {
+		if (!folderCounts.has(name) && !localFolders.includes(name)) {
+			setLocalFolders((prev) => [...prev, name]);
+		}
+		onSelectFolder(name);
+	};
+
+	const handleRenamed = (oldName: string, newName: string) => {
+		setLocalFolders((prev) =>
+			prev.map((n) => (n === oldName ? newName : n)).filter(Boolean)
+		);
+		if (selectedFolder === oldName) {
+			onSelectFolder(newName);
+		}
+	};
+
+	const handleDeleted = (name: string) => {
+		setLocalFolders((prev) => prev.filter((n) => n !== name));
+		if (selectedFolder === name) {
+			onSelectFolder("all");
+		}
+	};
+
+	return (
+		<>
+			<div className="flex h-full w-48 shrink-0 flex-col border-r bg-background lg:w-56">
+				<div className="flex items-center justify-between px-3 py-2.5">
+					<span className="font-medium text-foreground text-xs uppercase tracking-wider">
+						Folders
+					</span>
+					<Button
+						aria-label="Create folder"
+						className="size-6"
+						onClick={() => setShowCreate(true)}
+						size="icon"
+						variant="ghost"
+					>
+						<FolderPlusIcon className="size-4" weight="duotone" />
+					</Button>
+				</div>
+
+				<div className="flex-1 space-y-0.5 overflow-y-auto px-2 pb-4">
+					{/* All Flags */}
+					<button
+						className={cn(
+							"flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors",
+							selectedFolder === "all"
+								? "bg-accent text-accent-foreground font-medium"
+								: "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+						)}
+						onClick={() => onSelectFolder("all")}
+						type="button"
+					>
+						<FlagIcon className="size-4 shrink-0" weight="duotone" />
+						<span className="flex-1">All Flags</span>
+						<span className="text-muted-foreground text-xs tabular-nums">
+							{allCount}
+						</span>
+					</button>
+
+					{/* Uncategorized */}
+					{uncategorizedCount > 0 && (
+						<button
+							className={cn(
+								"flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm transition-colors",
+								selectedFolder === "uncategorized"
+									? "bg-accent text-accent-foreground font-medium"
+									: "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+							)}
+							onClick={() => onSelectFolder("uncategorized")}
+							type="button"
+						>
+							<FolderIcon className="size-4 shrink-0 opacity-40" weight="duotone" />
+							<span className="flex-1">Uncategorized</span>
+							<span className="text-muted-foreground text-xs tabular-nums">
+								{uncategorizedCount}
+							</span>
+						</button>
+					)}
+
+					{/* Named folders */}
+					{allFolderNames.length > 0 && (
+						<div className="my-1 h-px bg-border" />
+					)}
+					{allFolderNames.map((folder) => (
+						<FolderRow
+							count={folderCounts.get(folder) ?? 0}
+							existingFolders={allFolderNames}
+							flagsInFolder={flags.filter((f) => f.folder === folder)}
+							isSelected={selectedFolder === folder}
+							key={folder}
+							name={folder}
+							onDeletedAction={handleDeleted}
+							onRenamedAction={handleRenamed}
+							onSelect={() => onSelectFolder(folder)}
+							websiteId={websiteId}
+						/>
+					))}
+
+					{allFolderNames.length === 0 && uncategorizedCount === 0 && (
+						<p className="px-2 py-4 text-center text-muted-foreground text-xs">
+							No folders yet
+						</p>
+					)}
+				</div>
+			</div>
+
+			<CreateFolderDialog
+				existingFolders={allFolderNames}
+				isOpen={showCreate}
+				onClose={() => setShowCreate(false)}
+				onCreateAction={handleCreate}
+			/>
+		</>
+	);
+}

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -22,6 +22,7 @@ export interface Flag {
 	variants?: Variant[];
 	dependencies?: string[];
 	environment?: string;
+	folder?: string | null;
 	persistAcrossAuth?: boolean;
 	websiteId?: string | null;
 	organizationId?: string | null;

--- a/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
@@ -14,6 +14,10 @@ import { orpc } from "@/lib/orpc";
 import { isFlagSheetOpenAtom } from "@/stores/jotai/flagsAtoms";
 import { FlagSheet } from "./_components/flag-sheet";
 import { FlagsList, FlagsListSkeleton } from "./_components/flags-list";
+import {
+	FolderSidebar,
+	type FolderSelection,
+} from "./_components/folder-sidebar";
 import type { Flag, TargetGroup } from "./_components/types";
 
 export default function FlagsPage() {
@@ -23,6 +27,7 @@ export default function FlagsPage() {
 	const [isFlagSheetOpen, setIsFlagSheetOpen] = useAtom(isFlagSheetOpenAtom);
 	const [editingFlag, setEditingFlag] = useState<Flag | null>(null);
 	const [flagToDelete, setFlagToDelete] = useState<Flag | null>(null);
+	const [selectedFolder, setSelectedFolder] = useState<FolderSelection>("all");
 
 	const { data: flags, isLoading: flagsLoading } = useQuery({
 		...orpc.flags.list.queryOptions({ input: { websiteId } }),
@@ -48,6 +53,21 @@ export default function FlagsPage() {
 		}
 		return map;
 	}, [activeFlags]);
+
+	// Determine whether to group by folder or filter
+	const hasFolders = useMemo(
+		() => activeFlags.some((f) => f.folder),
+		[activeFlags]
+	);
+
+	const filteredFlags = useMemo(() => {
+		if (selectedFolder === "all") return activeFlags;
+		if (selectedFolder === "uncategorized")
+			return activeFlags.filter((f) => !f.folder);
+		return activeFlags.filter((f) => f.folder === selectedFolder);
+	}, [activeFlags, selectedFolder]);
+
+	const shouldGroupByFolder = selectedFolder === "all" && hasFolders;
 
 	const deleteFlagMutation = useMutation({
 		...orpc.flags.delete.mutationOptions(),
@@ -90,53 +110,80 @@ export default function FlagsPage() {
 	return (
 		<FeatureGate feature={GATED_FEATURES.FEATURE_FLAGS}>
 			<ErrorBoundary>
-				<div className="h-full overflow-y-auto">
-					<Suspense fallback={<FlagsListSkeleton />}>
-						{flagsLoading ? (
-							<FlagsListSkeleton />
-						) : activeFlags.length === 0 ? (
-							<div className="flex flex-1 items-center justify-center py-16">
-								<EmptyState
-									action={{
-										label: "Create Your First Flag",
-										onClick: handleCreateFlag,
-									}}
-									description="Create your first feature flag to start controlling feature rollouts and A/B testing across your application."
-									icon={<FlagIcon weight="duotone" />}
-									title="No feature flags yet"
-									variant="minimal"
-								/>
-							</div>
-						) : (
-							<FlagsList
-								flags={activeFlags as Flag[]}
-								groups={groupsMap}
-								onDelete={handleDeleteFlagRequest}
-								onEdit={handleEditFlag}
-							/>
-						)}
-					</Suspense>
-
-					{isFlagSheetOpen && (
-						<Suspense fallback={null}>
-							<FlagSheet
-								flag={editingFlag}
-								isOpen={isFlagSheetOpen}
-								onCloseAction={handleFlagSheetClose}
-								websiteId={websiteId}
-							/>
-						</Suspense>
+				<div className="flex h-full min-h-0">
+					{/* Folder sidebar — shown when there are flags */}
+					{!flagsLoading && activeFlags.length > 0 && (
+						<FolderSidebar
+							flags={activeFlags as Flag[]}
+							onSelectFolder={setSelectedFolder}
+							selectedFolder={selectedFolder}
+							websiteId={websiteId}
+						/>
 					)}
 
-					<DeleteDialog
-						isDeleting={deleteFlagMutation.isPending}
-						isOpen={flagToDelete !== null}
-						itemName={flagToDelete?.name || flagToDelete?.key}
-						onClose={() => setFlagToDelete(null)}
-						onConfirm={handleConfirmDelete}
-						title="Delete Feature Flag"
-					/>
+					{/* Main content */}
+					<div className="min-w-0 flex-1 overflow-y-auto">
+						<Suspense fallback={<FlagsListSkeleton />}>
+							{flagsLoading ? (
+								<FlagsListSkeleton />
+							) : activeFlags.length === 0 ? (
+								<div className="flex flex-1 items-center justify-center py-16">
+									<EmptyState
+										action={{
+											label: "Create Your First Flag",
+											onClick: handleCreateFlag,
+										}}
+										description="Create your first feature flag to start controlling feature rollouts and A/B testing across your application."
+										icon={<FlagIcon weight="duotone" />}
+										title="No feature flags yet"
+										variant="minimal"
+									/>
+								</div>
+							) : filteredFlags.length === 0 ? (
+								<div className="flex flex-1 items-center justify-center py-16">
+									<EmptyState
+										action={{
+											label: "Create Flag",
+											onClick: handleCreateFlag,
+										}}
+										description="No flags in this folder yet. Create a flag and assign it to this folder."
+										icon={<FlagIcon weight="duotone" />}
+										title="No flags here"
+										variant="minimal"
+									/>
+								</div>
+							) : (
+								<FlagsList
+									flags={filteredFlags as Flag[]}
+									groupByFolder={shouldGroupByFolder}
+									groups={groupsMap}
+									onDelete={handleDeleteFlagRequest}
+									onEdit={handleEditFlag}
+								/>
+							)}
+						</Suspense>
+					</div>
 				</div>
+
+				{isFlagSheetOpen && (
+					<Suspense fallback={null}>
+						<FlagSheet
+							flag={editingFlag}
+							isOpen={isFlagSheetOpen}
+							onCloseAction={handleFlagSheetClose}
+							websiteId={websiteId}
+						/>
+					</Suspense>
+				)}
+
+				<DeleteDialog
+					isDeleting={deleteFlagMutation.isPending}
+					isOpen={flagToDelete !== null}
+					itemName={flagToDelete?.name || flagToDelete?.key}
+					onClose={() => setFlagToDelete(null)}
+					onConfirm={handleConfirmDelete}
+					title="Delete Feature Flag"
+				/>
 			</ErrorBoundary>
 		</FeatureGate>
 	);

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -669,11 +669,16 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),
 	},
 	(table) => [
+		index("idx_flags_folder").using(
+			"btree",
+			table.folder.asc().nullsLast().op("text_ops")
+		),
 		uniqueIndex("flags_key_website_unique")
 			.on(table.key, table.websiteId)
 			.where(isNotNull(table.websiteId)),

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -84,6 +84,7 @@ const listFlagsSchema = z
 		websiteId: z.string().optional(),
 		organizationId: z.string().optional(),
 		status: z.enum(["active", "inactive", "archived"]).optional(),
+		folder: z.string().optional(),
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
 		message: "Either websiteId or organizationId must be provided",
@@ -142,6 +143,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(100).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -271,7 +273,7 @@ export const flagsRouter = {
 		.output(z.array(flagOutputSchema))
 		.handler(({ context, input }) => {
 			const scope = getScope(input.websiteId, input.organizationId);
-			const cacheKey = `list:${scope}:${input.status || "all"}`;
+			const cacheKey = `list:${scope}:${input.status || "all"}:${input.folder ?? "all"}`;
 
 			return flagsCache.withCache({
 				key: cacheKey,
@@ -292,6 +294,14 @@ export const flagsRouter = {
 
 					if (input.status) {
 						conditions.push(eq(flags.status, input.status));
+					}
+
+					if (input.folder !== undefined) {
+						if (input.folder === null || input.folder === "") {
+							conditions.push(isNull(flags.folder));
+						} else {
+							conditions.push(eq(flags.folder, input.folder));
+						}
 					}
 
 					const flagsList = await context.db.query.flags.findMany({
@@ -628,6 +638,7 @@ export const flagsRouter = {
 							variants: input.variants,
 							dependencies: input.dependencies,
 							environment: input.environment,
+							folder: input.folder ?? null,
 							deletedAt: null,
 							updatedAt: new Date(),
 						})
@@ -685,6 +696,7 @@ export const flagsRouter = {
 						websiteId: input.websiteId || null,
 						organizationId: input.organizationId || null,
 						environment: input.environment || existingFlag?.[0]?.environment,
+						folder: input.folder || null,
 						userId: null,
 						createdBy,
 					})

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -143,7 +143,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
-		folder: z.string().max(100).nullable().optional(),
+		folder: z.string().min(1).max(100).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -297,11 +297,7 @@ export const flagsRouter = {
 					}
 
 					if (input.folder !== undefined) {
-						if (input.folder === null || input.folder === "") {
-							conditions.push(isNull(flags.folder));
-						} else {
-							conditions.push(eq(flags.folder, input.folder));
-						}
+						conditions.push(eq(flags.folder, input.folder));
 					}
 
 					const flagsList = await context.db.query.flags.findMany({

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -62,6 +62,15 @@ export const flagFormSchema = z
 			.optional(),
 		environment: z.string().nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z
+			.string()
+			.max(100, "Folder name too long")
+			.regex(
+				/^[a-zA-Z0-9_\-/ ]*$/,
+				"Folder name must contain only letters, numbers, spaces, hyphens, underscores, and slashes"
+			)
+			.nullable()
+			.optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -64,6 +64,7 @@ export const flagFormSchema = z
 		targetGroupIds: z.array(z.string()).optional(),
 		folder: z
 			.string()
+			.min(1, "Folder name cannot be empty")
 			.max(100, "Folder name too long")
 			.regex(
 				/^[a-zA-Z0-9_\-/ ]*$/,


### PR DESCRIPTION
## Summary

Adds a folder system for organizing feature flags in the dashboard UI, as requested in #271.

### Implementation: Option A (Simple String Folder Field)

**Database Schema** (`packages/db/src/drizzle/schema.ts`)
- Added optional `folder` text field to flags table
- Added `idx_flags_folder` index for query performance
- Backward compatible — existing flags default to `null`

**Shared Validation** (`packages/shared/src/flags/index.ts`)
- Added `folder` field to `flagFormSchema`: optional string, max 100 chars

**API Router** (`packages/rpc/src/routers/flags.ts`)
- `flags.list`: Added `folder` filter parameter + updated cache key
- `flags.update`: `folder` field included via schema spread
- `flags.create`: Added `folder` to both new flag insert and soft-deleted flag restore

**Dashboard UI**
- **Folder Sidebar** (`folder-sidebar.tsx`): Left sidebar showing "All Flags", "Uncategorized", and named folders with counts. Create/rename/delete folder modals.
- **Flags List** (`flags-list.tsx`): `groupByFolder` prop with collapsible `FolderSection` components
- **Flag Sheet** (`flag-sheet.tsx`): `FolderCombobox` component in create/edit form with search, suggestions, and "create new" option
- **Page** (`page.tsx`): Sidebar layout with folder filtering state and grouped/filtered modes

### Key Design Decisions
- Purely UI organization — no business logic changes
- Existing flags without folders appear under "Uncategorized"
- Uses existing Databuddy UI components (Dialog, Command, Popover, etc.)
- Mobile-responsive layout
- Uses `drizzle-kit push` (no migration files) — apply with `bun run db:push`

### Files Changed (8 files, +888/-47)

| File | Change |
|------|--------|
| `packages/db/src/drizzle/schema.ts` | Added `folder` field + index |
| `packages/shared/src/flags/index.ts` | Added `folder` to validation schema |
| `packages/rpc/src/routers/flags.ts` | Added folder filter/create/update support |
| `apps/.../flags/_components/types.ts` | Added `folder` to Flag type |
| `apps/.../flags/_components/folder-sidebar.tsx` | **New** — full sidebar with CRUD modals |
| `apps/.../flags/_components/flags-list.tsx` | FolderSection grouped view |
| `apps/.../flags/_components/flag-sheet.tsx` | FolderCombobox in create/edit form |
| `apps/.../flags/page.tsx` | Sidebar layout + folder filtering |

/claim #271