### PR TITLE
Add .well-known/security.txt for RFC 9116 compliance

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@databuddy.cc
+Expires: 2027-03-21T00:00:00.000Z
+Preferred-Languages: en
+Policy: https://github.com/databuddy-analytics/Databuddy/blob/main/SECURITY.md
+Canonical: https://github.com/databuddy-analytics/Databuddy/blob/main/.well-known/security.txt


### PR DESCRIPTION
## Summary

- Adds `.well-known/security.txt` per [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) with contact, expiry (1 year), preferred languages, policy link, and canonical URL
- Contact email sourced from existing `SECURITY.md`

Closes #325