### PR TITLE
 feat(dashboard): streamline api key permission setup

### DIFF
--- a/apps/dashboard/components/organizations/api-key-create-dialog.tsx
+++ b/apps/dashboard/components/organizations/api-key-create-dialog.tsx
@@ -283,8 +283,8 @@ export function ApiKeyCreateDialog({
 								</Badge>
 							</div>
 							<p className="text-muted-foreground text-xs">
-								These permissions apply to all websites. Read Data is included
-								by default.
+								These permissions apply to all websites unless you restrict to
+								specific ones below.
 							</p>
 							<Tabs
 								defaultValue="all"
@@ -372,9 +372,9 @@ export function ApiKeyCreateDialog({
 										className="w-(--radix-popover-trigger-width) p-0"
 									>
 										<Command>
+											<CommandInput placeholder="Search websites..." />
 											<CommandList>
 												<CommandEmpty>No websites found.</CommandEmpty>
-												<CommandInput placeholder="Search websites..." />
 												<CommandGroup>
 													{(websites as Website[]).map((website) => (
 														<CommandItem

--- a/apps/dashboard/components/organizations/api-key-create-dialog.tsx
+++ b/apps/dashboard/components/organizations/api-key-create-dialog.tsx
@@ -162,12 +162,8 @@ export function ApiKeyCreateDialog({
 	const onSubmit = form.handleSubmit((values) => {
 		const resources: Record<string, ApiScope[]> = {};
 
-		if (globalScopes.length > 0) {
-			if (websiteAccess.length === 0) {
-				resources.global = globalScopes;
-			} else {
-				resources.global = DEFAULT_SCOPES;
-			}
+		if (globalScopes.length > 0 && websiteAccess.length === 0) {
+			resources.global = globalScopes;
 		}
 
 		// Add website-specific scopes with proper prefix

--- a/apps/dashboard/components/organizations/api-key-create-dialog.tsx
+++ b/apps/dashboard/components/organizations/api-key-create-dialog.tsx
@@ -11,7 +11,7 @@ import {
 	PlusIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 import type { Website } from "@/hooks/use-websites";
@@ -69,8 +69,13 @@ export function ApiKeyCreateDialog({
 	onSuccessAction,
 }: ApiKeyCreateDialogProps) {
 	const queryClient = useQueryClient();
-	const [globalScopes, setGlobalScopes] = useState<ApiScope[]>(ALL_SCOPES);
+	// const [globalScopes, setGlobalScopes] = useState<ApiScope[]>(ALL_SCOPES);
 	const [websiteAccess, setWebsiteAccess] = useState<ApiKeyAccessEntry[]>([]);
+
+	const [scopeMode, setScopeMode] = useState("all");
+	const [restrictedScopes, setRestrictedScopes] =
+		useState<ApiScope[]>(DEFAULT_SCOPES);
+
 	const [popoverOpen, setPopoverOpen] = useState(false);
 	const [created, setCreated] = useState<{
 		id: string;
@@ -98,21 +103,18 @@ export function ApiKeyCreateDialog({
 		},
 	});
 
-	const assignGlobalScopes = (value: string) => {
-		switch (value) {
+	const globalScopes = useMemo(() => {
+		switch (scopeMode) {
 			case "all":
-				setGlobalScopes(ALL_SCOPES);
-				break;
+				return ALL_SCOPES;
 			case "restricted":
-				setGlobalScopes(DEFAULT_SCOPES);
-				break;
+				return restrictedScopes;
 			case "read-data":
-				setGlobalScopes(DEFAULT_SCOPES);
-				break;
+				return DEFAULT_SCOPES;
 			default:
-				setGlobalScopes(DEFAULT_SCOPES);
+				return DEFAULT_SCOPES;
 		}
-	};
+	}, [scopeMode, restrictedScopes]);
 
 	const handleClose = () => {
 		if (created) {
@@ -121,7 +123,8 @@ export function ApiKeyCreateDialog({
 		onOpenChangeAction(false);
 		setTimeout(() => {
 			form.reset();
-			setGlobalScopes(ALL_SCOPES);
+			setScopeMode("all");
+			setRestrictedScopes(DEFAULT_SCOPES);
 			setWebsiteAccess([]);
 			setCreated(null);
 			setCopied(false);
@@ -136,12 +139,6 @@ export function ApiKeyCreateDialog({
 		}
 	};
 
-	const toggleGlobalScope = (scope: ApiScope) => {
-		setGlobalScopes((prev) =>
-			prev.includes(scope) ? prev.filter((s) => s !== scope) : [...prev, scope]
-		);
-	};
-
 	const addWebsite = (resourceId: string) => {
 		if (websiteAccess.some((e) => e.resourceId === resourceId)) {
 			return;
@@ -149,6 +146,7 @@ export function ApiKeyCreateDialog({
 		setWebsiteAccess((prev) => [
 			...prev,
 			{ resourceType: "website", resourceId, scopes: [] },
+			// don't snapshot globalScopes here, as they are computed on submit to ensure they reflect the latest selection
 		]);
 	};
 
@@ -170,6 +168,7 @@ export function ApiKeyCreateDialog({
 		// Add website-specific scopes with proper prefix
 		for (const entry of websiteAccess) {
 			if (entry.resourceId) {
+				// snapshot globalScopes on submit to ensure it reflects latest selection
 				resources[`website:${entry.resourceId}`] = globalScopes;
 			}
 		}
@@ -288,7 +287,8 @@ export function ApiKeyCreateDialog({
 							</p>
 							<Tabs
 								defaultValue="all"
-								onValueChange={assignGlobalScopes}
+								onValueChange={setScopeMode}
+								value={scopeMode}
 								variant="default"
 							>
 								<TabsList className="w-full bg-background">
@@ -302,13 +302,20 @@ export function ApiKeyCreateDialog({
 								>
 									<div className="grid grid-cols-2 gap-1">
 										{SCOPE_OPTIONS.map((scope) => {
-											const isSelected = globalScopes.includes(scope.value);
+											const isSelected = restrictedScopes.includes(scope.value);
 											const isDefault = DEFAULT_SCOPES.includes(scope.value);
 											return (
 												<button
 													className="flex items-center gap-2 rounded px-3 py-2.5 text-left text-sm"
 													key={scope.value}
-													onClick={() => toggleGlobalScope(scope.value)}
+													onClick={() =>
+														setRestrictedScopes((prev) => {
+															if (prev.includes(scope.value)) {
+																return prev.filter((s) => s !== scope.value);
+															}
+															return [...prev, scope.value];
+														})
+													}
 													type="button"
 												>
 													<div

--- a/apps/dashboard/components/organizations/api-key-create-dialog.tsx
+++ b/apps/dashboard/components/organizations/api-key-create-dialog.tsx
@@ -3,13 +3,12 @@
 import type { ApiScope } from "@databuddy/api-keys/scopes";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
+	CaretUpDownIcon,
 	CheckCircleIcon,
 	CheckIcon,
 	CopyIcon,
-	GlobeIcon,
 	KeyIcon,
 	PlusIcon,
-	TrashIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
@@ -19,15 +18,16 @@ import type { Website } from "@/hooks/use-websites";
 import { orpc } from "@/lib/orpc";
 import { Badge } from "../ui/badge";
 import { Button } from "../ui/button";
+import {
+	Command,
+	CommandEmpty,
+	CommandGroup,
+	CommandItem,
+	CommandList,
+} from "../ui/command";
 import { Input } from "../ui/input";
 import { Label } from "../ui/label";
-import {
-	Select,
-	SelectContent,
-	SelectItem,
-	SelectTrigger,
-	SelectValue,
-} from "../ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "../ui/popover";
 import {
 	Sheet,
 	SheetBody,
@@ -37,6 +37,7 @@ import {
 	SheetHeader,
 	SheetTitle,
 } from "../ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "../ui/tabs";
 import { type ApiKeyAccessEntry, SCOPE_OPTIONS } from "./api-key-types";
 
 interface ApiKeyCreateDialogProps {
@@ -57,6 +58,9 @@ const formSchema = z.object({
 
 type FormData = z.infer<typeof formSchema>;
 
+const DEFAULT_SCOPES: ApiScope[] = ["read:data"];
+const ALL_SCOPES: ApiScope[] = SCOPE_OPTIONS.map((opt) => opt.value);
+
 export function ApiKeyCreateDialog({
 	open,
 	onOpenChangeAction,
@@ -64,9 +68,9 @@ export function ApiKeyCreateDialog({
 	onSuccessAction,
 }: ApiKeyCreateDialogProps) {
 	const queryClient = useQueryClient();
-	const [globalScopes, setGlobalScopes] = useState<ApiScope[]>(["read:data"]);
+	const [globalScopes, setGlobalScopes] = useState<ApiScope[]>(ALL_SCOPES);
 	const [websiteAccess, setWebsiteAccess] = useState<ApiKeyAccessEntry[]>([]);
-	const [websiteToAdd, setWebsiteToAdd] = useState<string | undefined>();
+	const [popoverOpen, setPopoverOpen] = useState(false);
 	const [created, setCreated] = useState<{
 		id: string;
 		secret: string;
@@ -93,6 +97,22 @@ export function ApiKeyCreateDialog({
 		},
 	});
 
+	const assignGlobalScopes = (value: string) => {
+		switch (value) {
+			case "all":
+				setGlobalScopes(ALL_SCOPES);
+				break;
+			case "restricted":
+				setGlobalScopes(DEFAULT_SCOPES);
+				break;
+			case "read-data":
+				setGlobalScopes(DEFAULT_SCOPES);
+				break;
+			default:
+				setGlobalScopes(DEFAULT_SCOPES);
+		}
+	};
+
 	const handleClose = () => {
 		if (created) {
 			onSuccessAction(created);
@@ -100,9 +120,8 @@ export function ApiKeyCreateDialog({
 		onOpenChangeAction(false);
 		setTimeout(() => {
 			form.reset();
-			setGlobalScopes(["read:data"]);
+			setGlobalScopes(ALL_SCOPES);
 			setWebsiteAccess([]);
-			setWebsiteToAdd(undefined);
 			setCreated(null);
 			setCopied(false);
 		}, 200);
@@ -122,49 +141,39 @@ export function ApiKeyCreateDialog({
 		);
 	};
 
-	const addWebsite = () => {
-		if (!websiteToAdd) {
-			return;
-		}
-		if (websiteAccess.some((e) => e.resourceId === websiteToAdd)) {
+	const addWebsite = (resourceId: string) => {
+		if (websiteAccess.some((e) => e.resourceId === resourceId)) {
 			return;
 		}
 		setWebsiteAccess((prev) => [
 			...prev,
-			{ resourceType: "website", resourceId: websiteToAdd, scopes: [] },
+			{ resourceType: "website", resourceId, scopes: globalScopes },
 		]);
-		setWebsiteToAdd(undefined);
 	};
 
 	const removeWebsite = (resourceId: string) => {
 		setWebsiteAccess((prev) => prev.filter((e) => e.resourceId !== resourceId));
 	};
 
-	const toggleWebsiteScope = (resourceId: string, scope: ApiScope) => {
-		setWebsiteAccess((prev) =>
-			prev.map((entry) => {
-				if (entry.resourceId !== resourceId) {
-					return entry;
-				}
-				const scopes = entry.scopes.includes(scope)
-					? entry.scopes.filter((s) => s !== scope)
-					: [...entry.scopes, scope];
-				return { ...entry, scopes };
-			})
-		);
+	const isWebsiteSelected = (resourceId: string) => {
+		return websiteAccess.some((e) => e.resourceId === resourceId);
 	};
 
 	const onSubmit = form.handleSubmit((values) => {
 		const resources: Record<string, ApiScope[]> = {};
 
 		if (globalScopes.length > 0) {
-			resources.global = globalScopes;
+			if (websiteAccess.length === 0) {
+				resources.global = globalScopes;
+			} else {
+				resources.global = DEFAULT_SCOPES;
+			}
 		}
 
 		// Add website-specific scopes with proper prefix
 		for (const entry of websiteAccess) {
 			if (entry.resourceId && entry.scopes.length > 0) {
-				resources[`website:${entry.resourceId}`] = entry.scopes;
+				resources[`website:${entry.resourceId}`] = globalScopes;
 			}
 		}
 
@@ -182,7 +191,7 @@ export function ApiKeyCreateDialog({
 			<Sheet onOpenChange={handleClose} open={open}>
 				<SheetContent className="sm:max-w-md" side="right">
 					<div className="flex h-full flex-col items-center justify-center p-8 text-center">
-						<div className="mb-5 flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+						<div className="zoom-in-90 mb-5 flex h-16 w-16 animate-in items-center justify-center rounded-full bg-green-100 duration-200 ease-out dark:bg-green-900/30">
 							<CheckCircleIcon
 								className="text-green-600 dark:text-green-400"
 								size={32}
@@ -271,11 +280,8 @@ export function ApiKeyCreateDialog({
 						{/* Global Permissions */}
 						<section className="space-y-3">
 							<div className="flex items-center justify-between">
-								<div className="flex items-center gap-2">
-									<GlobeIcon className="text-muted-foreground" size={16} />
-									<Label className="font-medium">Global Permissions</Label>
-								</div>
-								<Badge className="font-normal" variant="secondary">
+								<Label className="font-medium">Global Permissions</Label>
+								<Badge className="font-normal" variant="outline">
 									{globalScopes.length} selected
 								</Badge>
 							</div>
@@ -283,44 +289,58 @@ export function ApiKeyCreateDialog({
 								These permissions apply to all websites. Read Data is included
 								by default.
 							</p>
-							<div className="rounded border bg-card p-1">
-								<div className="grid grid-cols-2 gap-1">
-									{SCOPE_OPTIONS.map((scope) => {
-										const isSelected = globalScopes.includes(scope.value);
-										const isDefault = scope.value === "read:data";
-										return (
-											<button
-												className="flex items-center gap-2 rounded px-3 py-2.5 text-left text-sm"
-												key={scope.value}
-												onClick={() => toggleGlobalScope(scope.value)}
-												type="button"
-											>
-												<div
-													className={`flex size-4 shrink-0 items-center justify-center rounded-sm border ${
-														isSelected
-															? "border-primary bg-primary text-primary"
-															: "border-muted-foreground/30"
-													}`}
+							<Tabs
+								defaultValue="all"
+								onValueChange={assignGlobalScopes}
+								variant="default"
+							>
+								<TabsList className="w-full bg-background">
+									<TabsTrigger value="all">All</TabsTrigger>
+									<TabsTrigger value="restricted">Restricted</TabsTrigger>
+									<TabsTrigger value="read-data">Read data only</TabsTrigger>
+								</TabsList>
+								<TabsContent
+									className="rounded border bg-card"
+									value="restricted"
+								>
+									<div className="grid grid-cols-2 gap-1">
+										{SCOPE_OPTIONS.map((scope) => {
+											const isSelected = globalScopes.includes(scope.value);
+											const isDefault = DEFAULT_SCOPES.includes(scope.value);
+											return (
+												<button
+													className="flex items-center gap-2 rounded px-3 py-2.5 text-left text-sm"
+													key={scope.value}
+													onClick={() => toggleGlobalScope(scope.value)}
+													type="button"
 												>
-													{isSelected && (
-														<CheckIcon
-															className="text-white"
-															size={12}
-															weight="bold"
-														/>
+													<div
+														className={`flex size-4 shrink-0 items-center justify-center rounded-sm border ${
+															isSelected
+																? "border-primary bg-primary text-primary"
+																: "border-muted-foreground/30"
+														}`}
+													>
+														{isSelected && (
+															<CheckIcon
+																className="text-white"
+																size={12}
+																weight="bold"
+															/>
+														)}
+													</div>
+													<span className="truncate">{scope.label}</span>
+													{isDefault && (
+														<span className="text-[10px] text-muted-foreground">
+															default
+														</span>
 													)}
-												</div>
-												<span className="truncate">{scope.label}</span>
-												{isDefault && (
-													<span className="text-[10px] text-muted-foreground">
-														default
-													</span>
-												)}
-											</button>
-										);
-									})}
-								</div>
-							</div>
+												</button>
+											);
+										})}
+									</div>
+								</TabsContent>
+							</Tabs>
 						</section>
 
 						{/* Website-Specific Permissions */}
@@ -333,112 +353,57 @@ export function ApiKeyCreateDialog({
 									</span>
 								</div>
 								<p className="text-muted-foreground text-xs">
-									Limit this key to specific websites with custom permissions
+									Limit this key to specific websites
 								</p>
 
-								{/* Add Website */}
-								<div className="flex gap-2">
-									<Select onValueChange={setWebsiteToAdd} value={websiteToAdd}>
-										<SelectTrigger className="h-10 flex-1">
-											<SelectValue placeholder="Select a website..." />
-										</SelectTrigger>
-										<SelectContent>
-											{websites
-												.filter(
-													(w) =>
-														!websiteAccess.some((e) => e.resourceId === w.id)
-												)
-												.map((w: Website) => (
-													<SelectItem key={w.id} value={w.id}>
-														{w.name || w.domain}
-													</SelectItem>
-												))}
-										</SelectContent>
-									</Select>
-									<Button
-										disabled={!websiteToAdd}
-										onClick={addWebsite}
-										size="icon"
-										type="button"
-										variant="outline"
+								<Popover onOpenChange={setPopoverOpen} open={popoverOpen}>
+									<PopoverTrigger asChild>
+										<Button
+											aria-expanded={open}
+											className="w-full justify-between"
+											role="combobox"
+											variant="outline"
+										>
+											{websiteAccess.length > 0
+												? `${websiteAccess.map((entry) => websites?.find((w) => w.id === entry.resourceId)?.name || entry.resourceId).join(", ")}`
+												: "Select websites..."}
+											<CaretUpDownIcon className="size-3.5 opacity-50" />
+										</Button>
+									</PopoverTrigger>
+									<PopoverContent
+										align="start"
+										className="w-(--radix-popover-trigger-width) p-0"
 									>
-										<PlusIcon size={16} />
-									</Button>
-								</div>
-
-								{/* Website Access List */}
-								{websiteAccess.length > 0 && (
-									<div className="space-y-3">
-										{websiteAccess.map((entry) => {
-											const website = websites.find(
-												(w) => w.id === entry.resourceId
-											);
-											return (
-												<div
-													className="rounded border bg-muted/20 p-3"
-													key={entry.resourceId}
-												>
-													<div className="mb-3 flex items-center justify-between">
-														<span className="font-medium text-sm">
-															{(website?.name || website?.domain) ??
-																entry.resourceId}
-														</span>
-														<Button
-															className="size-7"
-															onClick={() =>
-																removeWebsite(entry.resourceId ?? "")
-															}
-															size="icon"
-															type="button"
-															variant="ghost"
+										<Command>
+											<CommandList>
+												<CommandEmpty>No websites found.</CommandEmpty>
+												<CommandGroup>
+													{(websites as Website[]).map((website) => (
+														<CommandItem
+															key={website.id}
+															onSelect={(currentValue) => {
+																isWebsiteSelected(currentValue)
+																	? removeWebsite(currentValue)
+																	: addWebsite(currentValue);
+																setPopoverOpen(false);
+															}}
+															value={website.id}
 														>
-															<TrashIcon size={14} />
-														</Button>
-													</div>
-													<div className="grid grid-cols-2 gap-1">
-														{SCOPE_OPTIONS.slice(0, 6).map((scope) => {
-															const isSelected = entry.scopes.includes(
-																scope.value
-															);
-															return (
-																<button
-																	className={`flex items-center gap-2 rounded px-2 py-1.5 text-left text-xs ${
-																		isSelected
-																			? "bg-primary/20 text-foreground"
-																			: "hover:bg-muted"
-																	}`}
-																	key={scope.value}
-																	onClick={() =>
-																		toggleWebsiteScope(
-																			entry.resourceId ?? "",
-																			scope.value
-																		)
-																	}
-																	type="button"
-																>
-																	<div
-																		className={`flex size-3 shrink-0 items-center justify-center rounded-sm border ${
-																			isSelected
-																				? "border-primary bg-primary text-primary-foreground"
-																				: "border-muted-foreground/30"
-																		}`}
-																	>
-																		{isSelected && (
-																			<CheckIcon size={8} weight="bold" />
-																		)}
-																	</div>
-																	<span className="truncate">
-																		{scope.label}
-																	</span>
-																</button>
-															);
-														})}
-													</div>
-												</div>
-											);
-										})}
-									</div>
-								)}
+															{website.name || website.domain}
+															<CheckIcon
+																className={`ml-auto size-3.5 ${
+																	isWebsiteSelected(website.id)
+																		? "opacity-100"
+																		: "opacity-0"
+																}`}
+															/>
+														</CommandItem>
+													))}
+												</CommandGroup>
+											</CommandList>
+										</Command>
+									</PopoverContent>
+								</Popover>
 							</section>
 						)}
 					</SheetBody>

--- a/apps/dashboard/components/organizations/api-key-create-dialog.tsx
+++ b/apps/dashboard/components/organizations/api-key-create-dialog.tsx
@@ -22,6 +22,7 @@ import {
 	Command,
 	CommandEmpty,
 	CommandGroup,
+	CommandInput,
 	CommandItem,
 	CommandList,
 } from "../ui/command";
@@ -147,7 +148,7 @@ export function ApiKeyCreateDialog({
 		}
 		setWebsiteAccess((prev) => [
 			...prev,
-			{ resourceType: "website", resourceId, scopes: globalScopes },
+			{ resourceType: "website", resourceId, scopes: [] },
 		]);
 	};
 
@@ -168,7 +169,7 @@ export function ApiKeyCreateDialog({
 
 		// Add website-specific scopes with proper prefix
 		for (const entry of websiteAccess) {
-			if (entry.resourceId && entry.scopes.length > 0) {
+			if (entry.resourceId) {
 				resources[`website:${entry.resourceId}`] = globalScopes;
 			}
 		}
@@ -355,7 +356,7 @@ export function ApiKeyCreateDialog({
 								<Popover onOpenChange={setPopoverOpen} open={popoverOpen}>
 									<PopoverTrigger asChild>
 										<Button
-											aria-expanded={open}
+											aria-expanded={popoverOpen}
 											className="w-full justify-between"
 											role="combobox"
 											variant="outline"
@@ -373,6 +374,7 @@ export function ApiKeyCreateDialog({
 										<Command>
 											<CommandList>
 												<CommandEmpty>No websites found.</CommandEmpty>
+												<CommandInput placeholder="Search websites..." />
 												<CommandGroup>
 													{(websites as Website[]).map((website) => (
 														<CommandItem

--- a/apps/dashboard/components/ui/button.tsx
+++ b/apps/dashboard/components/ui/button.tsx
@@ -12,9 +12,9 @@ const buttonVariants = cva(
 				default:
 					'bg-primary text-primary-foreground hover:bg-primary/90 disabled:bg-accent-disabled disabled:text-neutral-500',
 				destructive:
-					'bg-destructive text-white disabled:bg-accent-disabled disabled:text-neutral-500  hover:bg-destructive-brighter focus-visible:ring-destructive/20',
+					'bg-destructive text-white disabled:bg-accent-disabled disabled:border-accent-disabled disabled:text-neutral-500 hover:bg-destructive-brighter focus-visible:ring-destructive/20',
 				outline:
-					'border text-accent-foreground bg-transparent hover:border-transparent disabled:bg-accent-disabled disabled:text-neutral-400  hover:bg-secondary hover:text-accent-foreground',
+					'border text-accent-foreground disabled:border-accent-disabled bg-transparent disabled:bg-accent-disabled disabled:text-muted-foreground hover:bg-secondary hover:text-accent-foreground',
 				secondary:
 					'bg-secondary  text-accent-foreground hover:bg-secondary-brighter disabled:bg-accent-disabled disabled:text-neutral-500',
 				ghost:

--- a/apps/dashboard/components/ui/tabs.tsx
+++ b/apps/dashboard/components/ui/tabs.tsx
@@ -75,7 +75,7 @@ function TabsList({
 
 	useLayoutEffect(() => {
 		if (
-			(variant !== "underline" && variant !== "navigation") ||
+			(!["navigation", "underline", "default"].includes(variant) ) ||
 			!listRef.current ||
 			!activeValue
 		)
@@ -149,6 +149,7 @@ function TabsList({
 
 	// Default variant
 	return (
+		<div className="relative">
 		<TabsPrimitive.List
 			className={cn(
 				"inline-flex h-9 w-fit items-center justify-center rounded bg-accent-brighter p-[3px] text-muted-foreground",
@@ -158,6 +159,11 @@ function TabsList({
 			ref={listRef}
 			{...props}
 		/>
+		<div
+					className="absolute inset-0 top-1 bottom-1 z-0 rounded-md bg-secondary-brightest border border-accent-foreground/10 w-full transition-all duration-200 ease-out"
+					style={indicatorStyle}
+				/>
+		</div>
 	);
 }
 
@@ -248,10 +254,11 @@ function TabsTrigger({
 	return (
 		<TabsPrimitive.Trigger
 			className={cn(
-				"inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1",
+				"z-5 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1",
 				"font-medium text-muted-foreground data-[state=active]:text-foreground text-sm transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px]",
-				"focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:border-accent-foreground/10",
-				"data-[state=active]:bg-secondary-brightest [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				"focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 _data-[state=active]:border-accent-foreground/10",
+				"_data-[state=active]:bg-secondary-brightest [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				 // disable trigger active styling so TabList default `absolute` indicator animation is visible
 				className
 			)}
 			data-slot="tabs-trigger"

--- a/apps/dashboard/components/ui/tabs.tsx
+++ b/apps/dashboard/components/ui/tabs.tsx
@@ -254,7 +254,7 @@ function TabsTrigger({
 	return (
 		<TabsPrimitive.Trigger
 			className={cn(
-				"z-5 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1",
+				"z-1 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1",
 				"font-medium text-muted-foreground data-[state=active]:text-foreground text-sm transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px]",
 				"focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 _data-[state=active]:border-accent-foreground/10",
 				"_data-[state=active]:bg-secondary-brightest [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",

--- a/apps/dashboard/components/ui/tabs.tsx
+++ b/apps/dashboard/components/ui/tabs.tsx
@@ -256,9 +256,10 @@ function TabsTrigger({
 			className={cn(
 				"z-1 inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 whitespace-nowrap rounded-md border border-transparent px-2 py-1",
 				"font-medium text-muted-foreground data-[state=active]:text-foreground text-sm transition-[color,box-shadow] focus-visible:border-ring focus-visible:outline-1 focus-visible:outline-ring focus-visible:ring-[3px]",
-				"focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 _data-[state=active]:border-accent-foreground/10",
-				"_data-[state=active]:bg-secondary-brightest [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
-				 // disable trigger active styling so TabList default `absolute` indicator animation is visible
+				"focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50",
+				" [&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+				// "data-[state=active]:bg-secondary-brightest data-[state=active]:border-accent-foreground/10",
+				 // disable trigger active styling so TabList default `absolute` indicator is visible 
 				className
 			)}
 			data-slot="tabs-trigger"

--- a/apps/docs/content/docs/api-keys.mdx
+++ b/apps/docs/content/docs/api-keys.mdx
@@ -21,9 +21,14 @@ An API key authenticates server-to-server calls to Databuddy. It supports fine-g
 ### Create a key
 
 1. Open [Organization Settings → API Keys](https://app.databuddy.cc/organizations/settings/api-keys)
-2. Click “Create API Key”
-3. Choose a name, optional organization, scopes, and resource access
-4. Copy the secret immediately (it’s only shown once)
+2. Click "Create API Key"
+3. Enter a key name
+4. Choose how broad the key should be:
+   - `All`: grants all available scopes across the organization
+   - `Restricted`: lets you customize the key's global scopes
+   - `Read data only`: quickly creates a read-only key
+5. Optionally select specific websites to limit the key to those websites only
+6. Copy the secret immediately (it's only shown once)
 
 We only display the `prefix` and first characters (`start`) later for identification. Never share the full secret.
 
@@ -59,12 +64,16 @@ Grant only what you need. Prefer resource-scoped access where possible.
 
 ### Resource access
 
+API keys are created from Organization Settings and default to organization-wide access.
+
 Access can be scoped to:
 
-- **global**: Applies to all websites in the organization
-- **website**: Applies to a specific website only
+- **global**: Applies the selected scopes to all websites in the organization
+- **website**: Applies the selected scopes only to the specific websites you choose
 
-Example: a key with `read:data` scoped to a single website can read analytics only for that website, not others in the organization.
+If you add website restrictions, the key no longer inherits global read access by default.
+
+Example: a key with `read:data` limited to a single website can read analytics only for that website, not others in the organization.
 
 ### Errors
 
@@ -115,6 +124,7 @@ Logs include IP addresses, user agents, and timestamps for security monitoring.
 - Treat API keys like passwords; don't commit them to source control
 - Use environment variables or secret managers
 - Share only the prefix and `start` snippet for identification
+- Start with `Read data only` or `Restricted` when full global access is not needed
 - Use least-privilege scopes and resource scoping
 - Rotate keys periodically and revoke unused keys
 - Monitor audit logs for suspicious activity

--- a/apps/docs/content/docs/api/authentication.mdx
+++ b/apps/docs/content/docs/api/authentication.mdx
@@ -30,7 +30,10 @@ Alternatively, use Bearer token format:
 1. Go to **[Dashboard → Organization Settings → API Keys](https://app.databuddy.cc/organizations/settings/api-keys)**
 2. Click **Create API Key**
 3. Enter a descriptive name (e.g., "Production Server", "CI Pipeline")
-4. Select the required scopes
+4. Choose a preset:
+   - **All** for full organization-wide access
+   - **Restricted** to customize global scopes
+   - **Read data only** for a quick read-only key
 5. Optionally restrict access to specific websites
 6. Copy and securely store your key — it won't be shown again
 
@@ -59,14 +62,14 @@ API keys can have two access levels:
 
 ### Global Access
 
-Access all websites in your account or organization. Best for:
+Access all websites in your account or organization with the selected global scopes. Best for:
 - Internal dashboards
 - Automated reporting
 - Organization-wide analytics
 
 ### Website-Specific Access
 
-Access only specified websites. Best for:
+Access only specified websites. Restricted keys do not inherit a default global `read:data` scope. Best for:
 - Third-party integrations
 - Client-specific keys
 - Least-privilege security

--- a/apps/docs/content/docs/api/index.mdx
+++ b/apps/docs/content/docs/api/index.mdx
@@ -22,6 +22,8 @@ Access your analytics data programmatically with Databuddy's REST API. All endpo
 
 **1. Get your API key** from [Dashboard → Organization Settings → API Keys](https://app.databuddy.cc/organizations/settings/api-keys)
 
+API keys start with organization-wide access by default, and you can switch to restricted scopes or limit a key to specific websites during creation.
+
 **2. List your websites:**
 
 <CodeBlock 


### PR DESCRIPTION
### Description
- replace the API key dialog's manual selects with preset global permission tabs and a searchable website picker
- default newly selected websites to the current global scopes to reduce repetitive permission setup
- simplify API key resource submission so global access is only sent when no website-specific restrictions are chosen
- handcrafted with minimal AI assistance
- polished button and tabs components styling inline with established design system


https://github.com/user-attachments/assets/cda63493-6007-4a34-83b6-284eac687ba5


<details>
<summary>Checklist</summary>

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings
- [  ] I have added tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes 

</details>