### PR TITLE
feat(flags): add folder organization system for feature flags (#271)

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -245,6 +245,7 @@ export function FlagSheet({
 				variants: [],
 				dependencies: [],
 				environment: undefined,
+				folder: undefined,
 				targetGroupIds: [],
 			},
 			schedule: undefined,
@@ -287,6 +288,7 @@ export function FlagSheet({
 					variants: flag.variants ?? [],
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
+					folder: flag.folder ?? undefined,
 					targetGroupIds: extractTargetGroupIds(),
 				},
 				schedule: undefined,
@@ -394,6 +396,7 @@ export function FlagSheet({
 					variants: data.variants || [],
 					dependencies: data.dependencies || [],
 					environment: data.environment?.trim() || undefined,
+					folder: data.folder?.trim() || null,
 					defaultValue: data.defaultValue,
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
@@ -412,6 +415,7 @@ export function FlagSheet({
 					variants: data.variants || [],
 					dependencies: data.dependencies || [],
 					environment: data.environment?.trim() || undefined,
+					folder: data.folder?.trim() || null,
 					defaultValue: data.defaultValue,
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
@@ -548,6 +552,28 @@ export function FlagSheet({
 									)}
 								/>
 							</div>
+
+							{/* Folder (optional) */}
+							<FormField
+								control={form.control}
+								name="flag.folder"
+								render={({ field }) => (
+									<FormItem>
+										<FormLabel className="text-muted-foreground">
+											Folder (optional)
+										</FormLabel>
+										<FormControl>
+											<Input
+												placeholder="e.g. payments, experiments/beta…"
+												{...field}
+												value={field.value ?? ""}
+												onChange={(e) => field.onChange(e.target.value || undefined)}
+											/>
+										</FormControl>
+										<FormMessage />
+									</FormItem>
+								)}
+							/>
 
 							{/* Separator */}
 							<div className="h-px bg-border" />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -2,9 +2,13 @@
 
 import {
 	ArchiveIcon,
+	CaretDownIcon,
+	CaretRightIcon,
 	DotsThreeIcon,
 	FlagIcon,
 	FlaskIcon,
+	FolderIcon,
+	FolderOpenIcon,
 	GaugeIcon,
 	LinkIcon,
 	PencilSimpleIcon,
@@ -12,7 +16,7 @@ import {
 	TrashIcon,
 } from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { List } from "@/components/ui/composables/list";
@@ -404,6 +408,65 @@ function FlagRow({
 	);
 }
 
+function FolderSection({
+	name,
+	flags,
+	flagMap,
+	dependentsMap,
+	groups,
+	onEdit,
+	onDelete,
+}: {
+	name: string;
+	flags: Flag[];
+	flagMap: Map<string, Flag>;
+	dependentsMap: Map<string, Flag[]>;
+	groups: Map<string, TargetGroup[]>;
+	onEdit: (flag: Flag) => void;
+	onDelete: (flagId: string) => void;
+}) {
+	const [open, setOpen] = useState(true);
+
+	return (
+		<div className="mb-1">
+			<button
+				type="button"
+				onClick={() => setOpen((v) => !v)}
+				className="flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted/50 transition-colors"
+			>
+				{open ? (
+					<>
+						<FolderOpenIcon size={15} className="text-amber-500" />
+						<CaretDownIcon size={12} />
+					</>
+				) : (
+					<>
+						<FolderIcon size={15} className="text-amber-500" />
+						<CaretRightIcon size={12} />
+					</>
+				)}
+				<span>{name}</span>
+				<span className="ml-auto text-xs text-muted-foreground/60">{flags.length}</span>
+			</button>
+			{open && (
+				<List className="rounded bg-card ml-2 border-l border-border/50 pl-1">
+					{flags.map((flag) => (
+						<FlagRow
+							dependents={dependentsMap.get(flag.key) ?? []}
+							flag={flag}
+							flagMap={flagMap}
+							groups={groups.get(flag.id) ?? []}
+							key={flag.id}
+							onDelete={onDelete}
+							onEdit={onEdit}
+						/>
+					))}
+				</List>
+			)}
+		</div>
+	);
+}
+
 export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 	const flagMap = useMemo(() => {
 		const map = new Map<string, Flag>();
@@ -427,20 +490,64 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 		return map;
 	}, [flags]);
 
+	// Group flags by folder; flags without a folder go into the root (null) group
+	const { folderGroups, rootFlags } = useMemo(() => {
+		const byFolder = new Map<string, Flag[]>();
+		const root: Flag[] = [];
+		for (const f of flags) {
+			if (f.folder) {
+				const existing = byFolder.get(f.folder) ?? [];
+				existing.push(f);
+				byFolder.set(f.folder, existing);
+			} else {
+				root.push(f);
+			}
+		}
+		// Sort folder names alphabetically for stable UI
+		const sortedFolders = [...byFolder.entries()].sort(([a], [b]) =>
+			a.localeCompare(b)
+		);
+		return { folderGroups: sortedFolders, rootFlags: root };
+	}, [flags]);
+
+	const hasFolders = folderGroups.length > 0;
+
 	return (
-		<List className="rounded bg-card">
-			{flags.map((flag) => (
-				<FlagRow
-					dependents={dependentsMap.get(flag.key) ?? []}
-					flag={flag}
-					flagMap={flagMap}
-					groups={groups.get(flag.id) ?? []}
-					key={flag.id}
-					onDelete={onDelete}
-					onEdit={onEdit}
-				/>
-			))}
-		</List>
+		<div>
+			{/* Folder sections */}
+			{hasFolders && (
+				<div className="mb-2">
+					{folderGroups.map(([folderName, folderFlags]) => (
+						<FolderSection
+							key={folderName}
+							name={folderName}
+							flags={folderFlags}
+							flagMap={flagMap}
+							dependentsMap={dependentsMap}
+							groups={groups}
+							onEdit={onEdit}
+							onDelete={onDelete}
+						/>
+					))}
+				</div>
+			)}
+			{/* Root (unfiled) flags */}
+			{rootFlags.length > 0 && (
+				<List className="rounded bg-card">
+					{rootFlags.map((flag) => (
+						<FlagRow
+							dependents={dependentsMap.get(flag.key) ?? []}
+							flag={flag}
+							flagMap={flagMap}
+							groups={groups.get(flag.id) ?? []}
+							key={flag.id}
+							onDelete={onDelete}
+							onEdit={onEdit}
+						/>
+					))}
+				</List>
+			)}
+		</div>
 	);
 }
 

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -22,6 +22,7 @@ export interface Flag {
 	variants?: Variant[];
 	dependencies?: string[];
 	environment?: string;
+	folder?: string | null;
 	persistAcrossAuth?: boolean;
 	websiteId?: string | null;
 	organizationId?: string | null;

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -684,6 +684,7 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -101,6 +101,7 @@ const createFlagSchema = z
 		organizationId: z.string().optional(),
 		payload: z.any().optional(),
 		persistAcrossAuth: z.boolean().optional(),
+		folder: z.string().max(100).nullable().optional(),
 		...flagFormSchema.shape,
 	})
 	.refine((data) => data.websiteId || data.organizationId, {
@@ -125,6 +126,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(100).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -572,6 +574,7 @@ export const flagsRouter = {
 							variants: input.variants,
 							dependencies: input.dependencies,
 							environment: input.environment,
+							folder: input.folder !== undefined ? input.folder : existingFlag[0].folder,
 							deletedAt: null,
 							updatedAt: new Date(),
 						})
@@ -629,6 +632,7 @@ export const flagsRouter = {
 						websiteId: input.websiteId || null,
 						organizationId: input.organizationId || null,
 						environment: input.environment || existingFlag?.[0]?.environment,
+						folder: input.folder ?? null,
 						userId: null,
 						createdBy,
 					})


### PR DESCRIPTION
Closes #271
/claim #271

Implements UI-only folder organization for feature flags, strictly following the issue spec:

> This is **purely for UI organization** and should **NOT affect any business logic** — flag evaluation, dependencies, API responses, and SDK behavior must remain unchanged.

## What changed

| File | Change |
|------|--------|
| `packages/db/src/drizzle/schema.ts` | Add nullable `folder` text column to `flags` table |
| `packages/rpc/src/routers/flags.ts` | Add `folder` field to create/update schemas and DB writes |
| `flags/_components/types.ts` | Add `folder?: string | null` to Flag type |
| `flags/_components/flags-list.tsx` | Collapsible folder sections grouped alphabetically |
| `flags/_components/flag-sheet.tsx` | Folder input field in create/edit form |

## Bugs fixed vs existing PRs

| Bug | Other PRs | This PR |
|-----|-----------|---------|
| Corrupted property name | ❌ `tttttfolder` typo in #350 | ✅ `folder` correctly named |
| Stale folder state in modal | ❌ useState initialized once | ✅ Reads from `flag.folder` on form reset |
| onChange not wired | ❌ popover/input not connected | ✅ Proper `onChange` handler |
| No business logic change | ❌ some PRs touch evaluation | ✅ Only schema + UI metadata |

## UX

- Flags with a folder appear under collapsible folder headers (sorted A–Z)
- Unfiled flags appear below folder sections as before
- Folder input is optional — leaving it blank keeps the flag at root level
- Folder sections show flag count and expand/collapse independently
- Icons: `@phosphor-icons/react` (FolderIcon, FolderOpenIcon, CaretDownIcon, CaretRightIcon)