### PR TITLE
feat: add healthchecks to Dockerfiles for api, basket, links, and uptime services

### DIFF
--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -32,4 +32,10 @@ EXPOSE 3001
 
 WORKDIR /app/apps/api
 
+COPY healthcheck.ts /app/healthcheck.ts
+ENV HEALTHCHECK_PORT=3001
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["bun", "/app/healthcheck.ts"]
+
 CMD ["bun", "run", "src/index.ts"]

--- a/basket.Dockerfile
+++ b/basket.Dockerfile
@@ -27,14 +27,20 @@ RUN bun build \
 	--bytecode \
 	./src/index.ts
 
-FROM gcr.io/distroless/cc
+FROM oven/bun:1.3.4-distroless
 
 WORKDIR /app
 
 COPY --from=build /app/server server
+COPY healthcheck.ts healthcheck.ts
 
 ENV NODE_ENV=production
+ENV HEALTHCHECK_PORT=4000
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["bun", "/app/healthcheck.ts"]
+
+ENTRYPOINT []
 CMD ["./server"]
 
 EXPOSE 4000

--- a/healthcheck.ts
+++ b/healthcheck.ts
@@ -1,0 +1,3 @@
+const port = process.env.HEALTHCHECK_PORT ?? process.env.PORT ?? "3000";
+const r = await fetch(`http://localhost:${port}/health`);
+process.exit(r.ok ? 0 : 1);

--- a/links.Dockerfile
+++ b/links.Dockerfile
@@ -28,14 +28,20 @@ RUN bun build \
 	--bytecode \
 	./src/index.ts
 
-FROM gcr.io/distroless/base
+FROM oven/bun:1.3.4-distroless
 
 WORKDIR /app
 
 COPY --from=build /app/server server
+COPY healthcheck.ts healthcheck.ts
 
 ENV NODE_ENV=production
+ENV HEALTHCHECK_PORT=2500
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["bun", "/app/healthcheck.ts"]
+
+ENTRYPOINT []
 CMD ["./server"]
 
 EXPOSE 2500

--- a/uptime.Dockerfile
+++ b/uptime.Dockerfile
@@ -23,14 +23,20 @@ RUN bun build \
     --bytecode \
     ./apps/uptime/src/index.ts
 
-FROM gcr.io/distroless/base
+FROM oven/bun:1.3.4-distroless
 
 WORKDIR /app
 
 COPY --from=build /app/server server
+COPY healthcheck.ts healthcheck.ts
 
 ENV NODE_ENV=production
+ENV HEALTHCHECK_PORT=4000
 
+HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+  CMD ["bun", "/app/healthcheck.ts"]
+
+ENTRYPOINT []
 CMD ["./server"]
 
 EXPOSE 4000


### PR DESCRIPTION
● ## Description    
                                                                                                                                                                                  
  Add production-ready `HEALTHCHECK` instructions to all four service Dockerfiles, enabling Docker to natively monitor container health.                                          
                                                                                                                                                                                  
  **Changes:**                                                                                                                                                                    
                                                                                                                                                                                  
  - **api.Dockerfile** — added HEALTHCHECK using shared `healthcheck.ts` script via `bun` (exec form)                                                                             
  - **basket.Dockerfile** — switched runtime from `gcr.io/distroless/cc` to `oven/bun:1.3.4-distroless` (preserves distroless security posture), added `ENTRYPOINT []` to prevent 
  bun from interpreting the compiled binary as JS, added HEALTHCHECK                                                                                                              
  - **links.Dockerfile** — same pattern as basket, runtime switched from `gcr.io/distroless/base` to `oven/bun:1.3.4-distroless`, port 2500                                       
  - **uptime.Dockerfile** — same pattern, runtime switched from `gcr.io/distroless/base` to `oven/bun:1.3.4-distroless`, port 4000                                                
  - **healthcheck.ts** — shared 3-line script that fetches `/health` using `HEALTHCHECK_PORT` env var, used by all 4 services                                                     
                                                                                                                                                                                  
  All health checks use exec form (`CMD ["bun", "/app/healthcheck.ts"]`) which works in distroless without a shell. Build stage versions are untouched.                           
                                                                                                                                                                                  
  **HEALTHCHECK config:** `--interval=30s --timeout=3s --start-period=10s --retries=3`                                                                                            
                                                                                                                                                                                  
  <details>                                                                                                                                                                       
  <summary>Checklist</summary>                                                                                                                                                    
                                                                                                                                                                                  
  - [x] My code follows the style guidelines of this project                                                                                                                      
  - [x] I have performed a self-review of my code                                                                                                                                 
  - [ ] I have commented my code, particularly in hard-to-understand areas                                                                                                        
  - [ ] I have made corresponding changes to the documentation                                                                                                                    
  - [x] My changes generate no new warnings                                                                                                                                       
  - [ ] I have added tests that prove my fix is effective or that my feature works                                                                                                
  - [x] New and existing unit tests pass locally with my changes                                                                                                                  
                                                                                                                                                                                  
  </details>                                                                                                                                                                      
             