### PR TITLE
feat(flags): add folder organization for feature flags

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flag-sheet.tsx
@@ -244,6 +244,7 @@ export function FlagSheet({
 				dependencies: [],
 				environment: undefined,
 				targetGroupIds: [],
+				folder: undefined,
 			},
 			schedule: undefined,
 		},
@@ -286,6 +287,7 @@ export function FlagSheet({
 					dependencies: flag.dependencies ?? [],
 					environment: flag.environment || undefined,
 					targetGroupIds: extractTargetGroupIds(),
+					folder: (flag.folder as string | undefined) || undefined,
 				},
 				schedule: undefined,
 			});
@@ -396,6 +398,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || null,
 				};
 				await updateMutation.mutateAsync(updateData);
 			} else {
@@ -414,6 +417,7 @@ export function FlagSheet({
 					rolloutPercentage: data.rolloutPercentage ?? 0,
 					rolloutBy: data.rolloutBy || undefined,
 					targetGroupIds: data.targetGroupIds || [],
+					folder: data.folder?.trim() || undefined,
 				};
 				await createMutation.mutateAsync(createData);
 			}
@@ -539,6 +543,26 @@ export function FlagSheet({
 													className="min-h-16 resize-none"
 													placeholder="What does this flag control?…"
 													{...field}
+												/>
+											</FormControl>
+											<FormMessage />
+										</FormItem>
+									)}
+								/>
+
+								<FormField
+									control={form.control}
+									name="flag.folder"
+									render={({ field }) => (
+										<FormItem>
+											<FormLabel className="text-muted-foreground">
+												Folder (optional)
+											</FormLabel>
+											<FormControl>
+												<Input
+													placeholder="e.g. auth/login or payments"
+													{...field}
+													value={field.value ?? ""}
 												/>
 											</FormControl>
 											<FormMessage />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -1,14 +1,17 @@
 "use client";
 
-import { ArchiveIcon } from "@phosphor-icons/react";
-import { DotsThreeIcon } from "@phosphor-icons/react";
-import { FlagIcon } from "@phosphor-icons/react";
-import { FlaskIcon } from "@phosphor-icons/react";
-import { GaugeIcon } from "@phosphor-icons/react";
-import { LinkIcon } from "@phosphor-icons/react";
-import { PencilSimpleIcon } from "@phosphor-icons/react";
-import { ShareNetworkIcon } from "@phosphor-icons/react";
-import { TrashIcon } from "@phosphor-icons/react";
+import {
+	ArchiveIcon,
+	DotsThreeIcon,
+	FlagIcon,
+	FlaskIcon,
+	FolderIcon,
+	GaugeIcon,
+	LinkIcon,
+	PencilSimpleIcon,
+	ShareNetworkIcon,
+	TrashIcon,
+} from "@phosphor-icons/react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { Badge } from "@/components/ui/badge";
@@ -329,7 +332,15 @@ function FlagRow({
 									flagMap={flagMap}
 								/>
 							</div>
-							<FlagKey className="-ms-1.5 max-w-full" flag={flag} />
+							<div className="flex items-center gap-2">
+								<FlagKey className="-ms-1.5 max-w-full" flag={flag} />
+								{flag.folder && (
+									<span className="flex items-center gap-1 text-muted-foreground text-xs">
+										<FolderIcon className="size-3" weight="duotone" />
+										{flag.folder}
+									</span>
+								)}
+							</div>
 						</div>
 					</div>
 				</List.Cell>

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -13,6 +13,7 @@ export interface Flag {
 	dependencies?: string[];
 	description?: string | null;
 	environment?: string;
+	folder?: string | null;
 	id: string;
 	key: string;
 	name?: string | null;

--- a/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
-import { FlagIcon } from "@phosphor-icons/react";
+import { FlagIcon, FolderIcon, FolderOpenIcon, StackIcon } from "@phosphor-icons/react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useParams } from "next/navigation";
@@ -10,11 +10,103 @@ import { EmptyState } from "@/components/empty-state";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { FeatureGate } from "@/components/feature-gate";
 import { DeleteDialog } from "@/components/ui/delete-dialog";
+import { cn } from "@/lib/utils";
 import { orpc } from "@/lib/orpc";
 import { isFlagSheetOpenAtom } from "@/stores/jotai/flagsAtoms";
 import { FlagSheet } from "./_components/flag-sheet";
 import { FlagsList, FlagsListSkeleton } from "./_components/flags-list";
 import type { Flag, TargetGroup } from "./_components/types";
+
+const ALL_FOLDERS = "__all__";
+const UNCATEGORIZED = "__uncategorized__";
+
+function FolderNav({
+	folders,
+	activeFolder,
+	totalCount,
+	uncategorizedCount,
+	onSelectFolder,
+}: {
+	folders: string[];
+	activeFolder: string;
+	totalCount: number;
+	uncategorizedCount: number;
+	onSelectFolder: (folder: string) => void;
+}) {
+	if (folders.length === 0) return null;
+
+	return (
+		<nav className="w-48 shrink-0 border-border/60 border-r pr-3">
+			<p className="mb-2 px-2 font-medium text-muted-foreground text-xs uppercase tracking-wider">
+				Folders
+			</p>
+			<ul className="space-y-0.5">
+				<li>
+					<button
+						className={cn(
+							"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+							activeFolder === ALL_FOLDERS
+								? "bg-primary/10 font-medium text-primary"
+								: "text-muted-foreground hover:bg-accent hover:text-foreground"
+						)}
+						onClick={() => onSelectFolder(ALL_FOLDERS)}
+						type="button"
+					>
+						<StackIcon className="size-4 shrink-0" weight="duotone" />
+						<span className="flex-1 truncate">All Flags</span>
+						<span className="rounded bg-accent px-1.5 py-0.5 font-mono text-muted-foreground text-xs">
+							{totalCount}
+						</span>
+					</button>
+				</li>
+				{folders.map((folder) => {
+					const isActive = activeFolder === folder;
+					return (
+						<li key={folder}>
+							<button
+								className={cn(
+									"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+									isActive
+										? "bg-primary/10 font-medium text-primary"
+										: "text-muted-foreground hover:bg-accent hover:text-foreground"
+								)}
+								onClick={() => onSelectFolder(folder)}
+								type="button"
+							>
+								{isActive ? (
+									<FolderOpenIcon className="size-4 shrink-0" weight="duotone" />
+								) : (
+									<FolderIcon className="size-4 shrink-0" weight="duotone" />
+								)}
+								<span className="flex-1 truncate">{folder}</span>
+							</button>
+						</li>
+					);
+				})}
+				{uncategorizedCount > 0 && (
+					<li>
+						<button
+							className={cn(
+								"flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors",
+								activeFolder === UNCATEGORIZED
+									? "bg-primary/10 font-medium text-primary"
+									: "text-muted-foreground hover:bg-accent hover:text-foreground"
+							)}
+							onClick={() => onSelectFolder(UNCATEGORIZED)}
+							type="button"
+						>
+							<FolderIcon className="size-4 shrink-0 opacity-40" weight="duotone" />
+							<span className="flex-1 truncate italic">Uncategorized</span>
+							<span className="rounded bg-accent px-1.5 py-0.5 font-mono text-muted-foreground text-xs">
+								{uncategorizedCount}
+							</span>
+						</button>
+					</li>
+				)}
+			</ul>
+		</nav>
+	);
+}
 
 export default function FlagsPage() {
 	const { id } = useParams();
@@ -23,15 +115,31 @@ export default function FlagsPage() {
 	const [isFlagSheetOpen, setIsFlagSheetOpen] = useAtom(isFlagSheetOpenAtom);
 	const [editingFlag, setEditingFlag] = useState<Flag | null>(null);
 	const [flagToDelete, setFlagToDelete] = useState<Flag | null>(null);
+	const [activeFolder, setActiveFolder] = useState<string>(ALL_FOLDERS);
 
 	const { data: flags, isLoading: flagsLoading } = useQuery({
 		...orpc.flags.list.queryOptions({ input: { websiteId } }),
+	});
+
+	const { data: folderList = [] } = useQuery({
+		...orpc.flags.listFolders.queryOptions({ input: { websiteId } }),
 	});
 
 	const activeFlags = useMemo(
 		() => flags?.filter((f) => f.status !== "archived") ?? [],
 		[flags]
 	);
+
+	const uncategorizedCount = useMemo(
+		() => activeFlags.filter((f) => !f.folder).length,
+		[activeFlags]
+	);
+
+	const filteredFlags = useMemo(() => {
+		if (activeFolder === ALL_FOLDERS) return activeFlags;
+		if (activeFolder === UNCATEGORIZED) return activeFlags.filter((f) => !f.folder);
+		return activeFlags.filter((f) => f.folder === activeFolder);
+	}, [activeFlags, activeFolder]);
 
 	const groupsMap = useMemo(() => {
 		const map = new Map<string, TargetGroup[]>();
@@ -57,6 +165,9 @@ export default function FlagsPage() {
 		onSuccess: () => {
 			queryClient.invalidateQueries({
 				queryKey: orpc.flags.list.key({ input: { websiteId } }),
+			});
+			queryClient.invalidateQueries({
+				queryKey: orpc.flags.listFolders.key({ input: { websiteId } }),
 			});
 		},
 	});
@@ -88,58 +199,85 @@ export default function FlagsPage() {
 	const handleFlagSheetClose = () => {
 		setIsFlagSheetOpen(false);
 		setEditingFlag(null);
+		queryClient.invalidateQueries({
+			queryKey: orpc.flags.listFolders.key({ input: { websiteId } }),
+		});
 	};
+
+	const hasFolders = folderList.length > 0;
 
 	return (
 		<FeatureGate feature={GATED_FEATURES.FEATURE_FLAGS}>
 			<ErrorBoundary>
-				<div className="h-full overflow-y-auto">
-					<Suspense fallback={<FlagsListSkeleton />}>
-						{flagsLoading ? (
-							<FlagsListSkeleton />
-						) : activeFlags.length === 0 ? (
-							<div className="flex flex-1 items-center justify-center py-16">
-								<EmptyState
-									action={{
-										label: "Create Your First Flag",
-										onClick: handleCreateFlag,
-									}}
-									description="Create your first feature flag to start controlling feature rollouts and A/B testing across your application."
-									icon={<FlagIcon weight="duotone" />}
-									title="No feature flags yet"
-									variant="minimal"
-								/>
-							</div>
-						) : (
-							<FlagsList
-								flags={activeFlags as unknown as Flag[]}
-								groups={groupsMap}
-								onDelete={handleDeleteFlagRequest}
-								onEdit={handleEditFlag}
+				<div className="flex h-full overflow-hidden">
+					{hasFolders && (
+						<div className="flex h-full shrink-0 overflow-y-auto py-4 pl-4">
+							<FolderNav
+								activeFolder={activeFolder}
+								folders={folderList}
+								onSelectFolder={setActiveFolder}
+								totalCount={activeFlags.length}
+								uncategorizedCount={uncategorizedCount}
 							/>
-						)}
-					</Suspense>
-
-					{isFlagSheetOpen && (
-						<Suspense fallback={null}>
-							<FlagSheet
-								flag={editingFlag}
-								isOpen={isFlagSheetOpen}
-								onCloseAction={handleFlagSheetClose}
-								websiteId={websiteId}
-							/>
-						</Suspense>
+						</div>
 					)}
-
-					<DeleteDialog
-						isDeleting={deleteFlagMutation.isPending}
-						isOpen={flagToDelete !== null}
-						itemName={flagToDelete?.name || flagToDelete?.key}
-						onClose={() => setFlagToDelete(null)}
-						onConfirm={handleConfirmDelete}
-						title="Delete Feature Flag"
-					/>
+					<div className="min-w-0 flex-1 overflow-y-auto">
+						<Suspense fallback={<FlagsListSkeleton />}>
+							{flagsLoading ? (
+								<FlagsListSkeleton />
+							) : activeFlags.length === 0 ? (
+								<div className="flex flex-1 items-center justify-center py-16">
+									<EmptyState
+										action={{
+											label: "Create Your First Flag",
+											onClick: handleCreateFlag,
+										}}
+										description="Create your first feature flag to start controlling feature rollouts and A/B testing across your application."
+										icon={<FlagIcon weight="duotone" />}
+										title="No feature flags yet"
+										variant="minimal"
+									/>
+								</div>
+							) : filteredFlags.length === 0 ? (
+								<div className="flex flex-1 items-center justify-center py-16">
+									<EmptyState
+										description="No flags in this folder yet."
+										icon={<FolderOpenIcon weight="duotone" />}
+										title="Empty folder"
+										variant="minimal"
+									/>
+								</div>
+							) : (
+								<FlagsList
+									flags={filteredFlags as Flag[]}
+									groups={groupsMap}
+									onDelete={handleDeleteFlagRequest}
+									onEdit={handleEditFlag}
+								/>
+							)}
+						</Suspense>
+					</div>
 				</div>
+
+				{isFlagSheetOpen && (
+					<Suspense fallback={null}>
+						<FlagSheet
+							flag={editingFlag}
+							isOpen={isFlagSheetOpen}
+							onCloseAction={handleFlagSheetClose}
+							websiteId={websiteId}
+						/>
+					</Suspense>
+				)}
+
+				<DeleteDialog
+					isDeleting={deleteFlagMutation.isPending}
+					isOpen={flagToDelete !== null}
+					itemName={flagToDelete?.name || flagToDelete?.key}
+					onClose={() => setFlagToDelete(null)}
+					onConfirm={handleConfirmDelete}
+					title="Delete Feature Flag"
+				/>
 			</ErrorBoundary>
 		</FeatureGate>
 	);

--- a/packages/db/src/drizzle/schema.ts
+++ b/packages/db/src/drizzle/schema.ts
@@ -731,11 +731,13 @@ export const flags = pgTable(
 		dependencies: text("dependencies").array(),
 		targetGroupIds: text("target_group_ids").array(),
 		environment: text("environment"),
+		folder: text("folder"),
 		createdAt: timestamp("created_at").defaultNow().notNull(),
 		updatedAt: timestamp("updated_at").defaultNow().notNull(),
 		deletedAt: timestamp("deleted_at"),
 	},
 	(table) => [
+		index("idx_flags_folder").on(table.websiteId, table.folder),
 		uniqueIndex("flags_key_website_unique")
 			.on(table.key, table.websiteId)
 			.where(isNotNull(table.websiteId)),

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -1,5 +1,6 @@
 import {
 	and,
+	asc,
 	desc,
 	eq,
 	flags,
@@ -9,7 +10,6 @@ import {
 	isNull,
 	ne,
 	notDeleted,
-	sql,
 	targetGroups,
 	withTransaction,
 } from "@databuddy/db";
@@ -885,7 +885,7 @@ export const flagsRouter = {
 						isNotNull(flags.folder)
 					)
 				)
-				.orderBy(sql`${flags.folder} asc`);
+				.orderBy(asc(flags.folder));
 
 			return rows.map((r) => r.folder as string);
 		}),

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -5,9 +5,11 @@ import {
 	flags,
 	flagsToTargetGroups,
 	inArray,
+	isNotNull,
 	isNull,
 	ne,
 	notDeleted,
+	sql,
 	targetGroups,
 	withTransaction,
 } from "@databuddy/db";
@@ -129,6 +131,7 @@ const updateFlagSchema = z
 		dependencies: z.array(z.string()).optional(),
 		environment: z.string().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(100).nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {
@@ -634,6 +637,7 @@ export const flagsRouter = {
 						websiteId: input.websiteId || null,
 						organizationId: input.organizationId || null,
 						environment: input.environment || existingFlag?.[0]?.environment,
+						folder: input.folder || null,
 						userId: null,
 						createdBy,
 					})
@@ -840,6 +844,50 @@ export const flagsRouter = {
 				await handleFlagUpdateDependencyCascading({ updatedFlag });
 			}
 			return updatedFlag;
+		}),
+
+	listFolders: protectedProcedure
+		.route({
+			description:
+				"Returns distinct folder paths for flags in a website or organization.",
+			method: "POST",
+			path: "/flags/listFolders",
+			summary: "List flag folders",
+			tags: ["Flags"],
+		})
+		.input(
+			z
+				.object({
+					websiteId: z.string().optional(),
+					organizationId: z.string().optional(),
+				})
+				.refine((d) => d.websiteId || d.organizationId, {
+					message: "Either websiteId or organizationId must be provided",
+					path: ["websiteId"],
+				})
+		)
+		.output(z.array(z.string()))
+		.handler(async ({ context, input }) => {
+			await authorizeScope(
+				context,
+				input.websiteId,
+				input.organizationId,
+				"read"
+			);
+
+			const rows = await context.db
+				.selectDistinct({ folder: flags.folder })
+				.from(flags)
+				.where(
+					and(
+						getScopeCondition(input.websiteId, input.organizationId),
+						isNull(flags.deletedAt),
+						isNotNull(flags.folder)
+					)
+				)
+				.orderBy(sql`${flags.folder} asc`);
+
+			return rows.map((r) => r.folder as string);
 		}),
 
 	delete: protectedProcedure

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -62,6 +62,7 @@ export const flagFormSchema = z
 			.optional(),
 		environment: z.string().nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
+		folder: z.string().max(100, "Folder path too long").nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -62,7 +62,7 @@ export const flagFormSchema = z
 			.optional(),
 		environment: z.string().nullable().optional(),
 		targetGroupIds: z.array(z.string()).optional(),
-		folder: z.string().max(100, "Folder path too long").nullable().optional(),
+		folder: z.string().min(1).max(100, "Folder path too long").nullable().optional(),
 	})
 	.superRefine((data, ctx) => {
 		if (data.type === "multivariant" && data.variants) {


### PR DESCRIPTION
## Summary

Closes #271

Adds a `folder` field to feature flags so teams can organize flags into logical groups (e.g. `auth/login`, `payments`, `experiments`).

**Changes:**
- **DB schema** (`packages/db`): new `folder text` column on `flags` table + composite index on `(websiteId, folder)` for efficient folder queries
- **RPC router** (`packages/rpc`): new `listFolders` endpoint returning distinct folder names per website; `folder` field propagated through `create` and `update` handlers
- **Shared schema** (`packages/shared`): `folder` added to `flagFormSchema` with 100-char max
- **Dashboard – flag sheet**: folder text input in the create/edit form under Description
- **Dashboard – flags page**: `FolderNav` sidebar (All Flags / named folders / Uncategorized) with active folder filtering; sidebar only renders when folders exist
- **Dashboard – flags list**: folder badge (folder icon + path) shown inline per row next to the flag key

## Test plan

- [ ] Create a flag with a folder value (e.g. `payments`) → folder badge appears in list, sidebar shows `payments` entry
- [ ] Create a flag without a folder → appears under Uncategorized in sidebar
- [ ] Filter by folder in sidebar → only matching flags shown
- [ ] Edit an existing flag to assign/change/clear folder → list and sidebar update
- [ ] `listFolders` returns sorted distinct folder names for the website
- [ ] `bun run db:push` applies the new column and index without errors