### PR TITLE
feat(insights): full insight history context for investigations

### DIFF
--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -49,7 +49,7 @@ import {
 	buildSystemPrompt,
 	fetchDismissedPatterns,
 	fetchRecentAnnotations,
-	fetchRecentInsightsForPrompt,
+	fetchInsightHistory,
 	formatOrgWebsitesContext,
 	type OrgWebsiteRow,
 } from "./prompts";
@@ -295,10 +295,10 @@ async function analyzeWebsite(params: {
 
 	const investigationMode = enrichedSignals.length > 0;
 
-	const [annotationContext, recentInsightsBlock, siteContext, dismissedBlock] =
+	const [annotationContext, historyBlock, siteContext, dismissedBlock] =
 		await Promise.all([
 			fetchRecentAnnotations(params.websiteId, params.config),
-			fetchRecentInsightsForPrompt(
+			fetchInsightHistory(
 				params.organizationId,
 				params.websiteId,
 				params.config
@@ -321,14 +321,14 @@ async function analyzeWebsite(params: {
 				githubRepo: params.githubRepo,
 				period: params.period,
 				timezone: params.config.timezone,
-				recentInsightsBlock,
+				historyBlock,
 				annotationContext,
 				dismissedBlock,
 				orgContext,
 				siteContext: siteBlock,
 			})
 		: `Analyze ${params.domain} (${currentRange.from} to ${currentRange.to} vs ${previousRange.from} to ${previousRange.to}, ${params.config.timezone}). Use web_metrics with period="both" to compare periods efficiently.${siteBlock}
-${orgContext}${annotationContext}${recentInsightsBlock}${dismissedBlock}`;
+${orgContext}${annotationContext}${historyBlock}${dismissedBlock}`;
 
 	const { tools: analyticsTools } = createInsightsAgentTools({
 		websiteId: params.websiteId,

--- a/apps/insights/src/prompts.ts
+++ b/apps/insights/src/prompts.ts
@@ -86,7 +86,7 @@ export async function fetchDismissedPatterns(
 	return `\n\nInsights users marked as NOT helpful (avoid similar narratives):\n${lines.join("\n")}`;
 }
 
-export async function fetchRecentInsightsForPrompt(
+export async function fetchInsightHistory(
 	organizationId: string,
 	websiteId: string,
 	config: InsightGenerationConfigSnapshot
@@ -95,8 +95,14 @@ export async function fetchRecentInsightsForPrompt(
 	const rows = await db
 		.select({
 			title: analyticsInsights.title,
+			description: analyticsInsights.description,
 			type: analyticsInsights.type,
+			severity: analyticsInsights.severity,
+			rootCause: analyticsInsights.rootCause,
+			changePercent: analyticsInsights.changePercent,
+			subjectKey: analyticsInsights.subjectKey,
 			createdAt: analyticsInsights.createdAt,
+			runId: analyticsInsights.runId,
 		})
 		.from(analyticsInsights)
 		.where(
@@ -113,12 +119,43 @@ export async function fetchRecentInsightsForPrompt(
 		return "";
 	}
 
-	const lines = rows.map(
-		(row) =>
-			`- [${row.type}] ${row.title} (${dayjs(row.createdAt).format("YYYY-MM-DD")})`
-	);
+	const subjectCounts = new Map<string, number>();
+	for (const row of rows) {
+		subjectCounts.set(
+			row.subjectKey,
+			(subjectCounts.get(row.subjectKey) ?? 0) + 1
+		);
+	}
 
-	return `\n\nRecently reported (avoid repeating unless materially changed):\n${lines.join("\n")}`;
+	const seen = new Set<string>();
+	const lines: string[] = [];
+	for (const row of rows) {
+		if (seen.has(row.subjectKey)) {
+			continue;
+		}
+		seen.add(row.subjectKey);
+
+		const date = dayjs(row.createdAt).format("YYYY-MM-DD");
+		const recurrence = subjectCounts.get(row.subjectKey) ?? 1;
+		const recurring = recurrence > 1 ? ` (reported ${recurrence}x)` : "";
+		const change =
+			row.changePercent === null
+				? ""
+				: ` ${row.changePercent > 0 ? "+" : ""}${Math.round(row.changePercent)}%`;
+
+		lines.push(
+			`- [${row.severity}] ${row.title}${change}${recurring} (${date})`
+		);
+		if (row.description) {
+			lines.push(`  ${row.description.slice(0, 150)}`);
+		}
+		if (row.rootCause) {
+			lines.push(`  Cause: ${row.rootCause.slice(0, 100)}`);
+		}
+	}
+
+	return `\n\nPrevious findings for this site (compare against current data — note what resolved, worsened, or persists):
+${lines.join("\n")}`;
 }
 
 export interface OrgWebsiteRow {
@@ -252,7 +289,7 @@ export function buildInvestigationPrompt(
 		githubRepo?: { owner: string; repo: string };
 		orgContext: string;
 		period: WeekOverWeekPeriod;
-		recentInsightsBlock: string;
+		historyBlock: string;
 		siteContext: string;
 		timezone: string;
 	}
@@ -285,5 +322,5 @@ ${githubInstruction}
 8. Emit findings via emit_insight as you go.
 
 summary_metrics is the canonical source for headline numbers.
-${params.orgContext}${params.annotationContext}${params.recentInsightsBlock}${params.dismissedBlock}`;
+${params.orgContext}${params.annotationContext}${params.historyBlock}${params.dismissedBlock}`;
 }

--- a/packages/evals/ui/index.html
+++ b/packages/evals/ui/index.html
@@ -794,16 +794,16 @@
       const id = escapeHtml(c.id);
       const cost = (c.metrics?.costUsd || 0) + (c.metrics?.judgeCostUsd || 0);
       return `<tr>
-                                                                                <td><div class="case-id" title="${id}">${id}</div></td>
-                                                                                <td><span class="pill cat">${escapeHtml(c.category || "case")}</span></td>
-                                                                                <td><span class="pill ${c.passed ? "pass" : "fail"}">${c.passed ? "Pass" : "Fail"}</span></td>
-                                                                                <td class="num ${scoreTone(c.scores?.tool_routing ?? 0)}">${c.scores?.tool_routing ?? "--"}</td>
-                                                                                <td class="num ${scoreTone(c.scores?.quality ?? 0)}">${c.scores?.quality ?? "--"}</td>
-                                                                                <td class="num">${((c.metrics?.latencyMs || 0) / 1000).toFixed(1)}s</td>
-                                                                                <td class="num">${c.metrics?.steps ?? "--"}</td>
-                                                                                <td class="num">${money(cost)}</td>
-                                                                                <td><button class="row-action" data-open-case="${id}" type="button">Inspect</button></td>
-                                                                              </tr><tr><td colspan="9"><div class="detail ${openId === c.id ? "open" : ""}" id="detail-${id}">${detail(c)}</div></td></tr>`;
+                                                                                    <td><div class="case-id" title="${id}">${id}</div></td>
+                                                                                    <td><span class="pill cat">${escapeHtml(c.category || "case")}</span></td>
+                                                                                    <td><span class="pill ${c.passed ? "pass" : "fail"}">${c.passed ? "Pass" : "Fail"}</span></td>
+                                                                                    <td class="num ${scoreTone(c.scores?.tool_routing ?? 0)}">${c.scores?.tool_routing ?? "--"}</td>
+                                                                                    <td class="num ${scoreTone(c.scores?.quality ?? 0)}">${c.scores?.quality ?? "--"}</td>
+                                                                                    <td class="num">${((c.metrics?.latencyMs || 0) / 1000).toFixed(1)}s</td>
+                                                                                    <td class="num">${c.metrics?.steps ?? "--"}</td>
+                                                                                    <td class="num">${money(cost)}</td>
+                                                                                    <td><button class="row-action" data-open-case="${id}" type="button">Inspect</button></td>
+                                                                                  </tr><tr><td colspan="9"><div class="detail ${openId === c.id ? "open" : ""}" id="detail-${id}">${detail(c)}</div></td></tr>`;
     }
 
     function detail(c) {
@@ -815,7 +815,7 @@
           .map((t) => `<span class="pill cat">${escapeHtml(t)}</span>`)
           .join("") || '<span class="sub">No tools called</span>';
       return `<div class="box"><h3>Response</h3><pre>${escapeHtml(c.response || "No response captured.")}</pre></div>
-                                                                                <div class="box"><h3>Failures</h3><ul class="fail-list">${failures}</ul><h3 style="margin-top:14px">Tools</h3><div class="tools">${tools}</div></div>`;
+                                                                                    <div class="box"><h3>Failures</h3><ul class="fail-list">${failures}</ul><h3 style="margin-top:14px">Tools</h3><div class="tools">${tools}</div></div>`;
     }
 
     function toggle(id) {


### PR DESCRIPTION
## Summary
- Replace flat title list with full insight history including description, rootCause, severity, change percent, and recurrence count
- Agent now compares current findings against previous runs — notes what resolved, worsened, or persists
- Deduplicates by subjectKey so recurring issues show "(reported 3x)" instead of separate entries
- Tested: agent referenced "continuing last week's doubling trend" and avoided re-reporting known bugs

## Test plan
- [ ] Run insights on a site with previous findings, verify agent references history
- [ ] Verify recurring issues show recurrence count
- [ ] Run `bun test` in apps/insights (61 tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full insight history to investigations so the agent can compare current vs previous runs, avoid repeats, and call out resolved, worsened, or persistent issues. Includes severity, change %, description, root cause, and recurrence counts.

- **New Features**
  - Provide full history in the prompt with severity, changePercent, description, rootCause, and recurrence.
  - Deduplicate by subjectKey and show recurrence (e.g., "reported 3x").
  - Agent references history to avoid re-reporting and to note trends.

- **Refactors**
  - Replace `fetchRecentInsightsForPrompt` with `fetchInsightHistory` and switch prompt var to `historyBlock`.
  - Tidy HTML in `packages/evals/ui/index.html` (formatting only).

<sup>Written for commit cb4fa781a01acfcb35a47ebe14a1b48d49615f11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/460?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

