### PR TITLE
fix(insights): history dedup uses title fallback, limits after dedup

### DIFF
--- a/apps/insights/src/prompts.ts
+++ b/apps/insights/src/prompts.ts
@@ -96,13 +96,11 @@ export async function fetchInsightHistory(
 		.select({
 			title: analyticsInsights.title,
 			description: analyticsInsights.description,
-			type: analyticsInsights.type,
 			severity: analyticsInsights.severity,
 			rootCause: analyticsInsights.rootCause,
 			changePercent: analyticsInsights.changePercent,
 			subjectKey: analyticsInsights.subjectKey,
 			createdAt: analyticsInsights.createdAt,
-			runId: analyticsInsights.runId,
 		})
 		.from(analyticsInsights)
 		.where(
@@ -113,7 +111,7 @@ export async function fetchInsightHistory(
 			)
 		)
 		.orderBy(desc(analyticsInsights.createdAt))
-		.limit(RECENT_INSIGHTS_PROMPT_LIMIT);
+		.limit(50);
 
 	if (rows.length === 0) {
 		return "";
@@ -121,22 +119,24 @@ export async function fetchInsightHistory(
 
 	const subjectCounts = new Map<string, number>();
 	for (const row of rows) {
-		subjectCounts.set(
-			row.subjectKey,
-			(subjectCounts.get(row.subjectKey) ?? 0) + 1
-		);
+		const key = row.subjectKey || row.title;
+		subjectCounts.set(key, (subjectCounts.get(key) ?? 0) + 1);
 	}
 
 	const seen = new Set<string>();
 	const lines: string[] = [];
 	for (const row of rows) {
-		if (seen.has(row.subjectKey)) {
+		if (lines.length >= RECENT_INSIGHTS_PROMPT_LIMIT) {
+			break;
+		}
+		const key = row.subjectKey || row.title;
+		if (seen.has(key)) {
 			continue;
 		}
-		seen.add(row.subjectKey);
+		seen.add(key);
 
 		const date = dayjs(row.createdAt).format("YYYY-MM-DD");
-		const recurrence = subjectCounts.get(row.subjectKey) ?? 1;
+		const recurrence = subjectCounts.get(key) ?? 1;
 		const recurring = recurrence > 1 ? ` (reported ${recurrence}x)` : "";
 		const change =
 			row.changePercent === null

--- a/packages/evals/ui/index.html
+++ b/packages/evals/ui/index.html
@@ -794,16 +794,16 @@
       const id = escapeHtml(c.id);
       const cost = (c.metrics?.costUsd || 0) + (c.metrics?.judgeCostUsd || 0);
       return `<tr>
-                                                                                    <td><div class="case-id" title="${id}">${id}</div></td>
-                                                                                    <td><span class="pill cat">${escapeHtml(c.category || "case")}</span></td>
-                                                                                    <td><span class="pill ${c.passed ? "pass" : "fail"}">${c.passed ? "Pass" : "Fail"}</span></td>
-                                                                                    <td class="num ${scoreTone(c.scores?.tool_routing ?? 0)}">${c.scores?.tool_routing ?? "--"}</td>
-                                                                                    <td class="num ${scoreTone(c.scores?.quality ?? 0)}">${c.scores?.quality ?? "--"}</td>
-                                                                                    <td class="num">${((c.metrics?.latencyMs || 0) / 1000).toFixed(1)}s</td>
-                                                                                    <td class="num">${c.metrics?.steps ?? "--"}</td>
-                                                                                    <td class="num">${money(cost)}</td>
-                                                                                    <td><button class="row-action" data-open-case="${id}" type="button">Inspect</button></td>
-                                                                                  </tr><tr><td colspan="9"><div class="detail ${openId === c.id ? "open" : ""}" id="detail-${id}">${detail(c)}</div></td></tr>`;
+                                                                                        <td><div class="case-id" title="${id}">${id}</div></td>
+                                                                                        <td><span class="pill cat">${escapeHtml(c.category || "case")}</span></td>
+                                                                                        <td><span class="pill ${c.passed ? "pass" : "fail"}">${c.passed ? "Pass" : "Fail"}</span></td>
+                                                                                        <td class="num ${scoreTone(c.scores?.tool_routing ?? 0)}">${c.scores?.tool_routing ?? "--"}</td>
+                                                                                        <td class="num ${scoreTone(c.scores?.quality ?? 0)}">${c.scores?.quality ?? "--"}</td>
+                                                                                        <td class="num">${((c.metrics?.latencyMs || 0) / 1000).toFixed(1)}s</td>
+                                                                                        <td class="num">${c.metrics?.steps ?? "--"}</td>
+                                                                                        <td class="num">${money(cost)}</td>
+                                                                                        <td><button class="row-action" data-open-case="${id}" type="button">Inspect</button></td>
+                                                                                      </tr><tr><td colspan="9"><div class="detail ${openId === c.id ? "open" : ""}" id="detail-${id}">${detail(c)}</div></td></tr>`;
     }
 
     function detail(c) {
@@ -815,7 +815,7 @@
           .map((t) => `<span class="pill cat">${escapeHtml(t)}</span>`)
           .join("") || '<span class="sub">No tools called</span>';
       return `<div class="box"><h3>Response</h3><pre>${escapeHtml(c.response || "No response captured.")}</pre></div>
-                                                                                    <div class="box"><h3>Failures</h3><ul class="fail-list">${failures}</ul><h3 style="margin-top:14px">Tools</h3><div class="tools">${tools}</div></div>`;
+                                                                                        <div class="box"><h3>Failures</h3><ul class="fail-list">${failures}</ul><h3 style="margin-top:14px">Tools</h3><div class="tools">${tools}</div></div>`;
     }
 
     function toggle(id) {


### PR DESCRIPTION
## Summary
Fixes three issues from PR #460 review:
- Empty subjectKey no longer collapses unrelated insights into one (P1)
- Fetch 50 rows then dedup to 12 unique subjects (was LIMIT 12 before dedup)
- Remove unused runId from select

## Test plan
- [ ] `bun test` in apps/insights

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix insight history dedup to prevent empty subjectKey from merging unrelated insights, and apply the 12-item cap after dedup by fetching 50 rows first. Remove the unused runId from the query and clean up HTML spacing in `packages/evals/ui`.

<sup>Written for commit 50b1ddc74bcc1ddbc9dae473ccd9319103cbed3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/461?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

