### PR TITLE
feat: conversational insight digest routing

### DIFF
--- a/apps/api/src/lib/evlog-api.ts
+++ b/apps/api/src/lib/evlog-api.ts
@@ -102,8 +102,5 @@ export function enrichApiWideEvent(ctx: EnrichContext): void {
 }
 
 export async function flushBatchedApiDrain(): Promise<void> {
-	await Promise.all([
-		batchedAxiomDrain.flush(),
-		batchedSuperlogDrain?.flush(),
-	]);
+	await Promise.all([batchedAxiomDrain.flush(), batchedSuperlogDrain?.flush()]);
 }

--- a/apps/basket/src/lib/evlog-basket.ts
+++ b/apps/basket/src/lib/evlog-basket.ts
@@ -103,8 +103,5 @@ export function enrichBasketWideEvent(ctx: EnrichContext): void {
 }
 
 export async function flushBatchedAxiomDrain(): Promise<void> {
-	await Promise.all([
-		batchedAxiomDrain.flush(),
-		batchedSuperlogDrain?.flush(),
-	]);
+	await Promise.all([batchedAxiomDrain.flush(), batchedSuperlogDrain?.flush()]);
 }

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@databuddy/ai": "workspace:*",
     "@databuddy/db": "workspace:*",
+    "@databuddy/encryption": "workspace:*",
     "@databuddy/env": "workspace:*",
     "@databuddy/redis": "workspace:*",
     "@databuddy/rpc": "workspace:*",

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -10,6 +10,12 @@ import { captureInsightsError, emitInsightsEvent } from "./lib/evlog-insights";
 
 const SLACK_POST_URL = "https://slack.com/api/chat.postMessage";
 const MAX_DIGEST_INSIGHTS = 5;
+const SLACK_HEADER_MAX = 150;
+const SLACK_SECTION_TEXT_MAX = 3000;
+
+function truncate(value: string, max: number): string {
+	return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
 
 interface DigestInsight {
 	description: string;
@@ -89,7 +95,10 @@ function buildBlocks(
 	const blocks: SlackBlock[] = [
 		{
 			type: "header",
-			text: { type: "plain_text", text: `Insights for ${websiteDomain}` },
+			text: {
+				type: "plain_text",
+				text: truncate(`Insights for ${websiteDomain}`, SLACK_HEADER_MAX),
+			},
 		},
 	];
 	for (const insight of insights.slice(0, MAX_DIGEST_INSIGHTS)) {
@@ -97,7 +106,10 @@ function buildBlocks(
 			type: "section",
 			text: {
 				type: "mrkdwn",
-				text: `*${escapeMrkdwn(insight.title)}*\n${escapeMrkdwn(insight.description)}\n_${escapeMrkdwn(insight.suggestion)}_`,
+				text: truncate(
+					`*${escapeMrkdwn(insight.title)}*\n${escapeMrkdwn(insight.description)}\n_${escapeMrkdwn(insight.suggestion)}_`,
+					SLACK_SECTION_TEXT_MAX
+				),
 			},
 		});
 	}

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -140,8 +140,12 @@ export async function deliverInsightDigests(params: {
 		params.organizationId,
 		params.websiteId
 	);
-	const slackDeliveries = deliveries.filter((d) => d.type === "slack");
-	if (slackDeliveries.length === 0) {
+	const slackChannelIds = [
+		...new Set(
+			deliveries.filter((d) => d.type === "slack").map((d) => d.channelId)
+		),
+	];
+	if (slackChannelIds.length === 0) {
 		return;
 	}
 
@@ -150,27 +154,27 @@ export async function deliverInsightDigests(params: {
 		emitInsightsEvent("warn", "delivery.slack.skipped_no_integration", {
 			organization_id: params.organizationId,
 			website_id: params.websiteId,
-			delivery_count: slackDeliveries.length,
+			delivery_count: slackChannelIds.length,
 		});
 		return;
 	}
 
 	const blocks = buildBlocks(params.websiteDomain, params.insights);
 	const text = `Insights for ${params.websiteDomain}`;
-	for (const delivery of slackDeliveries) {
+	for (const channelId of slackChannelIds) {
 		try {
-			await postToSlack(token, delivery.channelId, blocks, text);
+			await postToSlack(token, channelId, blocks, text);
 			emitInsightsEvent("info", "delivery.slack.posted", {
 				organization_id: params.organizationId,
 				website_id: params.websiteId,
-				slack_channel_id: delivery.channelId,
+				slack_channel_id: channelId,
 				insight_count: Math.min(params.insights.length, MAX_DIGEST_INSIGHTS),
 			});
 		} catch (error) {
 			captureInsightsError(error, "delivery.slack.failed", {
 				organization_id: params.organizationId,
 				website_id: params.websiteId,
-				slack_channel_id: delivery.channelId,
+				slack_channel_id: channelId,
 			});
 		}
 	}

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -1,0 +1,170 @@
+import { and, db, eq, isNull } from "@databuddy/db";
+import {
+	type InsightDelivery,
+	insightGenerationConfigs,
+	slackIntegrations,
+} from "@databuddy/db/schema";
+import { decrypt } from "@databuddy/encryption";
+import { env } from "@databuddy/env/insights";
+import { captureInsightsError, emitInsightsEvent } from "./lib/evlog-insights";
+
+const SLACK_POST_URL = "https://slack.com/api/chat.postMessage";
+const MAX_DIGEST_INSIGHTS = 5;
+
+interface DigestInsight {
+	description: string;
+	severity: string;
+	suggestion: string;
+	title: string;
+}
+
+interface SlackBlock {
+	text?: { text: string; type: string };
+	type: string;
+}
+
+async function resolveDeliveries(
+	organizationId: string,
+	websiteId: string
+): Promise<InsightDelivery[]> {
+	const [websiteConfig] = await db
+		.select({ deliveries: insightGenerationConfigs.deliveries })
+		.from(insightGenerationConfigs)
+		.where(
+			and(
+				eq(insightGenerationConfigs.organizationId, organizationId),
+				eq(insightGenerationConfigs.websiteId, websiteId)
+			)
+		)
+		.limit(1);
+	if (websiteConfig) {
+		return websiteConfig.deliveries;
+	}
+
+	const [orgConfig] = await db
+		.select({ deliveries: insightGenerationConfigs.deliveries })
+		.from(insightGenerationConfigs)
+		.where(
+			and(
+				eq(insightGenerationConfigs.organizationId, organizationId),
+				isNull(insightGenerationConfigs.websiteId)
+			)
+		)
+		.limit(1);
+	return orgConfig?.deliveries ?? [];
+}
+
+async function loadBotToken(organizationId: string): Promise<string | null> {
+	const key = env.DATABUDDY_ENCRYPTION_KEY;
+	if (!key) {
+		return null;
+	}
+	const [integration] = await db
+		.select({ ciphertext: slackIntegrations.botTokenCiphertext })
+		.from(slackIntegrations)
+		.where(
+			and(
+				eq(slackIntegrations.organizationId, organizationId),
+				eq(slackIntegrations.status, "active")
+			)
+		)
+		.limit(1);
+	if (!integration) {
+		return null;
+	}
+	return decrypt(integration.ciphertext, key);
+}
+
+function buildBlocks(
+	websiteDomain: string,
+	insights: DigestInsight[]
+): SlackBlock[] {
+	const blocks: SlackBlock[] = [
+		{
+			type: "header",
+			text: { type: "plain_text", text: `Insights for ${websiteDomain}` },
+		},
+	];
+	for (const insight of insights.slice(0, MAX_DIGEST_INSIGHTS)) {
+		blocks.push({
+			type: "section",
+			text: {
+				type: "mrkdwn",
+				text: `*${insight.title}*\n${insight.description}\n_${insight.suggestion}_`,
+			},
+		});
+	}
+	return blocks;
+}
+
+async function postToSlack(
+	token: string,
+	channelId: string,
+	blocks: SlackBlock[],
+	text: string
+): Promise<void> {
+	const res = await fetch(SLACK_POST_URL, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Authorization: `Bearer ${token}`,
+		},
+		body: JSON.stringify({ channel: channelId, blocks, text }),
+	});
+	const body = (await res.json()) as { ok: boolean; error?: string };
+	if (!body.ok) {
+		throw new Error(
+			`slack chat.postMessage failed: ${body.error ?? "unknown_error"}`
+		);
+	}
+}
+
+export async function deliverInsightDigests(params: {
+	insights: DigestInsight[];
+	organizationId: string;
+	websiteDomain: string;
+	websiteId: string;
+}): Promise<void> {
+	if (params.insights.length === 0) {
+		return;
+	}
+
+	const deliveries = await resolveDeliveries(
+		params.organizationId,
+		params.websiteId
+	);
+	const slackDeliveries = deliveries.filter((d) => d.type === "slack");
+	if (slackDeliveries.length === 0) {
+		return;
+	}
+
+	const token = await loadBotToken(params.organizationId);
+	if (!token) {
+		emitInsightsEvent("warn", "delivery.slack.skipped_no_integration", {
+			organization_id: params.organizationId,
+			website_id: params.websiteId,
+			delivery_count: slackDeliveries.length,
+		});
+		return;
+	}
+
+	const blocks = buildBlocks(params.websiteDomain, params.insights);
+	const text = `Insights for ${params.websiteDomain}`;
+	for (const delivery of slackDeliveries) {
+		try {
+			await postToSlack(token, delivery.channelId, blocks, text);
+			emitInsightsEvent("info", "delivery.slack.posted", {
+				organization_id: params.organizationId,
+				website_id: params.websiteId,
+				slack_channel_id: delivery.channelId,
+				insight_count: Math.min(params.insights.length, MAX_DIGEST_INSIGHTS),
+			});
+		} catch (error) {
+			captureInsightsError(error, "delivery.slack.failed", {
+				organization_id: params.organizationId,
+				website_id: params.websiteId,
+				slack_channel_id: delivery.channelId,
+			});
+		}
+	}
+}

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -23,6 +23,13 @@ interface SlackBlock {
 	type: string;
 }
 
+function escapeMrkdwn(value: string): string {
+	return value
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;");
+}
+
 async function resolveDeliveries(
 	organizationId: string,
 	websiteId: string
@@ -90,7 +97,7 @@ function buildBlocks(
 			type: "section",
 			text: {
 				type: "mrkdwn",
-				text: `*${insight.title}*\n${insight.description}\n_${insight.suggestion}_`,
+				text: `*${escapeMrkdwn(insight.title)}*\n${escapeMrkdwn(insight.description)}\n_${escapeMrkdwn(insight.suggestion)}_`,
 			},
 		});
 	}

--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -25,6 +25,7 @@ import { stepCountIs, tool, ToolLoopAgent, type ToolSet } from "ai";
 import { randomUUIDv7 } from "bun";
 import dayjs from "dayjs";
 import { resolveInsightsBilling } from "./billing";
+import { deliverInsightDigests } from "./delivery";
 import { type DetectedSignal, detectSignals, wowWindow } from "./detection";
 import { detectFunnelGoalSignals } from "./funnel-detection";
 import { enrichSignals } from "./enrichment";
@@ -608,6 +609,23 @@ export async function generateWebsiteInsights(
 	}
 
 	storeWebsiteSummary(site, saved);
+
+	if (saved.length > 0) {
+		try {
+			await deliverInsightDigests({
+				organizationId: input.organizationId,
+				websiteId: site.id,
+				websiteDomain: site.domain,
+				insights: saved,
+			});
+		} catch (error) {
+			captureInsightsError(error, "generation.delivery.failed", {
+				organization_id: input.organizationId,
+				website_id: site.id,
+				run_id: input.runId,
+			});
+		}
+	}
 
 	emitInsightsEvent("info", "generation.website.completed", {
 		organization_id: input.organizationId,

--- a/apps/uptime/src/lib/evlog-uptime.ts
+++ b/apps/uptime/src/lib/evlog-uptime.ts
@@ -108,8 +108,5 @@ export function enrichUptimeWideEvent(ctx: EnrichContext): void {
 }
 
 export async function flushBatchedUptimeDrain(): Promise<void> {
-	await Promise.all([
-		batchedAxiomDrain.flush(),
-		batchedSuperlogDrain?.flush(),
-	]);
+	await Promise.all([batchedAxiomDrain.flush(), batchedSuperlogDrain?.flush()]);
 }

--- a/bun.lock
+++ b/bun.lock
@@ -335,6 +335,7 @@
       "dependencies": {
         "@databuddy/ai": "workspace:*",
         "@databuddy/db": "workspace:*",
+        "@databuddy/encryption": "workspace:*",
         "@databuddy/env": "workspace:*",
         "@databuddy/redis": "workspace:*",
         "@databuddy/rpc": "workspace:*",

--- a/packages/ai/src/ai/mcp/agent-tools.ts
+++ b/packages/ai/src/ai/mcp/agent-tools.ts
@@ -10,6 +10,7 @@ import { createAnnotationTools } from "../tools/annotations";
 import { createFlagTools } from "../tools/flags";
 import { createFunnelTools } from "../tools/funnels";
 import { createGoalTools } from "../tools/goals";
+import { createInsightDigestTools } from "../tools/insight-digest";
 import { createLinksTools } from "../tools/links";
 import { createMemoryTools } from "../tools/memory";
 import { executeAgentSqlForWebsite } from "../tools/execute-sql-query";
@@ -241,6 +242,7 @@ Critical schema footguns: website id column is client_id (not website_id); times
 		...createGoalTools(),
 		...createAnnotationTools(),
 		...createLinksTools(),
+		...createInsightDigestTools(),
 		...createSlackConversationTools(options.slackContext),
 	};
 }

--- a/packages/ai/src/ai/mcp/run-agent.ts
+++ b/packages/ai/src/ai/mcp/run-agent.ts
@@ -325,7 +325,7 @@ const THREAD_REFERENCE_PATTERN =
 const ANALYTICS_REQUEST_PATTERN =
 	/\b(analytics?|metrics?|traffic|visitors?|sessions?|page\s*views?|pageviews?|top pages?|pages?|referrers?|sources?|campaigns?|conversions?|events?|errors?|vitals?|performance|uptime|revenue|transactions?|llm|latency|bounce|countries|country|regions?|cities|devices?|browsers?|operating systems?|utm|fresh|current|latest|live|rerun|last \d+|last week|last month|today|yesterday)\b/i;
 const NON_ANALYTICS_TOOL_PATTERN =
-	/\b(remember|memory|forget|profile|profiles|flag|flags|feature flag|feature flags|funnel|funnels|goal|goals|annotation|annotations|link|links|short link|short links|create|update|delete|archive|enable|disable|rollout|target|folder|folders|navigate|open|go to|take me)\b/i;
+	/\b(remember|memory|forget|profile|profiles|flag|flags|feature flag|feature flags|funnel|funnels|goal|goals|annotation|annotations|link|links|short link|short links|digest|digests|subscribe|unsubscribe|create|update|delete|archive|enable|disable|rollout|target|folder|folders|navigate|open|go to|take me)\b/i;
 const COPY_ONLY_PATTERN = /\b(exact copy|copy only)\b/i;
 const SLACK_FOLLOW_UP_OPEN_TAG = "<slack_follow_up";
 const SLACK_FOLLOW_UP_CLOSE_TAG = "</slack_follow_up>";

--- a/packages/ai/src/ai/mcp/tools.ts
+++ b/packages/ai/src/ai/mcp/tools.ts
@@ -1619,18 +1619,14 @@ const manageInsightDigestTool = defineMcpTool(
 			};
 		}
 
-		if (input.frequency) {
-			await callRPCProcedure(
-				"insightGeneration",
-				"upsertConfig",
-				{ ...scopeInput, frequency: input.frequency },
-				rpcContext
-			);
-		}
 		const config = await callRPCProcedure(
 			"insightGeneration",
 			"addSlackDelivery",
-			{ ...scopeInput, channelId: input.channelId },
+			{
+				...scopeInput,
+				channelId: input.channelId,
+				frequency: input.frequency,
+			},
 			rpcContext
 		);
 		const summary = summarizeDigestConfig(config);

--- a/packages/ai/src/ai/mcp/tools.ts
+++ b/packages/ai/src/ai/mcp/tools.ts
@@ -55,6 +55,7 @@ import {
 	buildRpcContext,
 	getCachedAccessibleWebsites,
 	getOrganizationId,
+	resolveOrganizationIds,
 } from "./tool-context";
 import { createToolRegistry } from "./registry";
 
@@ -1523,6 +1524,155 @@ const addUsersToFlagTool = defineMcpTool(
 	}
 );
 
+const DigestFrequencySchema = z.enum(["hourly", "daily", "weekly"]);
+
+function summarizeDigestConfig(config: unknown): {
+	channels: string[];
+	enabled: boolean;
+	frequency: string;
+	nextRunAt: string | null;
+	scope: string;
+} {
+	const record = asRecord(config);
+	const deliveries = Array.isArray(record.deliveries) ? record.deliveries : [];
+	const channels = deliveries
+		.map((delivery) => asRecord(delivery))
+		.filter(
+			(delivery) =>
+				delivery.type === "slack" && typeof delivery.channelId === "string"
+		)
+		.map((delivery) => delivery.channelId as string);
+	const nextRunAt = record.nextRunAt;
+	return {
+		channels,
+		enabled: record.enabled !== false,
+		frequency:
+			typeof record.frequency === "string" ? record.frequency : "weekly",
+		nextRunAt:
+			nextRunAt instanceof Date
+				? nextRunAt.toISOString()
+				: typeof nextRunAt === "string"
+					? nextRunAt
+					: null,
+		scope: typeof record.source === "string" ? record.source : "default",
+	};
+}
+
+const manageInsightDigestTool = defineMcpTool(
+	{
+		name: "manage_insight_digest",
+		description:
+			"Route, stop, or inspect Slack delivery of analytics insight digests. action=route sends digests to a channel, unroute stops it, status shows current routing.",
+		inputSchema: z.object({
+			...WebsiteSelectorSchema,
+			action: z
+				.enum(["route", "unroute", "status"])
+				.describe("route to a channel, unroute to stop, or status to inspect"),
+			channelId: z
+				.string()
+				.min(1)
+				.max(120)
+				.optional()
+				.describe("Slack channel ID. Required for route and unroute."),
+			frequency: DigestFrequencySchema.optional().describe(
+				"How often investigations run for this scope. Applied on route."
+			),
+			confirmed: ConfirmedSchema,
+		}),
+		outputSchema: MutationResultSchema,
+		resolveWebsite: "optional",
+		metadata: writeMetadata(["manage:websites"]),
+		ratelimit: { limit: 20, windowSec: 60 },
+	},
+	async (input, ctx) => {
+		const websiteId = ctx.websiteId;
+		const orgIds = await resolveOrganizationIds(websiteId, ctx);
+		if (orgIds instanceof Error) {
+			throw new McpToolError("not_found", orgIds.message);
+		}
+		const organizationId = orgIds[0];
+		const rpcContext = buildRpcContext(ctx);
+		const scopeInput = { organizationId, websiteId: websiteId ?? undefined };
+
+		if (input.action === "status") {
+			const config = await callRPCProcedure(
+				"insightGeneration",
+				"getConfig",
+				scopeInput,
+				rpcContext
+			);
+			const summary = summarizeDigestConfig(config);
+			return {
+				success: true,
+				message:
+					summary.channels.length > 0
+						? `Digest goes to ${summary.channels.length} Slack channel${summary.channels.length === 1 ? "" : "s"} on a ${summary.frequency} cadence.`
+						: "No Slack digest delivery is configured for this scope.",
+				digest: summary,
+			};
+		}
+
+		if (!input.channelId) {
+			throw new McpToolError(
+				"invalid_input",
+				"channelId is required to route or unroute a digest."
+			);
+		}
+
+		if (!input.confirmed) {
+			return {
+				preview: true,
+				confirmationRequired: true,
+				message:
+					input.action === "route"
+						? `Route insight digests to this Slack channel${input.frequency ? ` on a ${input.frequency} cadence` : ""}?`
+						: "Stop routing insight digests to this Slack channel?",
+				digest: {
+					action: input.action,
+					channelId: input.channelId,
+					frequency: input.frequency ?? null,
+					scope: websiteId ? "website" : "organization",
+				},
+			};
+		}
+
+		if (input.action === "unroute") {
+			const config = await callRPCProcedure(
+				"insightGeneration",
+				"removeSlackDelivery",
+				{ ...scopeInput, channelId: input.channelId },
+				rpcContext
+			);
+			return {
+				success: true,
+				message: "Stopped routing insight digests to this Slack channel.",
+				digest: summarizeDigestConfig(config),
+			};
+		}
+
+		if (input.frequency) {
+			await callRPCProcedure(
+				"insightGeneration",
+				"upsertConfig",
+				{ ...scopeInput, frequency: input.frequency },
+				rpcContext
+			);
+		}
+		const config = await callRPCProcedure(
+			"insightGeneration",
+			"addSlackDelivery",
+			{ ...scopeInput, channelId: input.channelId },
+			rpcContext
+		);
+		const summary = summarizeDigestConfig(config);
+		return {
+			success: true,
+			message: `Insight digests will be delivered to this Slack channel on a ${summary.frequency} cadence.`,
+			digest: summary,
+		};
+	}
+);
+
 const searchMemoryTool = defineMcpTool(
 	{
 		name: "search_memory",
@@ -1671,6 +1821,7 @@ const TOOL_REGISTRY = createToolRegistry([
 	createFlagTool,
 	updateFlagTool,
 	addUsersToFlagTool,
+	manageInsightDigestTool,
 	...INSIGHT_TOOL_FACTORIES,
 	...(MEMORY_ENABLED
 		? [searchMemoryTool, saveMemoryTool, forgetMemoryTool]

--- a/packages/ai/src/ai/mcp/tools.ts
+++ b/packages/ai/src/ai/mcp/tools.ts
@@ -10,6 +10,7 @@ import {
 } from "../../lib/supermemory";
 import { executeBatch } from "../../query";
 import { isAiGatewayConfigured } from "../config/models";
+import { summarizeDigestConfig } from "../tools/digest-summary";
 import { callRPCProcedure } from "../tools/utils";
 import {
 	LinkFolderSelectorSchema,
@@ -1525,38 +1526,6 @@ const addUsersToFlagTool = defineMcpTool(
 );
 
 const DigestFrequencySchema = z.enum(["hourly", "daily", "weekly"]);
-
-function summarizeDigestConfig(config: unknown): {
-	channels: string[];
-	enabled: boolean;
-	frequency: string;
-	nextRunAt: string | null;
-	scope: string;
-} {
-	const record = asRecord(config);
-	const deliveries = Array.isArray(record.deliveries) ? record.deliveries : [];
-	const channels = deliveries
-		.map((delivery) => asRecord(delivery))
-		.filter(
-			(delivery) =>
-				delivery.type === "slack" && typeof delivery.channelId === "string"
-		)
-		.map((delivery) => delivery.channelId as string);
-	const nextRunAt = record.nextRunAt;
-	return {
-		channels,
-		enabled: record.enabled !== false,
-		frequency:
-			typeof record.frequency === "string" ? record.frequency : "weekly",
-		nextRunAt:
-			nextRunAt instanceof Date
-				? nextRunAt.toISOString()
-				: typeof nextRunAt === "string"
-					? nextRunAt
-					: null,
-		scope: typeof record.source === "string" ? record.source : "default",
-	};
-}
 
 const manageInsightDigestTool = defineMcpTool(
 	{

--- a/packages/ai/src/ai/prompts/analytics.ts
+++ b/packages/ai/src/ai/prompts/analytics.ts
@@ -114,6 +114,7 @@ const ANALYTICS_MCP_BODY = `<agent-specific-rules>
 4. Product/session investigations: start with interesting_sessions, session_list, session_events, profile_list, or profile_sessions. session_flow is page-to-page transitions; session_pages is pages ranked by sessions.
 5. Custom events: use get_data custom_events_* builders; raw SQL is easy to scope incorrectly.
 6. Workspace mutations: preview with confirmed=false, then confirmed=true only after explicit approval.
+7. Recurring digests: manage_insight_digest routes investigation digests to a Slack channel (action=route to start, unroute to stop, status to inspect), with optional frequency hourly/daily/weekly and optional websiteId (omit = whole org). Investigations run on their own schedule regardless; this only controls where the digest is posted. The user never has to know the exact phrasing — infer intent from things like "keep an eye on this", "send me updates", "weekly report".
 
 **Data integrity:**
 - Every number must come from tools or arithmetic on tool results.
@@ -178,6 +179,7 @@ Slack rules:
 - Rewrite/exact copy => output only the final copy. Never start with "sure", "got it", "here's", labels, options, or explanation.
 - Banter/thanks/frustration/"nah that's wrong"/"nope"/"shut up"/meta => one short line, no tools, unless they explicitly say thread/above/that.
 - Default: answer first, 1-3 short sentences, <80 words, no headings/report formatting unless asked, no dashboard JSON, no invented numbers.
+- Proactive offer: when your OWN reply delivers concrete metrics/numbers (a report, summary, or recap of the data), end it with one short friendly line offering to post a recurring digest to THIS channel (use slack_channel_id), e.g. "want me to drop a weekly rundown here?" or "i can keep an eye on this and ping you here daily if useful". At most once per conversation. Never add it to a reply that contains no metrics — banter, acknowledgements ("glad it helped"), rewrites, and clarifications get no offer. If they say yes, call manage_insight_digest action=route with slack_channel_id and their cadence (preview confirmed=false, then confirmed=true).
 Examples: "which first?" with thread metrics => read thread and pick one. "nah that's wrong" => ask for correction.
 </slack-output>`;
 

--- a/packages/ai/src/ai/tools/digest-summary.ts
+++ b/packages/ai/src/ai/tools/digest-summary.ts
@@ -1,0 +1,39 @@
+export interface DigestConfigSummary {
+	channels: string[];
+	enabled: boolean;
+	frequency: string;
+	nextRunAt: string | null;
+	scope: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+export function summarizeDigestConfig(config: unknown): DigestConfigSummary {
+	const record = asRecord(config);
+	const deliveries = Array.isArray(record.deliveries) ? record.deliveries : [];
+	const channels = deliveries
+		.map((delivery) => asRecord(delivery))
+		.filter(
+			(delivery) =>
+				delivery.type === "slack" && typeof delivery.channelId === "string"
+		)
+		.map((delivery) => delivery.channelId as string);
+	const nextRunAt = record.nextRunAt;
+	return {
+		channels,
+		enabled: record.enabled !== false,
+		frequency:
+			typeof record.frequency === "string" ? record.frequency : "weekly",
+		nextRunAt:
+			nextRunAt instanceof Date
+				? nextRunAt.toISOString()
+				: typeof nextRunAt === "string"
+					? nextRunAt
+					: null,
+		scope: typeof record.source === "string" ? record.source : "default",
+	};
+}

--- a/packages/ai/src/ai/tools/insight-digest.ts
+++ b/packages/ai/src/ai/tools/insight-digest.ts
@@ -1,0 +1,175 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { callRPCProcedure, createToolLogger, getAppContext } from "./utils";
+
+const logger = createToolLogger("Insight Digest Tools");
+
+const digestFrequencySchema = z.enum(["hourly", "daily", "weekly"]);
+
+interface DigestConfigSummary {
+	channels: string[];
+	enabled: boolean;
+	frequency: string;
+	nextRunAt: string | null;
+	scope: string;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function summarizeDigestConfig(config: unknown): DigestConfigSummary {
+	const record = asRecord(config);
+	const deliveries = Array.isArray(record.deliveries) ? record.deliveries : [];
+	const channels = deliveries
+		.map((delivery) => asRecord(delivery))
+		.filter(
+			(delivery) =>
+				delivery.type === "slack" && typeof delivery.channelId === "string"
+		)
+		.map((delivery) => delivery.channelId as string);
+	const nextRunAt = record.nextRunAt;
+	return {
+		channels,
+		enabled: record.enabled !== false,
+		frequency:
+			typeof record.frequency === "string" ? record.frequency : "weekly",
+		nextRunAt:
+			nextRunAt instanceof Date
+				? nextRunAt.toISOString()
+				: typeof nextRunAt === "string"
+					? nextRunAt
+					: null,
+		scope: typeof record.source === "string" ? record.source : "default",
+	};
+}
+
+const manageDigestInputSchema = z.object({
+	action: z.enum(["route", "unroute", "status"]),
+	channelId: z
+		.string()
+		.min(1)
+		.max(120)
+		.optional()
+		.describe(
+			"Slack channel ID. Required for route and unroute. Use the current slack_channel_id from context for 'here'."
+		),
+	frequency: digestFrequencySchema
+		.optional()
+		.describe("How often investigations run for this scope. Applied on route."),
+	websiteId: z
+		.string()
+		.optional()
+		.describe("Scope to one website. Omit to apply to the whole organization."),
+	confirmed: z.boolean().describe("false=preview, true=apply"),
+});
+
+export function createInsightDigestTools() {
+	const manageInsightDigestTool = tool({
+		description:
+			"Route, stop, or inspect Slack delivery of analytics insight digests. action=route sends digests to a Slack channel, unroute stops it, status shows current routing. Investigations run on their schedule regardless; this only controls where the digest is posted.",
+		inputSchema: manageDigestInputSchema,
+		execute: async (
+			{ action, channelId, frequency, websiteId, confirmed },
+			options
+		) => {
+			const context = getAppContext(options);
+			const scopeInput = {
+				organizationId: context.organizationId,
+				websiteId: websiteId ?? undefined,
+			};
+			try {
+				if (action === "status") {
+					const config = await callRPCProcedure(
+						"insightGeneration",
+						"getConfig",
+						scopeInput,
+						context
+					);
+					const summary = summarizeDigestConfig(config);
+					return {
+						success: true,
+						message:
+							summary.channels.length > 0
+								? `Digests go to ${summary.channels.length} Slack channel${summary.channels.length === 1 ? "" : "s"} on a ${summary.frequency} cadence.`
+								: "No Slack digest delivery is configured for this scope.",
+						digest: summary,
+					};
+				}
+
+				if (!channelId) {
+					throw new Error(
+						"channelId is required to route or unroute a digest."
+					);
+				}
+
+				if (!confirmed) {
+					return {
+						preview: true,
+						confirmationRequired: true,
+						message:
+							action === "route"
+								? `Route insight digests to this Slack channel${frequency ? ` on a ${frequency} cadence` : ""}? Confirm to apply.`
+								: "Stop routing insight digests to this Slack channel? Confirm to apply.",
+						digest: {
+							action,
+							channelId,
+							frequency: frequency ?? null,
+							scope: websiteId ? "website" : "organization",
+						},
+						instruction:
+							"The user must explicitly confirm before you call this tool again with confirmed=true.",
+					};
+				}
+
+				if (action === "unroute") {
+					const config = await callRPCProcedure(
+						"insightGeneration",
+						"removeSlackDelivery",
+						{ ...scopeInput, channelId },
+						context
+					);
+					return {
+						success: true,
+						message: "Stopped routing insight digests to this Slack channel.",
+						digest: summarizeDigestConfig(config),
+					};
+				}
+
+				if (frequency) {
+					await callRPCProcedure(
+						"insightGeneration",
+						"upsertConfig",
+						{ ...scopeInput, frequency },
+						context
+					);
+				}
+				const config = await callRPCProcedure(
+					"insightGeneration",
+					"addSlackDelivery",
+					{ ...scopeInput, channelId },
+					context
+				);
+				const summary = summarizeDigestConfig(config);
+				return {
+					success: true,
+					message: `Insight digests will be delivered to this Slack channel on a ${summary.frequency} cadence.`,
+					digest: summary,
+				};
+			} catch (error) {
+				logger.error("Failed to manage insight digest", {
+					action,
+					websiteId,
+					error,
+				});
+				throw error instanceof Error
+					? error
+					: new Error("Failed to manage insight digest. Please try again.");
+			}
+		},
+	});
+
+	return { manage_insight_digest: manageInsightDigestTool } as const;
+}

--- a/packages/ai/src/ai/tools/insight-digest.ts
+++ b/packages/ai/src/ai/tools/insight-digest.ts
@@ -99,18 +99,10 @@ export function createInsightDigestTools() {
 					};
 				}
 
-				if (frequency) {
-					await callRPCProcedure(
-						"insightGeneration",
-						"upsertConfig",
-						{ ...scopeInput, frequency },
-						context
-					);
-				}
 				const config = await callRPCProcedure(
 					"insightGeneration",
 					"addSlackDelivery",
-					{ ...scopeInput, channelId },
+					{ ...scopeInput, channelId, frequency },
 					context
 				);
 				const summary = summarizeDigestConfig(config);

--- a/packages/ai/src/ai/tools/insight-digest.ts
+++ b/packages/ai/src/ai/tools/insight-digest.ts
@@ -1,50 +1,11 @@
 import { tool } from "ai";
 import { z } from "zod";
+import { summarizeDigestConfig } from "./digest-summary";
 import { callRPCProcedure, createToolLogger, getAppContext } from "./utils";
 
 const logger = createToolLogger("Insight Digest Tools");
 
 const digestFrequencySchema = z.enum(["hourly", "daily", "weekly"]);
-
-interface DigestConfigSummary {
-	channels: string[];
-	enabled: boolean;
-	frequency: string;
-	nextRunAt: string | null;
-	scope: string;
-}
-
-function asRecord(value: unknown): Record<string, unknown> {
-	return value && typeof value === "object" && !Array.isArray(value)
-		? (value as Record<string, unknown>)
-		: {};
-}
-
-function summarizeDigestConfig(config: unknown): DigestConfigSummary {
-	const record = asRecord(config);
-	const deliveries = Array.isArray(record.deliveries) ? record.deliveries : [];
-	const channels = deliveries
-		.map((delivery) => asRecord(delivery))
-		.filter(
-			(delivery) =>
-				delivery.type === "slack" && typeof delivery.channelId === "string"
-		)
-		.map((delivery) => delivery.channelId as string);
-	const nextRunAt = record.nextRunAt;
-	return {
-		channels,
-		enabled: record.enabled !== false,
-		frequency:
-			typeof record.frequency === "string" ? record.frequency : "weekly",
-		nextRunAt:
-			nextRunAt instanceof Date
-				? nextRunAt.toISOString()
-				: typeof nextRunAt === "string"
-					? nextRunAt
-					: null,
-		scope: typeof record.source === "string" ? record.source : "default",
-	};
-}
 
 const manageDigestInputSchema = z.object({
 	action: z.enum(["route", "unroute", "status"]),

--- a/packages/ai/src/query/date-utils.ts
+++ b/packages/ai/src/query/date-utils.ts
@@ -66,7 +66,10 @@ export function padToClickHouseDateTime(value: string): string {
 	return DATE_ONLY_RE.test(value) ? `${value} 00:00:00` : value;
 }
 
-export function todayInTimeZone(timeZone: string, now: Date = new Date()): string {
+export function todayInTimeZone(
+	timeZone: string,
+	now: Date = new Date()
+): string {
 	try {
 		return new Intl.DateTimeFormat("en-CA", {
 			timeZone,

--- a/packages/db/src/drizzle/schema/insights.ts
+++ b/packages/db/src/drizzle/schema/insights.ts
@@ -50,6 +50,11 @@ export type InsightRunItemStatus =
 	| "failed"
 	| "skipped";
 
+export interface InsightDelivery {
+	channelId: string;
+	type: "slack";
+}
+
 export interface InsightGenerationConfigSnapshot {
 	allowedTools: InsightGenerationTool[];
 	cooldownHours: number;
@@ -90,6 +95,10 @@ export const insightGenerationConfigs = pgTable(
 		allowedTools: jsonb("allowed_tools")
 			.$type<InsightGenerationTool[]>()
 			.default([...INSIGHT_GENERATION_DEFAULT_TOOLS])
+			.notNull(),
+		deliveries: jsonb("deliveries")
+			.$type<InsightDelivery[]>()
+			.default([])
 			.notNull(),
 		nextRunAt: timestamp("next_run_at", {
 			precision: 3,

--- a/packages/env/src/insights.ts
+++ b/packages/env/src/insights.ts
@@ -12,6 +12,7 @@ const insightsEnvSchema = z.object({
 	AXIOM_API_KEY: optionalString,
 	AXIOM_TOKEN: optionalString,
 	AXIOM_ORG_ID: optionalString,
+	DATABUDDY_ENCRYPTION_KEY: optionalString,
 });
 
 export const env = createEnv(insightsEnvSchema, {

--- a/packages/evals/src/cases/slack-thread.ts
+++ b/packages/evals/src/cases/slack-thread.ts
@@ -29,6 +29,9 @@ const ANALYTICS_TOOLS = [
 
 const MEMORY_TOOLS = ["search_memory", "save_memory", "forget_memory"];
 
+const OFFER_PHRASING =
+	"\\b(digest|weekly|daily|recurring|rundown|keep an eye|monitor|watch|ping you|drop (a|the)|send you|updates here|report here)\\b";
+
 const NO_SIDE_EFFECT_TOOLS = [...ANALYTICS_TOOLS, ...MEMORY_TOOLS];
 const THREAD_CONTEXT_ONLY = {
 	toolCallCounts: [
@@ -62,6 +65,7 @@ export const slackThreadCases: EvalCase[] = [
 	...dynamicSlackThreadCases(),
 	...fixedSlackQualityCases(),
 	...dynamicSlackQualityCases(),
+	...insightDigestCases(),
 ];
 
 function fixedSlackThreadCases(): EvalCase[] {
@@ -909,6 +913,125 @@ function buildDynamicCorrectionCase(
 			toolsNotCalled: NO_SIDE_EFFECT_TOOLS,
 		},
 	};
+}
+
+function insightDigestCases(): EvalCase[] {
+	return [
+		{
+			id: "digest-explicit-route-here",
+			category: "tool-routing",
+			name: "Routes a recurring digest to this channel on explicit request",
+			query: "can you drop a weekly rundown in this channel going forward?",
+			slack: thread({
+				currentUserId: ISSA,
+				messages: [
+					human(ISSA, "traffic's been climbing, want to stay on top of it"),
+				],
+			}),
+			surfaces: ["slack"],
+			tags: ["slack", "digest", "tool-routing"],
+			websiteId: WS,
+			expect: {
+				maxSteps: 4,
+				maxLatencyMs: 60_000,
+				toolsCalled: ["manage_insight_digest"],
+				toolInputs: [
+					{
+						tool: "manage_insight_digest",
+						includes: { action: "route" },
+					},
+				],
+			},
+		},
+		{
+			id: "digest-explicit-unroute-here",
+			category: "tool-routing",
+			name: "Stops a recurring digest when the user asks to turn it off",
+			query: "actually kill the weekly digest in here, too noisy",
+			slack: thread({
+				currentUserId: KAYLEE,
+				messages: [
+					human(ISSA, "we set up the weekly rundown last month"),
+					bot(
+						"Insight digests are delivered to this Slack channel on a weekly cadence."
+					),
+					human(KAYLEE, "it's a bit much tbh"),
+				],
+			}),
+			surfaces: ["slack"],
+			tags: ["slack", "digest", "tool-routing"],
+			websiteId: WS,
+			expect: {
+				maxSteps: 4,
+				maxLatencyMs: 60_000,
+				toolsCalled: ["manage_insight_digest"],
+				toolInputs: [
+					{
+						tool: "manage_insight_digest",
+						includes: { action: "unroute" },
+					},
+				],
+			},
+		},
+		{
+			id: "digest-no-offer-on-banter",
+			category: "behavioral",
+			name: "Does not pitch a digest on a pure banter turn",
+			query: "lol you're the best",
+			slack: thread({
+				currentUserId: ISSA,
+				messages: [
+					human(ISSA, "appreciate you databuddy"),
+					human(KAYLEE, "real"),
+				],
+			}),
+			surfaces: ["slack"],
+			tags: ["slack", "digest", "guardrail"],
+			websiteId: WS,
+			expect: {
+				maxSteps: 2,
+				maxLatencyMs: 30_000,
+				toolsNotCalled: ["manage_insight_digest"],
+				responseNotMatches: [
+					{
+						description: "no unsolicited digest pitch on banter",
+						pattern: OFFER_PHRASING,
+						flags: "i",
+					},
+				],
+			},
+		},
+		{
+			id: "digest-proactive-offer-after-report",
+			category: "behavioral",
+			name: "Appends a digest offer when delivering a fresh metrics report",
+			query: "how's traffic been the last 7 days?",
+			slack: {
+				currentUserId: ISSA,
+				channelId: "C_EVAL_THREAD",
+				teamId: "T_EVAL",
+				threadTs: "1778005033.664559",
+				trigger: "app_mention",
+				threadMessages: [],
+			},
+			surfaces: ["slack"],
+			tags: ["slack", "digest", "proactive-offer"],
+			websiteId: WS,
+			expect: {
+				maxSteps: 10,
+				maxLatencyMs: 90_000,
+				toolsCalled: ["get_data"],
+				toolsNotCalled: ["manage_insight_digest"],
+				responseMatches: [
+					{
+						description: "offers to set up a recurring digest in this channel",
+						pattern: OFFER_PHRASING,
+						flags: "i",
+					},
+				],
+			},
+		},
+	];
 }
 
 function thread(input: {

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -421,7 +421,7 @@ async function writeEffectiveConfig(
 	return getEffectiveConfig(scope.organizationId, scope.websiteId, executor);
 }
 
-async function mutateSlackDeliveries(
+function mutateSlackDeliveries(
 	scope: { organizationId: string; websiteId: string | null },
 	apply: (current: SlackDelivery[]) => SlackDelivery[]
 ): Promise<z.infer<typeof configOutputSchema>> {

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -40,6 +40,7 @@ const generationToolSchema = z.enum([
 ]);
 const depthSchema = z.enum(["light", "standard", "deep"]);
 const frequencySchema = z.enum(["hourly", "daily", "weekly", "custom"]);
+const scheduledFrequencySchema = z.enum(["hourly", "daily", "weekly"]);
 const modelTierSchema = z.enum(["fast", "balanced", "deep"]);
 const reasonSchema = z.enum(["manual", "scheduled", "cooldown_refresh"]);
 const deliverySchema = z.object({
@@ -740,7 +741,7 @@ export const insightGenerationRouter = {
 		.input(
 			z.object({
 				channelId: z.string().min(1).max(120),
-				frequency: frequencySchema.optional(),
+				frequency: scheduledFrequencySchema.optional(),
 				organizationId: z.string().nullish(),
 				websiteId: z.string().nullish(),
 			})

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -5,6 +5,7 @@ import {
 	eq,
 	inArray,
 	isNull,
+	isUniqueViolationFor,
 	withTransaction,
 } from "@databuddy/db";
 import {
@@ -47,6 +48,10 @@ const deliverySchema = z.object({
 });
 
 const MAX_SLACK_DELIVERIES = 10;
+const CONFIG_UNIQUE_CONSTRAINTS = [
+	"insight_generation_configs_org_default_uidx",
+	"insight_generation_configs_org_website_uidx",
+];
 
 type SlackDelivery = z.infer<typeof deliverySchema>;
 type ConfigExecutor =
@@ -374,7 +379,8 @@ async function getEffectiveConfig(
 async function writeEffectiveConfig(
 	scope: { organizationId: string; websiteId: string | null },
 	next: z.infer<typeof configOutputSchema>,
-	executor: ConfigExecutor = db
+	executor: ConfigExecutor = db,
+	deferCacheInvalidation = false
 ): Promise<z.infer<typeof configOutputSchema>> {
 	const existing = await findConfig(
 		scope.organizationId,
@@ -413,17 +419,20 @@ async function writeEffectiveConfig(
 		});
 	}
 
-	await invalidateInsightsCachesForOrganization(scope.organizationId).catch(
-		() => {
-			// Cache invalidation is best-effort after the config write succeeds.
-		}
-	);
+	if (!deferCacheInvalidation) {
+		await invalidateInsightsCachesForOrganization(scope.organizationId).catch(
+			() => {
+				// Cache invalidation is best-effort after the config write succeeds.
+			}
+		);
+	}
 	return getEffectiveConfig(scope.organizationId, scope.websiteId, executor);
 }
 
-function mutateSlackDeliveries(
+function runSlackDeliveryMutation(
 	scope: { organizationId: string; websiteId: string | null },
-	apply: (current: SlackDelivery[]) => SlackDelivery[]
+	apply: (current: SlackDelivery[]) => SlackDelivery[],
+	patch?: InsightGenerationConfigPatch
 ): Promise<z.infer<typeof configOutputSchema>> {
 	return withTransaction(async (tx) => {
 		await tx
@@ -437,9 +446,35 @@ function mutateSlackDeliveries(
 			scope.websiteId,
 			tx
 		);
+		const base = patch ? applyPatch(current, patch) : current;
 		const deliveries = apply(current.deliveries);
-		return writeEffectiveConfig(scope, { ...current, deliveries }, tx);
+		return writeEffectiveConfig(scope, { ...base, deliveries }, tx, true);
 	});
+}
+
+async function mutateSlackDeliveries(
+	scope: { organizationId: string; websiteId: string | null },
+	apply: (current: SlackDelivery[]) => SlackDelivery[],
+	patch?: InsightGenerationConfigPatch
+): Promise<z.infer<typeof configOutputSchema>> {
+	let result: z.infer<typeof configOutputSchema>;
+	try {
+		result = await runSlackDeliveryMutation(scope, apply, patch);
+	} catch (error) {
+		const isFirstInsertRace = CONFIG_UNIQUE_CONSTRAINTS.some((constraint) =>
+			isUniqueViolationFor(error, constraint)
+		);
+		if (!isFirstInsertRace) {
+			throw error;
+		}
+		result = await runSlackDeliveryMutation(scope, apply, patch);
+	}
+	await invalidateInsightsCachesForOrganization(scope.organizationId).catch(
+		() => {
+			// Cache invalidation is best-effort after the config write commits.
+		}
+	);
+	return result;
 }
 
 export async function ensureOrganizationInsightGenerationConfig(
@@ -705,6 +740,7 @@ export const insightGenerationRouter = {
 		.input(
 			z.object({
 				channelId: z.string().min(1).max(120),
+				frequency: frequencySchema.optional(),
 				organizationId: z.string().nullish(),
 				websiteId: z.string().nullish(),
 			})
@@ -712,21 +748,25 @@ export const insightGenerationRouter = {
 		.output(configOutputSchema)
 		.handler(async ({ context, input }) => {
 			const scope = await resolveScope(context, input, "update");
-			return mutateSlackDeliveries(scope, (current) => {
-				const filtered = current.filter(
-					(delivery) =>
-						!(
-							delivery.type === "slack" &&
-							delivery.channelId === input.channelId
-						)
-				);
-				if (filtered.length >= MAX_SLACK_DELIVERIES) {
-					throw rpcError.badRequest(
-						`Cannot route to more than ${MAX_SLACK_DELIVERIES} Slack channels`
+			return mutateSlackDeliveries(
+				scope,
+				(current) => {
+					const filtered = current.filter(
+						(delivery) =>
+							!(
+								delivery.type === "slack" &&
+								delivery.channelId === input.channelId
+							)
 					);
-				}
-				return [...filtered, { channelId: input.channelId, type: "slack" }];
-			});
+					if (filtered.length >= MAX_SLACK_DELIVERIES) {
+						throw rpcError.badRequest(
+							`Cannot route to more than ${MAX_SLACK_DELIVERIES} Slack channels`
+						);
+					}
+					return [...filtered, { channelId: input.channelId, type: "slack" }];
+				},
+				input.frequency ? { frequency: input.frequency } : undefined
+			);
 		}),
 
 	removeSlackDelivery: protectedProcedure

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -1,4 +1,12 @@
-import { and, db, desc, eq, inArray, isNull } from "@databuddy/db";
+import {
+	and,
+	db,
+	desc,
+	eq,
+	inArray,
+	isNull,
+	withTransaction,
+} from "@databuddy/db";
 import {
 	INSIGHT_GENERATION_DEFAULT_TOOLS,
 	insightGenerationConfigs,
@@ -37,6 +45,13 @@ const deliverySchema = z.object({
 	channelId: z.string().min(1).max(120),
 	type: z.literal("slack"),
 });
+
+const MAX_SLACK_DELIVERIES = 10;
+
+type SlackDelivery = z.infer<typeof deliverySchema>;
+type ConfigExecutor =
+	| typeof db
+	| Parameters<Parameters<typeof withTransaction>[0]>[0];
 
 const configPatchSchema = z.object({
 	allowedTools: z.array(generationToolSchema).min(1).max(4).optional(),
@@ -307,34 +322,38 @@ async function resolveScope(
 	return { organizationId, websiteId: null };
 }
 
+function scopeCondition(organizationId: string, websiteId: string | null) {
+	return websiteId
+		? and(
+				eq(insightGenerationConfigs.organizationId, organizationId),
+				eq(insightGenerationConfigs.websiteId, websiteId)
+			)
+		: and(
+				eq(insightGenerationConfigs.organizationId, organizationId),
+				isNull(insightGenerationConfigs.websiteId)
+			);
+}
+
 async function findConfig(
 	organizationId: string,
-	websiteId: string | null
+	websiteId: string | null,
+	executor: ConfigExecutor = db
 ): Promise<InsightGenerationConfig | null> {
-	const rows = await db
+	const rows = await executor
 		.select()
 		.from(insightGenerationConfigs)
-		.where(
-			websiteId
-				? and(
-						eq(insightGenerationConfigs.organizationId, organizationId),
-						eq(insightGenerationConfigs.websiteId, websiteId)
-					)
-				: and(
-						eq(insightGenerationConfigs.organizationId, organizationId),
-						isNull(insightGenerationConfigs.websiteId)
-					)
-		)
+		.where(scopeCondition(organizationId, websiteId))
 		.limit(1);
 	return rows[0] ?? null;
 }
 
 async function getEffectiveConfig(
 	organizationId: string,
-	websiteId: string | null
+	websiteId: string | null,
+	executor: ConfigExecutor = db
 ): Promise<z.infer<typeof configOutputSchema>> {
 	const fallback = defaultConfig(organizationId, websiteId);
-	const orgConfig = await findConfig(organizationId, null);
+	const orgConfig = await findConfig(organizationId, null, executor);
 	const orgEffective = rowToConfig(
 		orgConfig,
 		fallback,
@@ -344,7 +363,7 @@ async function getEffectiveConfig(
 		return orgEffective;
 	}
 
-	const websiteConfig = await findConfig(organizationId, websiteId);
+	const websiteConfig = await findConfig(organizationId, websiteId, executor);
 	return rowToConfig(
 		websiteConfig,
 		orgEffective,
@@ -354,9 +373,14 @@ async function getEffectiveConfig(
 
 async function writeEffectiveConfig(
 	scope: { organizationId: string; websiteId: string | null },
-	next: z.infer<typeof configOutputSchema>
+	next: z.infer<typeof configOutputSchema>,
+	executor: ConfigExecutor = db
 ): Promise<z.infer<typeof configOutputSchema>> {
-	const existing = await findConfig(scope.organizationId, scope.websiteId);
+	const existing = await findConfig(
+		scope.organizationId,
+		scope.websiteId,
+		executor
+	);
 	const now = new Date();
 	const values = {
 		allowedTools: next.allowedTools,
@@ -376,12 +400,12 @@ async function writeEffectiveConfig(
 	};
 
 	if (existing) {
-		await db
+		await executor
 			.update(insightGenerationConfigs)
 			.set({ ...values, updatedAt: now })
 			.where(eq(insightGenerationConfigs.id, existing.id));
 	} else {
-		await db.insert(insightGenerationConfigs).values({
+		await executor.insert(insightGenerationConfigs).values({
 			id: randomUUIDv7(),
 			organizationId: scope.organizationId,
 			websiteId: scope.websiteId,
@@ -394,7 +418,28 @@ async function writeEffectiveConfig(
 			// Cache invalidation is best-effort after the config write succeeds.
 		}
 	);
-	return getEffectiveConfig(scope.organizationId, scope.websiteId);
+	return getEffectiveConfig(scope.organizationId, scope.websiteId, executor);
+}
+
+async function mutateSlackDeliveries(
+	scope: { organizationId: string; websiteId: string | null },
+	apply: (current: SlackDelivery[]) => SlackDelivery[]
+): Promise<z.infer<typeof configOutputSchema>> {
+	return withTransaction(async (tx) => {
+		await tx
+			.select({ id: insightGenerationConfigs.id })
+			.from(insightGenerationConfigs)
+			.where(scopeCondition(scope.organizationId, scope.websiteId))
+			.limit(1)
+			.for("update");
+		const current = await getEffectiveConfig(
+			scope.organizationId,
+			scope.websiteId,
+			tx
+		);
+		const deliveries = apply(current.deliveries);
+		return writeEffectiveConfig(scope, { ...current, deliveries }, tx);
+	});
 }
 
 export async function ensureOrganizationInsightGenerationConfig(
@@ -667,21 +712,21 @@ export const insightGenerationRouter = {
 		.output(configOutputSchema)
 		.handler(async ({ context, input }) => {
 			const scope = await resolveScope(context, input, "update");
-			const current = await getEffectiveConfig(
-				scope.organizationId,
-				scope.websiteId
-			);
-			const deliveries = [
-				...current.deliveries.filter(
+			return mutateSlackDeliveries(scope, (current) => {
+				const filtered = current.filter(
 					(delivery) =>
 						!(
 							delivery.type === "slack" &&
 							delivery.channelId === input.channelId
 						)
-				),
-				{ channelId: input.channelId, type: "slack" as const },
-			];
-			return writeEffectiveConfig(scope, { ...current, deliveries });
+				);
+				if (filtered.length >= MAX_SLACK_DELIVERIES) {
+					throw rpcError.badRequest(
+						`Cannot route to more than ${MAX_SLACK_DELIVERIES} Slack channels`
+					);
+				}
+				return [...filtered, { channelId: input.channelId, type: "slack" }];
+			});
 		}),
 
 	removeSlackDelivery: protectedProcedure
@@ -701,15 +746,15 @@ export const insightGenerationRouter = {
 		.output(configOutputSchema)
 		.handler(async ({ context, input }) => {
 			const scope = await resolveScope(context, input, "update");
-			const current = await getEffectiveConfig(
-				scope.organizationId,
-				scope.websiteId
+			return mutateSlackDeliveries(scope, (current) =>
+				current.filter(
+					(delivery) =>
+						!(
+							delivery.type === "slack" &&
+							delivery.channelId === input.channelId
+						)
+				)
 			);
-			const deliveries = current.deliveries.filter(
-				(delivery) =>
-					!(delivery.type === "slack" && delivery.channelId === input.channelId)
-			);
-			return writeEffectiveConfig(scope, { ...current, deliveries });
 		}),
 
 	triggerRun: protectedProcedure

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -33,11 +33,16 @@ const depthSchema = z.enum(["light", "standard", "deep"]);
 const frequencySchema = z.enum(["hourly", "daily", "weekly", "custom"]);
 const modelTierSchema = z.enum(["fast", "balanced", "deep"]);
 const reasonSchema = z.enum(["manual", "scheduled", "cooldown_refresh"]);
+const deliverySchema = z.object({
+	channelId: z.string().min(1).max(120),
+	type: z.literal("slack"),
+});
 
 const configPatchSchema = z.object({
 	allowedTools: z.array(generationToolSchema).min(1).max(4).optional(),
 	cooldownHours: z.number().int().min(1).max(168).optional(),
 	cron: z.string().min(1).max(120).nullable().optional(),
+	deliveries: z.array(deliverySchema).max(10).optional(),
 	depth: depthSchema.optional(),
 	enabled: z.boolean().optional(),
 	frequency: frequencySchema.optional(),
@@ -54,6 +59,7 @@ const configOutputSchema = z.object({
 	cooldownHours: z.number(),
 	createdAt: z.union([z.date(), z.string()]).nullable(),
 	cron: z.string().nullable(),
+	deliveries: z.array(deliverySchema),
 	depth: depthSchema,
 	enabled: z.boolean(),
 	frequency: frequencySchema,
@@ -127,6 +133,7 @@ const DEFAULT_CONFIG: Omit<
 	allowedTools: [...INSIGHT_GENERATION_DEFAULT_TOOLS],
 	cooldownHours: 6,
 	cron: null,
+	deliveries: [],
 	depth: "standard",
 	enabled: true,
 	frequency: "weekly",
@@ -173,6 +180,7 @@ function rowToConfig(
 		cooldownHours: row.cooldownHours,
 		createdAt: row.createdAt,
 		cron: row.cron,
+		deliveries: row.deliveries,
 		depth: row.depth,
 		enabled: row.enabled,
 		frequency: row.frequency,
@@ -344,6 +352,51 @@ async function getEffectiveConfig(
 	);
 }
 
+async function writeEffectiveConfig(
+	scope: { organizationId: string; websiteId: string | null },
+	next: z.infer<typeof configOutputSchema>
+): Promise<z.infer<typeof configOutputSchema>> {
+	const existing = await findConfig(scope.organizationId, scope.websiteId);
+	const now = new Date();
+	const values = {
+		allowedTools: next.allowedTools,
+		cooldownHours: next.cooldownHours,
+		cron: next.cron,
+		deliveries: next.deliveries,
+		depth: next.depth,
+		enabled: next.enabled,
+		frequency: next.frequency,
+		lookbackDays: next.lookbackDays,
+		maxInsightsPerWebsite: next.maxInsightsPerWebsite,
+		maxSteps: next.maxSteps,
+		maxToolCalls: next.maxToolCalls,
+		modelTier: next.modelTier,
+		nextRunAt: getNextInsightRunAt(next, now),
+		timezone: next.timezone,
+	};
+
+	if (existing) {
+		await db
+			.update(insightGenerationConfigs)
+			.set({ ...values, updatedAt: now })
+			.where(eq(insightGenerationConfigs.id, existing.id));
+	} else {
+		await db.insert(insightGenerationConfigs).values({
+			id: randomUUIDv7(),
+			organizationId: scope.organizationId,
+			websiteId: scope.websiteId,
+			...values,
+		});
+	}
+
+	await invalidateInsightsCachesForOrganization(scope.organizationId).catch(
+		() => {
+			// Cache invalidation is best-effort after the config write succeeds.
+		}
+	);
+	return getEffectiveConfig(scope.organizationId, scope.websiteId);
+}
+
 export async function ensureOrganizationInsightGenerationConfig(
 	organizationId: string,
 	patch: InsightGenerationConfigPatch = {}
@@ -368,6 +421,7 @@ export async function ensureOrganizationInsightGenerationConfig(
 			allowedTools: next.allowedTools,
 			cooldownHours: next.cooldownHours,
 			cron: next.cron,
+			deliveries: next.deliveries,
 			depth: next.depth,
 			enabled: next.enabled,
 			frequency: next.frequency,
@@ -593,57 +647,69 @@ export const insightGenerationRouter = {
 				scope.websiteId
 			);
 			const next = applyPatch(current, input);
-			const existing = await findConfig(scope.organizationId, scope.websiteId);
-			const now = new Date();
-			const nextRunAt = getNextInsightRunAt(next, now);
+			return writeEffectiveConfig(scope, next);
+		}),
 
-			if (existing) {
-				await db
-					.update(insightGenerationConfigs)
-					.set({
-						allowedTools: next.allowedTools,
-						cooldownHours: next.cooldownHours,
-						cron: next.cron,
-						depth: next.depth,
-						enabled: next.enabled,
-						frequency: next.frequency,
-						lookbackDays: next.lookbackDays,
-						maxInsightsPerWebsite: next.maxInsightsPerWebsite,
-						maxSteps: next.maxSteps,
-						maxToolCalls: next.maxToolCalls,
-						modelTier: next.modelTier,
-						nextRunAt,
-						timezone: next.timezone,
-						updatedAt: now,
-					})
-					.where(eq(insightGenerationConfigs.id, existing.id));
-			} else {
-				await db.insert(insightGenerationConfigs).values({
-					id: randomUUIDv7(),
-					organizationId: scope.organizationId,
-					websiteId: scope.websiteId,
-					allowedTools: next.allowedTools,
-					cooldownHours: next.cooldownHours,
-					cron: next.cron,
-					depth: next.depth,
-					enabled: next.enabled,
-					frequency: next.frequency,
-					lookbackDays: next.lookbackDays,
-					maxInsightsPerWebsite: next.maxInsightsPerWebsite,
-					maxSteps: next.maxSteps,
-					maxToolCalls: next.maxToolCalls,
-					modelTier: next.modelTier,
-					nextRunAt,
-					timezone: next.timezone,
-				});
-			}
-
-			await invalidateInsightsCachesForOrganization(scope.organizationId).catch(
-				() => {
-					// Cache invalidation is best-effort after the config write succeeds.
-				}
+	addSlackDelivery: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/insights/generation/addSlackDelivery",
+			summary: "Route an insight digest to a Slack channel",
+			tags: ["Insights"],
+		})
+		.input(
+			z.object({
+				channelId: z.string().min(1).max(120),
+				organizationId: z.string().nullish(),
+				websiteId: z.string().nullish(),
+			})
+		)
+		.output(configOutputSchema)
+		.handler(async ({ context, input }) => {
+			const scope = await resolveScope(context, input, "update");
+			const current = await getEffectiveConfig(
+				scope.organizationId,
+				scope.websiteId
 			);
-			return getEffectiveConfig(scope.organizationId, scope.websiteId);
+			const deliveries = [
+				...current.deliveries.filter(
+					(delivery) =>
+						!(
+							delivery.type === "slack" &&
+							delivery.channelId === input.channelId
+						)
+				),
+				{ channelId: input.channelId, type: "slack" as const },
+			];
+			return writeEffectiveConfig(scope, { ...current, deliveries });
+		}),
+
+	removeSlackDelivery: protectedProcedure
+		.route({
+			method: "POST",
+			path: "/insights/generation/removeSlackDelivery",
+			summary: "Stop routing an insight digest to a Slack channel",
+			tags: ["Insights"],
+		})
+		.input(
+			z.object({
+				channelId: z.string().min(1).max(120),
+				organizationId: z.string().nullish(),
+				websiteId: z.string().nullish(),
+			})
+		)
+		.output(configOutputSchema)
+		.handler(async ({ context, input }) => {
+			const scope = await resolveScope(context, input, "update");
+			const current = await getEffectiveConfig(
+				scope.organizationId,
+				scope.websiteId
+			);
+			const deliveries = current.deliveries.filter(
+				(delivery) =>
+					!(delivery.type === "slack" && delivery.channelId === input.channelId)
+			);
+			return writeEffectiveConfig(scope, { ...current, deliveries });
 		}),
 
 	triggerRun: protectedProcedure

--- a/packages/rpc/src/routers/links.ts
+++ b/packages/rpc/src/routers/links.ts
@@ -395,12 +395,11 @@ export const linksRouter = {
 							"Failed to cache link after create"
 						)
 					);
-					invalidateAgentContextSnapshotsForOwner(organizationId).catch(
-						(err) =>
-							logger.error(
-								{ organizationId, error: String(err) },
-								"Failed to invalidate agent context snapshots after link create"
-							)
+					invalidateAgentContextSnapshotsForOwner(organizationId).catch((err) =>
+						logger.error(
+							{ organizationId, error: String(err) },
+							"Failed to invalidate agent context snapshots after link create"
+						)
 					);
 
 					return newLink;


### PR DESCRIPTION
## Summary
- Adds conversational control over where investigation digests get delivered: users route/unroute a recurring digest to a Slack channel via the Slack agent or MCP, with no dashboard UI.
- New `manage_insight_digest` tool on both the MCP server and in-app agent toolsets (route/unroute/status, optional frequency and websiteId).
- Agent proactively offers a recurring digest after delivering a metrics report, and stays silent on banter.
- Insights generation now posts the top insights to each org's routed Slack channel after a run, decrypting the org bot token via `@databuddy/encryption`.
- New `deliveries` column on `insightGenerationConfigs` plus RPC procedures (`getConfig`/`upsertConfig`/`addSlackDelivery`/`removeSlackDelivery`) with scope-checked access.

## Test plan
- [x] `bun run check-types` clean across all 34 packages
- [x] Eval suite: 4/4 digest cases passing (score 100) against production data — routes on explicit request, unroutes on request, offers after a report, no offer on banter
- [ ] Verify a real digest posts to a routed Slack channel after a generation run

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add conversational routing for recurring insight digests to Slack, and reliably post them to routed channels. Edits are atomic with a retry on first-insert races, cadence is set on route, channels are de-duped, mrkdwn is escaped, text is truncated to Slack limits, and routing is capped at 10.

- **New Features**
  - New `manage_insight_digest` tool in MCP and in-app (route/unroute/status, optional `hourly`/`daily`/`weekly`, org or website scope).
  - Agent offers a recurring digest after delivering a metrics report; no offer on banter.
  - Generation posts up to 5 top insights to routed Slack channels using the org bot token, decrypted via `@databuddy/encryption`.
  - RPC methods `getConfig`, `upsertConfig`, `addSlackDelivery` (optional cadence: hourly/daily/weekly only), `removeSlackDelivery` with scope checks.
  - Reliability: atomic, commit-safe routing with a retry on first-insert races; cadence set atomically on route; Slack mrkdwn escaped; de-dup channels before posting; truncate Slack header/section text to API limits; max 10 Slack channels per scope.
  - Share one digest config summarizer across MCP and agent tools.

- **Migration**
  - Run DB migrations to add the `deliveries` column.
  - Set `DATABUDDY_ENCRYPTION_KEY` in `apps/insights` env so Slack bot tokens can be decrypted.
  - Ensure an active Slack integration with a stored bot token exists for each org.

<sup>Written for commit e47e5c017e8568f65af4013426e845f39e487e0c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

