### PR TITLE
chore(infra): drop dead redpanda metrics source from Vector

### DIFF
--- a/infra/ingest/vector.yaml
+++ b/infra/ingest/vector.yaml
@@ -24,13 +24,6 @@ sources:
     decoding:
       codec: json
 
-  redpanda_metrics:
-    type: prometheus_scrape
-    endpoints:
-      - "${REDPANDA_METRICS_ENDPOINT}"
-    scrape_interval_secs: 15
-    scrape_timeout_secs: 5
-
 transforms:
   route_analytics:
     type: route
@@ -48,14 +41,6 @@ transforms:
       blocked_traffic: '.topic == "analytics-blocked-traffic"'
       uptime_checks: '.topic == "analytics-uptime-checks"'
       link_visits: '.topic == "analytics-link-visits"'
-
-  redpanda_metrics_transform:
-    type: remap
-    inputs:
-      - redpanda_metrics
-    source: |
-      .tags.cluster = "${REDPANDA_CLUSTER_NAME}"
-      .tags.env = "${ENVIRONMENT}"
 
 sinks:
   clickhouse_events:
@@ -285,11 +270,3 @@ sinks:
     path: /var/log/vector/dead_letters.log
     encoding:
       codec: json
-
-  axiom_redpanda_metrics:
-    type: axiom
-    inputs:
-      - redpanda_metrics_transform
-    dataset: "${AXIOM_DATASET}"
-    token: "${AXIOM_TOKEN}"
-    compression: gzip


### PR DESCRIPTION
## Summary

Cleanup after #481. Removes the `redpanda_metrics` prometheus_scrape source, its `redpanda_metrics_transform`, and the `axiom_redpanda_metrics` sink from Vector's pipeline.

The source had been failing every 15s since the Redpanda Cloud migration — Cloud doesn't expose `/public_metrics` on a public port the way the self-hosted Hetzner box did. Cluster metrics are visible in the Redpanda Cloud dashboard now.

Corresponding Railway env vars (`REDPANDA_METRICS_ENDPOINT`, `REDPANDA_CLUSTER_NAME`, `AXIOM_DATASET`, `AXIOM_TOKEN` on Vector + Vector Staging, plus `ALLOW_INSECURE_KAFKA` on Basket) already removed.

## Test plan

- [ ] Vector logs no longer spam `Connection refused` against 157.180.x or `request_failed` against `/public_metrics`
- [ ] Consumer group `vector-analytics` remains stable and continues consuming

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead Redpanda metrics pipeline from `Vector` to stop failing scrapes and reduce log noise after the Redpanda Cloud migration.

- **Refactors**
  - Dropped `redpanda_metrics` source, `redpanda_metrics_transform`, and `axiom_redpanda_metrics` sink from `infra/ingest/vector.yaml`.

<sup>Written for commit c0330356c176ee1faf9e9b496912b118128b04e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

