### PR TITLE
Land in-flight ai, db, and redis cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "db:deploy": "dotenv -- turbo run db:deploy",
     "db:seed": "dotenv -- sh -c 'cd packages/db && bun run db:seed \"$@\"' --",
     "email:dev": "dotenv -- sh -c 'cd packages/email && bun run dev'",
+    "email:segments": "dotenv -- sh -c 'cd packages/db && bun run email:segments \"$@\"' --",
     "sdk:build": "turbo run build --filter @databuddy/sdk --filter @databuddy/cache",
     "dev:dashboard": "dotenv -- turbo run dev --filter @databuddy/dashboard --filter @databuddy/api --filter @databuddy/insights",
     "dev:insights": "dotenv -- turbo run dev --filter @databuddy/insights",

--- a/packages/ai/src/ai/mcp/agent-tools.ts
+++ b/packages/ai/src/ai/mcp/agent-tools.ts
@@ -147,7 +147,8 @@ export function createMcpAgentTools(
 				const data = await executeQuery(
 					queryRequest,
 					websiteDomain,
-					queryRequest.timezone
+					queryRequest.timezone,
+					options.abortSignal
 				);
 				return { data, rowCount: data.length, type: args.type };
 			},
@@ -182,6 +183,7 @@ Critical schema footguns: website id column is client_id (not website_id); times
 					sql: args.sql,
 					params: args.params,
 					toolName: "MCP Agent SQL",
+					abortSignal: options.abortSignal,
 				});
 			},
 		}),
@@ -233,6 +235,7 @@ Critical schema footguns: website id column is client_id (not website_id); times
 				const results = await executeBatch(requests, {
 					websiteDomain,
 					timezone: args.timezone ?? "UTC",
+					abortSignal: options.abortSignal,
 				});
 				return {
 					batch: true,

--- a/packages/ai/src/ai/mcp/investigate.ts
+++ b/packages/ai/src/ai/mcp/investigate.ts
@@ -302,6 +302,12 @@ export async function runInvestigation(
 				"",
 				"Tool trace (what was actually queried and returned):",
 				compactTrace(trace.toolCalls),
+				...(trace.truncated
+					? [
+							"",
+							"NOTE: This investigation was stopped by a time limit before the agent finished gathering data. Base your memo only on the partial tool trace above. State in the verdict reason that the run was time-limited, and set confidence to 'low' unless the partial evidence is unambiguous.",
+						]
+					: []),
 			].join("\n"),
 		});
 

--- a/packages/ai/src/ai/mcp/run-agent.ts
+++ b/packages/ai/src/ai/mcp/run-agent.ts
@@ -5,7 +5,7 @@ import {
 	storeConversation,
 } from "../../lib/supermemory";
 import type { ApiKeyRow } from "@databuddy/api-keys/resolve";
-import type { LanguageModelUsage } from "ai";
+import type { LanguageModelUsage, StepResult, ToolSet } from "ai";
 import { ToolLoopAgent } from "ai";
 import { DatabuddyAgentUserError } from "../../agent/errors";
 import { getAILogger } from "../../lib/ai-logger";
@@ -55,6 +55,7 @@ export interface RunMcpAgentTraceResult {
 	answer: string;
 	steps: number;
 	toolCalls: McpAgentToolTrace[];
+	truncated?: boolean;
 	usage: LanguageModelUsage;
 }
 
@@ -114,9 +115,71 @@ export async function runMcpAgentWithTrace(
 			toolCalls: collectToolTrace(result.steps),
 			usage: result.totalUsage,
 		};
+	} catch (err) {
+		if (isInternalTimeoutAbort(err, options.abortSignal)) {
+			return await buildTruncatedTrace(prepared);
+		}
+		throw err;
 	} finally {
 		abort.cleanup();
 	}
+}
+
+function isInternalTimeoutAbort(
+	err: unknown,
+	externalSignal: AbortSignal | undefined
+): boolean {
+	return (
+		err instanceof Error &&
+		err.name === "AbortError" &&
+		!externalSignal?.aborted
+	);
+}
+
+async function buildTruncatedTrace(
+	prepared: Awaited<ReturnType<typeof prepareMcpAgentRun>>
+): Promise<RunMcpAgentTraceResult> {
+	const steps = prepared.capturedSteps;
+	const usage = aggregateStepUsage(steps);
+	await trackPreparedUsage(prepared, usage);
+	const stepCount = steps.length;
+	return {
+		answer: `The investigation reached its time budget after ${stepCount} step${stepCount === 1 ? "" : "s"} and was stopped before composing a final summary. The partial tool trace is the only evidence gathered.`,
+		steps: stepCount,
+		toolCalls: collectToolTrace(steps),
+		truncated: true,
+		usage,
+	};
+}
+
+function aggregateStepUsage(
+	steps: ReadonlyArray<{ usage: LanguageModelUsage }>
+): LanguageModelUsage {
+	let inputTokens = 0;
+	let outputTokens = 0;
+	let totalTokens = 0;
+	let noCacheTokens = 0;
+	let cacheReadTokens = 0;
+	let cacheWriteTokens = 0;
+	let textTokens = 0;
+	let reasoningTokens = 0;
+	for (const { usage } of steps) {
+		inputTokens += usage.inputTokens ?? 0;
+		outputTokens += usage.outputTokens ?? 0;
+		totalTokens += usage.totalTokens ?? 0;
+		noCacheTokens += usage.inputTokenDetails?.noCacheTokens ?? 0;
+		cacheReadTokens += usage.inputTokenDetails?.cacheReadTokens ?? 0;
+		cacheWriteTokens += usage.inputTokenDetails?.cacheWriteTokens ?? 0;
+		textTokens += usage.outputTokenDetails?.textTokens ?? 0;
+		reasoningTokens += usage.outputTokenDetails?.reasoningTokens ?? 0;
+	}
+	return {
+		inputTokens,
+		outputTokens,
+		totalTokens,
+		inputTokenDetails: { noCacheTokens, cacheReadTokens, cacheWriteTokens },
+		outputTokenDetails: { textTokens, reasoningTokens },
+	};
 }
 
 export async function* streamMcpAgentText(
@@ -189,12 +252,7 @@ async function prepareMcpAgentRun(options: RunMcpAgentOptions) {
 	const selectedModelId =
 		options.modelOverride ?? getDefaultAgentModelId(source);
 
-	const apiKeyId =
-		options.apiKey &&
-		typeof options.apiKey === "object" &&
-		"id" in options.apiKey
-			? (options.apiKey as { id: string }).id
-			: null;
+	const apiKeyId = options.apiKey?.id ?? null;
 
 	const billingCustomerId =
 		options.billingMode === "skip"
@@ -265,6 +323,7 @@ async function prepareMcpAgentRun(options: RunMcpAgentOptions) {
 	mcpTelemetryMetadata["tcc.sessionId"] = sessionId;
 
 	const ai = getAILogger();
+	const capturedSteps: StepResult<ToolSet>[] = [];
 	const agent = new ToolLoopAgent({
 		model: ai.wrap(config.model),
 		instructions,
@@ -273,6 +332,9 @@ async function prepareMcpAgentRun(options: RunMcpAgentOptions) {
 		stopWhen: config.stopWhen,
 		temperature: config.temperature,
 		experimental_context: config.experimental_context,
+		onStepFinish: (step) => {
+			capturedSteps.push(step);
+		},
 		experimental_telemetry: {
 			isEnabled: true,
 			functionId: `databuddy.${source}.ask`,
@@ -296,6 +358,7 @@ async function prepareMcpAgentRun(options: RunMcpAgentOptions) {
 		agent,
 		apiKeyId,
 		billingCustomerId,
+		capturedSteps,
 		memoryUserId,
 		mcpUserId,
 		messages,

--- a/packages/ai/src/ai/tools/execute-sql-query.ts
+++ b/packages/ai/src/ai/tools/execute-sql-query.ts
@@ -32,12 +32,14 @@ export async function executeAgentSqlForWebsite({
 	sql,
 	params,
 	toolName = "Execute SQL Tool",
+	abortSignal,
 }: {
 	websiteId: string;
 	websiteDomain?: string;
 	sql: string;
 	params?: Record<string, unknown>;
 	toolName?: string;
+	abortSignal?: AbortSignal;
 }): Promise<QueryResult> {
 	const validation = validateAgentSQL(sql);
 	if (!validation.valid) {
@@ -66,7 +68,8 @@ export async function executeAgentSqlForWebsite({
 			max_result_bytes: 50_000_000,
 			result_overflow_mode: "break",
 			use_query_cache: 0,
-		}
+		},
+		abortSignal
 	);
 
 	return result.data.length > MAX_MODEL_ROWS
@@ -104,6 +107,7 @@ export const executeSqlQueryTool = tool({
 			websiteDomain: resolved.domain,
 			sql,
 			params,
+			abortSignal: options.abortSignal,
 		});
 	},
 });

--- a/packages/ai/src/ai/tools/utils/query.ts
+++ b/packages/ai/src/ai/tools/utils/query.ts
@@ -73,13 +73,15 @@ export async function executeTimedQuery<T extends Record<string, unknown>>(
 	sql: string,
 	params: Record<string, unknown> = {},
 	logContext?: Record<string, unknown>,
-	clickhouseSettings?: Record<string, string | number>
+	clickhouseSettings?: Record<string, string | number>,
+	abortSignal?: AbortSignal
 ): Promise<QueryResult<T>> {
 	const logger = createToolLogger(toolName);
 	const queryStart = Date.now();
 
 	try {
 		const raw = await chQuery<T>(sql, params, {
+			abort_signal: abortSignal,
 			readonly: true,
 			...(clickhouseSettings && { clickhouse_settings: clickhouseSettings }),
 		});

--- a/packages/ai/src/query/batch-executor.ts
+++ b/packages/ai/src/query/batch-executor.ts
@@ -15,6 +15,7 @@ interface BatchResult {
 	type: string;
 }
 interface BatchOptions {
+	abortSignal?: AbortSignal;
 	timezone?: string;
 	websiteDomain?: string | null;
 }
@@ -252,7 +253,7 @@ async function runSingle(
 			{ ...req, timezone: opts?.timezone ?? req.timezone },
 			opts?.websiteDomain
 		);
-		const data = await builder.execute();
+		const data = await builder.execute(opts?.abortSignal);
 
 		mergeWideEvent({
 			query_type: req.type,
@@ -422,6 +423,7 @@ export async function executeBatch(
 				({ req }) => QueryBuilders[req.type]?.noCache
 			);
 			const rawRows = await chQuery(sql, params, {
+				abort_signal: opts?.abortSignal,
 				clickhouse_settings: getClickHouseQuerySettings(groupNoCache),
 			});
 

--- a/packages/ai/src/query/index.ts
+++ b/packages/ai/src/query/index.ts
@@ -83,8 +83,9 @@ function createBuilder(
 export const executeQuery = async (
 	request: QueryRequest,
 	websiteDomain?: string | null,
-	timezone?: string
-) => createBuilder(request, websiteDomain, timezone).execute();
+	timezone?: string,
+	abortSignal?: AbortSignal
+) => createBuilder(request, websiteDomain, timezone).execute(abortSignal);
 
 export const compileQuery = (
 	request: QueryRequest,

--- a/packages/ai/src/query/simple-builder.ts
+++ b/packages/ai/src/query/simple-builder.ts
@@ -1104,9 +1104,10 @@ export class SimpleQueryBuilder {
 		return this.request.offset ? ` OFFSET ${this.request.offset}` : "";
 	}
 
-	async execute(): Promise<Record<string, unknown>[]> {
+	async execute(abortSignal?: AbortSignal): Promise<Record<string, unknown>[]> {
 		const { sql, params } = this.compile();
 		const rawData = await chQuery<Record<string, unknown>>(sql, params, {
+			abort_signal: abortSignal,
 			clickhouse_settings: getClickHouseQuerySettings(this.config.noCache),
 		});
 		return applyPlugins(rawData, this.config, this.websiteDomain);

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,6 +18,7 @@
     "db:push": "dotenv -- drizzle-kit push",
     "db:studio": "dotenv -- drizzle-kit studio",
     "db:seed": "tsx src/seed.ts",
+    "email:segments": "dotenv -- bun src/scripts/export-user-email-segments.ts",
     "clickhouse:init": "tsx src/clickhouse/setup.ts",
     "test": "bun test src",
     "e2e:db:create": "bun ./scripts/e2e-db-lifecycle.ts create",

--- a/packages/db/src/clickhouse/client.ts
+++ b/packages/db/src/clickhouse/client.ts
@@ -147,6 +147,7 @@ export const clickHouse: ClickHouseClient = Object.assign(
 );
 
 export interface ChQueryOptions {
+	abort_signal?: AbortSignal;
 	clickhouse_settings?: Record<string, string | number>;
 	readonly?: boolean;
 }
@@ -163,6 +164,7 @@ async function chQueryWithMeta<T>(
 	const res = await clickHouse.query({
 		query,
 		query_params: params,
+		...(options?.abort_signal && { abort_signal: options.abort_signal }),
 		...(Object.keys(settings).length > 0 && {
 			clickhouse_settings: settings,
 		}),

--- a/packages/db/src/scripts/export-user-email-segments.ts
+++ b/packages/db/src/scripts/export-user-email-segments.ts
@@ -1,0 +1,531 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { and, eq, isNull } from "drizzle-orm";
+import { chQuery } from "../clickhouse";
+import { db, shutdownPostgres } from "../client";
+import { member, user, websites } from "../drizzle/schema";
+import {
+	EMAIL_SEGMENTS,
+	type SegmentUser,
+	type SegmentWebsite,
+	type SegmentedUser,
+	type WebsiteActivity,
+	segmentRowsToCsv,
+	segmentUsers,
+} from "../user-email-segments";
+
+const AUTUMN_API_VERSION = "1.2";
+const AUTUMN_API_URL = "https://api.useautumn.com/v1";
+const ACTIVE_PRODUCT_STATUSES = new Set(["active", "trialing", "past_due"]);
+const PAID_CUSTOMER_HEADER_RE = /^customer[_ -]?id\b/i;
+const PAID_CUSTOMER_SEPARATOR_RE = /[\t,]/;
+const LINE_SPLIT_RE = /\r?\n/;
+
+interface CliOptions {
+	activeDays: number;
+	includeUnverified: boolean;
+	minEvents: number;
+	outputDir: string;
+	paidCustomerIdsPath: string | null;
+	skipAutumn: boolean;
+}
+
+interface AutumnCustomerListResponse {
+	limit: number;
+	list: unknown[];
+	offset: number;
+	total: number;
+}
+
+interface ExportSummary {
+	activeDays: number;
+	generatedAt: string;
+	includeUnverified: boolean;
+	minEvents: number;
+	paidCustomerCount: number;
+	segments: Record<
+		string,
+		{
+			count: number;
+			file: string;
+		}
+	>;
+	warnings: string[];
+}
+
+function parsePositiveInteger(value: string, name: string): number {
+	const parsed = Number.parseInt(value, 10);
+	if (!(Number.isFinite(parsed) && parsed > 0)) {
+		throw new Error(`${name} must be a positive integer`);
+	}
+	return parsed;
+}
+
+function optionValue(arg: string, name: string): string | null {
+	const prefix = `${name}=`;
+	if (!arg.startsWith(prefix)) {
+		return null;
+	}
+	return arg.slice(prefix.length);
+}
+
+function readCliOptions(argv: string[]): CliOptions {
+	const options: CliOptions = {
+		activeDays: 30,
+		includeUnverified: false,
+		minEvents: 1,
+		outputDir: "tmp/email-segments",
+		paidCustomerIdsPath: null,
+		skipAutumn: false,
+	};
+
+	for (const arg of argv) {
+		if (arg === "--include-unverified") {
+			options.includeUnverified = true;
+			continue;
+		}
+		if (arg === "--skip-autumn") {
+			options.skipAutumn = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h") {
+			printHelp();
+			process.exit(0);
+		}
+
+		const activeDays = optionValue(arg, "--active-days");
+		if (activeDays !== null) {
+			options.activeDays = parsePositiveInteger(activeDays, "--active-days");
+			continue;
+		}
+
+		const minEvents = optionValue(arg, "--min-events");
+		if (minEvents !== null) {
+			options.minEvents = parsePositiveInteger(minEvents, "--min-events");
+			continue;
+		}
+
+		const outputDir = optionValue(arg, "--output-dir");
+		if (outputDir !== null) {
+			options.outputDir = outputDir;
+			continue;
+		}
+
+		const paidCustomerIdsPath = optionValue(arg, "--paid-customer-ids");
+		if (paidCustomerIdsPath !== null) {
+			options.paidCustomerIdsPath = paidCustomerIdsPath;
+			continue;
+		}
+
+		throw new Error(`Unknown option: ${arg}`);
+	}
+
+	return options;
+}
+
+function printHelp() {
+	console.log(`Export user email segments.
+
+Usage:
+  bun run email:segments [options]
+
+Options:
+  --active-days=N              Recent screen_view window. Default: 30
+  --min-events=N               Minimum recent screen_view events for active. Default: 1
+  --output-dir=PATH            Directory for CSV output. Default: tmp/email-segments
+  --paid-customer-ids=PATH     Optional newline/CSV file of paid customer IDs
+  --include-unverified         Include users whose email is not verified
+  --skip-autumn                Do not fetch paid customers from Autumn
+`);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function readString(value: unknown): string | null {
+	return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function readBoolean(value: unknown): boolean {
+	return value === true;
+}
+
+function isoString(value: Date | string): string {
+	return value instanceof Date ? value.toISOString() : value;
+}
+
+async function loadUsers(includeUnverified: boolean): Promise<SegmentUser[]> {
+	const filters = [isNull(user.deletedAt), eq(user.status, "ACTIVE")];
+	if (!includeUnverified) {
+		filters.push(eq(user.emailVerified, true));
+	}
+
+	const [rows, ownerRows] = await Promise.all([
+		db
+			.select({
+				createdAt: user.createdAt,
+				email: user.email,
+				emailVerified: user.emailVerified,
+				firstName: user.firstName,
+				id: user.id,
+				name: user.name,
+				organizationId: member.organizationId,
+			})
+			.from(user)
+			.leftJoin(member, eq(member.userId, user.id))
+			.where(and(...filters)),
+		db
+			.select({
+				organizationId: member.organizationId,
+				userId: member.userId,
+			})
+			.from(member)
+			.where(eq(member.role, "owner")),
+	]);
+
+	const ownerByOrganizationId = new Map(
+		ownerRows.map((row) => [row.organizationId, row.userId])
+	);
+	const usersById = new Map<
+		string,
+		Omit<SegmentUser, "billingCustomerIds" | "organizationIds"> & {
+			billingCustomerIds: Set<string>;
+			organizationIds: Set<string>;
+		}
+	>();
+
+	for (const row of rows) {
+		const existing = usersById.get(row.id);
+		const current = existing ?? {
+			billingCustomerIds: new Set([row.id]),
+			createdAt: isoString(row.createdAt),
+			email: row.email,
+			emailVerified: row.emailVerified,
+			firstName: row.firstName,
+			id: row.id,
+			name: row.name,
+			organizationIds: new Set<string>(),
+		};
+
+		if (row.organizationId) {
+			current.organizationIds.add(row.organizationId);
+			const ownerId = ownerByOrganizationId.get(row.organizationId);
+			if (ownerId) {
+				current.billingCustomerIds.add(ownerId);
+			}
+		}
+
+		usersById.set(row.id, current);
+	}
+
+	return [...usersById.values()].map((row) => ({
+		...row,
+		billingCustomerIds: [...row.billingCustomerIds],
+		organizationIds: [...row.organizationIds],
+	}));
+}
+
+function loadWebsites(): Promise<SegmentWebsite[]> {
+	return db
+		.select({
+			id: websites.id,
+			organizationId: websites.organizationId,
+		})
+		.from(websites)
+		.where(isNull(websites.deletedAt));
+}
+
+async function loadWebsiteActivity(
+	websiteIds: string[],
+	activeDays: number
+): Promise<WebsiteActivity[]> {
+	if (websiteIds.length === 0) {
+		return [];
+	}
+
+	const activeSince = new Date(Date.now() - activeDays * 24 * 60 * 60 * 1000);
+	const rows = await chQuery<{
+		eventsInWindow: number;
+		lastEventAt: string | null;
+		websiteId: string;
+	}>(
+		`SELECT
+			client_id AS websiteId,
+			count() AS eventsInWindow,
+			toString(max(time)) AS lastEventAt
+		FROM analytics.events
+		PREWHERE time >= parseDateTime64BestEffort({activeSince:String})
+			AND client_id IN {websiteIds:Array(String)}
+		WHERE event_name = 'screen_view'
+		GROUP BY client_id`,
+		{
+			activeSince: activeSince.toISOString(),
+			websiteIds,
+		},
+		{ readonly: true }
+	);
+
+	return rows.map((row) => ({
+		eventsInWindow: row.eventsInWindow,
+		lastEventAt: row.lastEventAt,
+		websiteId: row.websiteId,
+	}));
+}
+
+function planIdFromProduct(product: Record<string, unknown>): string | null {
+	const id = readString(product.id) ?? readString(product.planId);
+	const status = readString(product.status)?.toLowerCase();
+	const isAddOn = readBoolean(product.is_add_on) || readBoolean(product.addOn);
+	const isDefault = readBoolean(product.is_default);
+
+	if (!(id && status && ACTIVE_PRODUCT_STATUSES.has(status))) {
+		return null;
+	}
+	if (isAddOn || isDefault || id.toLowerCase() === "free") {
+		return null;
+	}
+	return id.toLowerCase();
+}
+
+function paidPlanFromCustomer(customer: unknown): string | null {
+	if (!isRecord(customer)) {
+		return null;
+	}
+	const products = Array.isArray(customer.products)
+		? customer.products
+		: Array.isArray(customer.subscriptions)
+			? customer.subscriptions
+			: [];
+
+	for (const product of products) {
+		if (!isRecord(product)) {
+			continue;
+		}
+		const planId = planIdFromProduct(product);
+		if (planId) {
+			return planId;
+		}
+	}
+	return null;
+}
+
+function customerIdFromCustomer(customer: unknown): string | null {
+	if (!isRecord(customer)) {
+		return null;
+	}
+	return readString(customer.id);
+}
+
+function parseAutumnCustomerList(value: unknown): AutumnCustomerListResponse {
+	if (!(isRecord(value) && Array.isArray(value.list))) {
+		throw new Error("Unexpected Autumn customers response");
+	}
+	const total =
+		typeof value.total_filtered_count === "number"
+			? value.total_filtered_count
+			: typeof value.total_count === "number"
+				? value.total_count
+				: typeof value.total === "number"
+					? value.total
+					: value.list.length;
+
+	return {
+		limit: typeof value.limit === "number" ? value.limit : value.list.length,
+		list: value.list,
+		offset: typeof value.offset === "number" ? value.offset : 0,
+		total,
+	};
+}
+
+async function fetchAutumnPaidCustomerPlans(): Promise<Map<string, string>> {
+	const secretKey = process.env.AUTUMN_SECRET_KEY;
+	if (!secretKey) {
+		return new Map();
+	}
+
+	const plans = new Map<string, string>();
+	const limit = 100;
+	let offset = 0;
+	let total = Number.POSITIVE_INFINITY;
+
+	while (offset < total) {
+		const url = new URL(`${AUTUMN_API_URL}/customers`);
+		url.searchParams.set("limit", String(limit));
+		url.searchParams.set("offset", String(offset));
+
+		const response = await fetch(url, {
+			headers: {
+				Authorization: `Bearer ${secretKey}`,
+				"Content-Type": "application/json",
+				"x-api-version": AUTUMN_API_VERSION,
+			},
+		});
+
+		if (!response.ok) {
+			throw new Error(`Autumn customers request failed: ${response.status}`);
+		}
+
+		const payload = parseAutumnCustomerList(await response.json());
+		for (const customer of payload.list) {
+			const customerId = customerIdFromCustomer(customer);
+			const planId = paidPlanFromCustomer(customer);
+			if (customerId && planId) {
+				plans.set(customerId, planId);
+			}
+		}
+
+		if (payload.list.length === 0) {
+			break;
+		}
+		total = payload.total;
+		offset = payload.offset + payload.limit;
+	}
+
+	return plans;
+}
+
+function parsePaidCustomerLine(line: string): [string, string] | null {
+	const trimmed = line.trim();
+	if (!(trimmed && !trimmed.startsWith("#"))) {
+		return null;
+	}
+	if (PAID_CUSTOMER_HEADER_RE.test(trimmed)) {
+		return null;
+	}
+
+	const [customerId, planId] = trimmed
+		.split(PAID_CUSTOMER_SEPARATOR_RE)
+		.map((part) => part.trim());
+	if (!customerId) {
+		return null;
+	}
+	return [customerId, planId || "paid"];
+}
+
+async function readPaidCustomerPlansFromFile(
+	filePath: string
+): Promise<Map<string, string>> {
+	const resolvedPath = path.resolve(filePath);
+	const file = await readFile(resolvedPath, "utf8").catch(() => null);
+	if (file === null) {
+		throw new Error(`Paid customer file not found: ${filePath}`);
+	}
+
+	const rows = file
+		.split(LINE_SPLIT_RE)
+		.map(parsePaidCustomerLine)
+		.filter((row): row is [string, string] => Boolean(row));
+
+	return new Map(rows);
+}
+
+async function loadPaidCustomerPlans(
+	options: CliOptions,
+	warnings: string[]
+): Promise<Map<string, string>> {
+	const plans = new Map<string, string>();
+
+	if (options.paidCustomerIdsPath) {
+		for (const [customerId, planId] of await readPaidCustomerPlansFromFile(
+			options.paidCustomerIdsPath
+		)) {
+			plans.set(customerId, planId);
+		}
+	}
+
+	if (!options.skipAutumn && process.env.AUTUMN_SECRET_KEY) {
+		for (const [customerId, planId] of await fetchAutumnPaidCustomerPlans()) {
+			plans.set(customerId, planId);
+		}
+	}
+
+	if (plans.size === 0) {
+		warnings.push(
+			"No paid customer source was loaded; paying.csv will be empty unless paid IDs are supplied."
+		);
+	}
+
+	if (!(options.skipAutumn || process.env.AUTUMN_SECRET_KEY)) {
+		warnings.push(
+			"AUTUMN_SECRET_KEY is not set; pass --paid-customer-ids=PATH or run with billing env loaded for paying users."
+		);
+	}
+
+	return plans;
+}
+
+function segmentFileName(segment: string): string {
+	return `${segment.replaceAll("_", "-")}.csv`;
+}
+
+async function writeSegments(
+	outputDir: string,
+	segments: Record<string, SegmentedUser[]>,
+	summary: ExportSummary
+) {
+	await mkdir(outputDir, { recursive: true });
+
+	for (const segment of EMAIL_SEGMENTS) {
+		const fileName = segmentFileName(segment);
+		await writeFile(
+			path.join(outputDir, fileName),
+			segmentRowsToCsv(segments[segment])
+		);
+		summary.segments[segment] = {
+			count: segments[segment].length,
+			file: fileName,
+		};
+	}
+
+	await writeFile(
+		path.join(outputDir, "summary.json"),
+		`${JSON.stringify(summary, null, 2)}\n`
+	);
+}
+
+async function main() {
+	const options = readCliOptions(process.argv.slice(2));
+	const outputDir = path.resolve(options.outputDir);
+	const warnings: string[] = [];
+
+	try {
+		const [users, sites, paidPlans] = await Promise.all([
+			loadUsers(options.includeUnverified),
+			loadWebsites(),
+			loadPaidCustomerPlans(options, warnings),
+		]);
+		const activity = await loadWebsiteActivity(
+			sites.map((site) => site.id),
+			options.activeDays
+		);
+		const segments = segmentUsers(users, sites, activity, paidPlans, {
+			minEvents: options.minEvents,
+		});
+		const summary: ExportSummary = {
+			activeDays: options.activeDays,
+			generatedAt: new Date().toISOString(),
+			includeUnverified: options.includeUnverified,
+			minEvents: options.minEvents,
+			paidCustomerCount: paidPlans.size,
+			segments: {},
+			warnings,
+		};
+
+		await writeSegments(outputDir, segments, summary);
+
+		console.log(`Wrote email segments to ${outputDir}`);
+		for (const segment of EMAIL_SEGMENTS) {
+			console.log(`${segment}: ${segments[segment].length}`);
+		}
+		for (const warning of warnings) {
+			console.warn(`Warning: ${warning}`);
+		}
+	} finally {
+		await shutdownPostgres();
+	}
+}
+
+if (import.meta.main) {
+	await main();
+}

--- a/packages/db/src/user-email-segments.test.ts
+++ b/packages/db/src/user-email-segments.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type SegmentUser,
+	segmentRowsToCsv,
+	segmentUsers,
+} from "./user-email-segments";
+
+const baseUser = {
+	createdAt: "2026-01-01T00:00:00.000Z",
+	emailVerified: true,
+	firstName: null,
+	name: "",
+} satisfies Partial<SegmentUser>;
+
+function user(input: Partial<SegmentUser> & Pick<SegmentUser, "email" | "id">) {
+	return {
+		...baseUser,
+		billingCustomerIds: [input.id],
+		organizationIds: [],
+		...input,
+	} satisfies SegmentUser;
+}
+
+describe("segmentUsers", () => {
+	test("puts paid users in paying before activity segments", () => {
+		const segments = segmentUsers(
+			[
+				user({
+					email: "paying@example.com",
+					id: "user-1",
+					organizationIds: ["org-1"],
+				}),
+			],
+			[{ id: "site-1", organizationId: "org-1" }],
+			[{ eventsInWindow: 0, lastEventAt: null, websiteId: "site-1" }],
+			new Map([["user-1", "pro"]]),
+			{ minEvents: 1 }
+		);
+
+		expect(segments.paying).toHaveLength(1);
+		expect(segments.active_websites).toHaveLength(0);
+		expect(segments.paying[0]).toMatchObject({
+			email: "paying@example.com",
+			planIds: ["pro"],
+			segment: "paying",
+		});
+	});
+
+	test("splits free users by recent website activity and missing websites", () => {
+		const segments = segmentUsers(
+			[
+				user({
+					email: "active@example.com",
+					id: "user-1",
+					organizationIds: ["org-1"],
+				}),
+				user({
+					email: "inactive@example.com",
+					id: "user-2",
+					organizationIds: ["org-2"],
+				}),
+				user({ email: "empty@example.com", id: "user-3" }),
+			],
+			[
+				{ id: "site-1", organizationId: "org-1" },
+				{ id: "site-2", organizationId: "org-2" },
+			],
+			[
+				{
+					eventsInWindow: 12,
+					lastEventAt: "2026-01-02T00:00:00.000Z",
+					websiteId: "site-1",
+				},
+			],
+			new Map(),
+			{ minEvents: 1 }
+		);
+
+		expect(segments.active_websites.map((row) => row.email)).toEqual([
+			"active@example.com",
+		]);
+		expect(segments.inactive_websites.map((row) => row.email)).toEqual([
+			"inactive@example.com",
+		]);
+		expect(segments.no_websites.map((row) => row.email)).toEqual([
+			"empty@example.com",
+		]);
+	});
+});
+
+describe("segmentRowsToCsv", () => {
+	test("escapes names and joins multi-value fields", () => {
+		const csv = segmentRowsToCsv([
+			{
+				activeWebsiteCount: 1,
+				billingCustomerIds: ["user-1", "owner-1"],
+				createdAt: "2026-01-01T00:00:00.000Z",
+				email: "test@example.com",
+				eventsInWindow: 3,
+				firstName: "Test",
+				lastEventAt: "2026-01-02T00:00:00.000Z",
+				name: 'Test "Comma, Person"',
+				organizationCount: 1,
+				planIds: ["pro"],
+				segment: "paying",
+				userId: "user-1",
+				websiteCount: 1,
+			},
+		]);
+
+		expect(csv).toContain('"Test ""Comma, Person"""');
+		expect(csv).toContain("pro,user-1|owner-1");
+	});
+});

--- a/packages/db/src/user-email-segments.ts
+++ b/packages/db/src/user-email-segments.ts
@@ -1,0 +1,234 @@
+export const EMAIL_SEGMENTS = [
+	"paying",
+	"active_websites",
+	"inactive_websites",
+	"no_websites",
+] as const;
+
+export type EmailSegment = (typeof EMAIL_SEGMENTS)[number];
+
+export interface SegmentUser {
+	billingCustomerIds: string[];
+	createdAt: string;
+	email: string;
+	emailVerified: boolean;
+	firstName: string | null;
+	id: string;
+	name: string;
+	organizationIds: string[];
+}
+
+export interface SegmentWebsite {
+	id: string;
+	organizationId: string;
+}
+
+export interface WebsiteActivity {
+	eventsInWindow: number;
+	lastEventAt: string | null;
+	websiteId: string;
+}
+
+export interface SegmentOptions {
+	minEvents: number;
+}
+
+export interface SegmentedUser {
+	activeWebsiteCount: number;
+	billingCustomerIds: string[];
+	createdAt: string;
+	email: string;
+	eventsInWindow: number;
+	firstName: string;
+	lastEventAt: string | null;
+	name: string;
+	organizationCount: number;
+	planIds: string[];
+	segment: EmailSegment;
+	userId: string;
+	websiteCount: number;
+}
+
+export type SegmentsByName = Record<EmailSegment, SegmentedUser[]>;
+
+const NAME_PART_SPLIT_RE = /\s+/;
+
+function addToMapSet(
+	map: Map<string, Set<string>>,
+	key: string,
+	value: string
+) {
+	const existing = map.get(key);
+	if (existing) {
+		existing.add(value);
+		return;
+	}
+	map.set(key, new Set([value]));
+}
+
+function fallbackFirstName(user: SegmentUser): string {
+	const firstName = user.firstName?.trim();
+	if (firstName) {
+		return firstName;
+	}
+
+	const namePart = user.name.trim().split(NAME_PART_SPLIT_RE).find(Boolean);
+	if (namePart) {
+		return namePart;
+	}
+
+	return user.email.split("@")[0] || "there";
+}
+
+function latestDate(left: string | null, right: string | null): string | null {
+	if (!left) {
+		return right;
+	}
+	if (!right) {
+		return left;
+	}
+	return Date.parse(right) > Date.parse(left) ? right : left;
+}
+
+function createEmptySegments(): SegmentsByName {
+	return {
+		paying: [],
+		active_websites: [],
+		inactive_websites: [],
+		no_websites: [],
+	};
+}
+
+export function segmentUsers(
+	users: SegmentUser[],
+	websites: SegmentWebsite[],
+	activity: WebsiteActivity[],
+	paidPlansByCustomerId: Map<string, string>,
+	options: SegmentOptions
+): SegmentsByName {
+	const websiteIdsByOrganizationId = new Map<string, Set<string>>();
+	for (const website of websites) {
+		addToMapSet(websiteIdsByOrganizationId, website.organizationId, website.id);
+	}
+
+	const activityByWebsiteId = new Map(
+		activity.map((row) => [row.websiteId, row])
+	);
+	const out = createEmptySegments();
+
+	for (const user of users) {
+		const websiteIds = new Set<string>();
+		for (const organizationId of user.organizationIds) {
+			const orgWebsiteIds = websiteIdsByOrganizationId.get(organizationId);
+			if (!orgWebsiteIds) {
+				continue;
+			}
+			for (const websiteId of orgWebsiteIds) {
+				websiteIds.add(websiteId);
+			}
+		}
+
+		let activeWebsiteCount = 0;
+		let eventsInWindow = 0;
+		let lastEventAt: string | null = null;
+
+		for (const websiteId of websiteIds) {
+			const row = activityByWebsiteId.get(websiteId);
+			if (!row) {
+				continue;
+			}
+			eventsInWindow += row.eventsInWindow;
+			if (row.eventsInWindow >= options.minEvents) {
+				activeWebsiteCount += 1;
+			}
+			lastEventAt = latestDate(lastEventAt, row.lastEventAt);
+		}
+
+		const planIds = [
+			...new Set(
+				user.billingCustomerIds
+					.map((customerId) => paidPlansByCustomerId.get(customerId))
+					.filter((planId): planId is string => Boolean(planId))
+			),
+		].sort();
+
+		const segment: EmailSegment =
+			planIds.length > 0
+				? "paying"
+				: websiteIds.size === 0
+					? "no_websites"
+					: activeWebsiteCount > 0
+						? "active_websites"
+						: "inactive_websites";
+
+		out[segment].push({
+			activeWebsiteCount,
+			billingCustomerIds: [...new Set(user.billingCustomerIds)].sort(),
+			createdAt: user.createdAt,
+			email: user.email,
+			eventsInWindow,
+			firstName: fallbackFirstName(user),
+			lastEventAt,
+			name: user.name,
+			organizationCount: new Set(user.organizationIds).size,
+			planIds,
+			segment,
+			userId: user.id,
+			websiteCount: websiteIds.size,
+		});
+	}
+
+	for (const segment of EMAIL_SEGMENTS) {
+		out[segment].sort((left, right) => left.email.localeCompare(right.email));
+	}
+
+	return out;
+}
+
+function csvEscape(value: string | number | null): string {
+	const text = value === null ? "" : String(value);
+	if (!(text.includes(",") || text.includes('"') || text.includes("\n"))) {
+		return text;
+	}
+	return `"${text.replaceAll('"', '""')}"`;
+}
+
+export function segmentRowsToCsv(rows: SegmentedUser[]): string {
+	const headers = [
+		"segment",
+		"email",
+		"firstName",
+		"name",
+		"userId",
+		"createdAt",
+		"organizationCount",
+		"websiteCount",
+		"activeWebsiteCount",
+		"eventsInWindow",
+		"lastEventAt",
+		"planIds",
+		"billingCustomerIds",
+	];
+
+	const lines = rows.map((row) =>
+		[
+			row.segment,
+			row.email,
+			row.firstName,
+			row.name,
+			row.userId,
+			row.createdAt,
+			row.organizationCount,
+			row.websiteCount,
+			row.activeWebsiteCount,
+			row.eventsInWindow,
+			row.lastEventAt,
+			row.planIds.join("|"),
+			row.billingCustomerIds.join("|"),
+		]
+			.map(csvEscape)
+			.join(",")
+	);
+
+	return `${headers.join(",")}\n${lines.join("\n")}${lines.length ? "\n" : ""}`;
+}

--- a/packages/redis/000-redis.test.ts
+++ b/packages/redis/000-redis.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
 import {
 	createRedisConnectionOptions,
 	getRedisUrl,
 } from "./redis-options";
 
 process.env.REDIS_URL = "redis://test-host:6379";
+
+const { getRedisCache, shutdownRedis } = await import("./redis");
 
 describe("redis", () => {
 	describe("connection options", () => {
@@ -40,9 +42,26 @@ describe("redis", () => {
 			expect(retryStrategy(20)).toBe(2000);
 		});
 
-		it("returns null after 20 attempts", () => {
-			expect(retryStrategy(21)).toBeNull();
-			expect(retryStrategy(50)).toBeNull();
+		it("never returns null so ioredis keeps reconnecting", () => {
+			expect(retryStrategy(21)).toBe(2100);
+			expect(retryStrategy(30)).toBe(3000);
+			expect(retryStrategy(1000)).toBe(3000);
+		});
+	});
+
+	describe("singleton lifecycle", () => {
+		afterAll(async () => {
+			await shutdownRedis();
+		});
+
+		it("rebuilds the singleton after the connection ends", async () => {
+			const first = getRedisCache();
+			first.disconnect();
+			first.emit("end");
+
+			const second = getRedisCache();
+			expect(second).not.toBe(first);
+			second.disconnect();
 		});
 	});
 });

--- a/packages/redis/redis-options.ts
+++ b/packages/redis/redis-options.ts
@@ -17,12 +17,7 @@ export function createRedisConnectionOptions(): RedisConnectionOptions {
 	return {
 		connectTimeout: 10_000,
 		commandTimeout: 5000,
-		retryStrategy: (times) => {
-			if (times > 20) {
-				return null;
-			}
-			return Math.min(times * 100, 3000);
-		},
+		retryStrategy: (times) => Math.min(times * 100, 3000),
 		maxRetriesPerRequest: 3,
 	};
 }

--- a/packages/redis/redis.ts
+++ b/packages/redis/redis.ts
@@ -21,13 +21,21 @@ export function getRedisCache() {
 		return redisInstance;
 	}
 
-	redisInstance = new Redis(getRedisUrl(), createRedisConnectionOptions());
+	const instance = new Redis(getRedisUrl(), createRedisConnectionOptions());
+	redisInstance = instance;
 
-	redisInstance.on("error", () => {});
+	instance.on("error", (error) => {
+		console.error("[redis] client error:", error);
+	});
+	instance.on("end", () => {
+		if (redisInstance === instance) {
+			redisInstance = null;
+		}
+	});
 	process.on("SIGTERM", shutdownRedis);
 	process.on("SIGINT", shutdownRedis);
 
-	return redisInstance;
+	return instance;
 }
 
 export const redis = new Proxy({} as Redis, {


### PR DESCRIPTION
## Summary

Lands 4 sliced commits that were sitting uncommitted in the working tree:

- **feat(db)**: support `abort_signal` in `chQueryWithMeta` options (small plumbing)
- **feat(ai)**: time-budget agent runs with abort signals and truncated traces
- **fix(redis)**: retry forever and rebuild singleton after disconnect
- **feat(db)**: export user email segments script (`bun email:segments`)

## Test plan

- [x] Pre-push hook ran full test suite (434 passing in @databuddy/basket alone)
- [x] Pre-commit hook ran type-check + lint on every commit
- [ ] AI agent investigations now stop cleanly at the time budget instead of hanging
- [ ] Redis stays connected through Upstash blips without permanent give-up
- [ ] `bun email:segments` produces the expected paying/active/inactive/no_websites buckets

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Time-bound MCP agent runs and thread abort signals through the AI/DB path so queries stop cleanly and we return truncated traces instead of hanging. Adds a user email segmentation export and makes Redis reconnect forever with a self-healing singleton.

- New Features
  - MCP agent now respects a time budget; on timeout it returns a truncated trace and updates the investigate memo with a time-limit note.
  - Threaded `AbortSignal` through agent tools, SQL/batch queries, and into ClickHouse via `chQueryWithMeta({ abort_signal })`.
  - Added `bun email:segments` (root passthrough to `packages/db`) to export user email segments (paying, active_websites, inactive_websites, no_websites) with CSV output and optional Autumn billing or local ID list.

- Bug Fixes
  - Redis: switch to capped backoff that retries forever and rebuild the singleton after `end`, preventing permanent dead clients.

<sup>Written for commit ff9491ac1902787e3bf52487f6af0114d2437816. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

