### PR TITLE
[codex] Improve Slack insight digest markdown

### DIFF
--- a/apps/insights/src/delivery.test.ts
+++ b/apps/insights/src/delivery.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildBlocks } from "./delivery";
+import { buildBlocks, buildFallbackText } from "./delivery";
 
 function sectionText(blocks: ReturnType<typeof buildBlocks>, index: number) {
 	return blocks[index]?.text?.text ?? "";
@@ -32,6 +32,9 @@ describe("Slack insight digest markdown", () => {
 		expect(blocks[0]?.text?.text).toBe(
 			"Insights for Databuddy (app.databuddy.cc)"
 		);
+		expect(buildFallbackText("Databuddy <@U123>", "app.databuddy.cc")).toBe(
+			"Insights for Databuddy &lt;@U123&gt; (app.databuddy.cc)"
+		);
 	});
 
 	it("renders each card as label, title, evidence, impact, and next action", () => {
@@ -45,7 +48,7 @@ describe("Slack insight digest markdown", () => {
 						"The goal only matches /billing, but 15 of 32 billing visitors landed on /billing/plans or /billing/history.",
 					id: "goal-insight",
 					impactSummary:
-						"Billing interest is stronger than the goal reports.",
+						"  Billing interest is stronger than the goal reports.  ",
 					severity: "warning",
 					sentiment: "negative",
 					suggestion:
@@ -80,6 +83,9 @@ describe("Slack insight digest markdown", () => {
 		expect(sectionText(blocks, 1)).toContain(
 			"Why it matters: Billing interest is stronger"
 		);
+		expect(sectionText(blocks, 1)).not.toContain(
+			"Why it matters:   Billing"
+		);
 		expect(sectionText(blocks, 1)).toContain(
 			"Next: Switch goal to /billing contains"
 		);
@@ -100,24 +106,24 @@ describe("Slack insight digest markdown", () => {
 					description:
 						"Two funnels share ids 019d7dac-6c23-7000-b8b0-b5cacc81db79 and 019d7dac-ef9b-... but have identical results.",
 					id: "duplicate-funnel",
-						severity: "warning",
-						sentiment: "negative",
-						suggestion:
-							"Delete funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 and run document.execCommand('copy') in the console.",
-						title:
-							"Duplicate funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 is active",
-						type: "funnel_regression",
-					},
-				],
-				[]
+					severity: "warning",
+					sentiment: "negative",
+					suggestion:
+						"Delete funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 and run document.execCommand('copy') in the console.",
+					title:
+						"Duplicate funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 is active",
+					type: "funnel_regression",
+				},
+			],
+			[]
 		);
 
-			const text = sectionText(blocks, 1);
-			expect(text).toContain("*Cleanup · Funnel config*");
-			expect(text).toContain("*Duplicate funnel the affected item is active*");
-			expect(text).toContain("Evidence: Two funnels share ids the affected item");
-			expect(text).toContain(
-				"Next: Review the funnel configuration and remove duplicate setup if present."
+		const text = sectionText(blocks, 1);
+		expect(text).toContain("*Cleanup · Funnel config*");
+		expect(text).toContain("*Duplicate funnel the affected item is active*");
+		expect(text).toContain("Evidence: Two funnels share ids the affected item");
+		expect(text).toContain(
+			"Next: Review the funnel configuration and remove duplicate setup if present."
 		);
 		expect(text).not.toContain("019d7dac");
 		expect(text).not.toContain("document.execCommand");
@@ -144,5 +150,6 @@ describe("Slack insight digest markdown", () => {
 
 		expect(blocks[0]?.text?.text).toBe("Insights for example.com");
 		expect(sectionText(blocks, 1)).toContain("*Opportunity · Acquisition*");
+		expect(sectionText(blocks, 1)).toContain("Next: Annotate the campaign.");
 	});
 });

--- a/apps/insights/src/delivery.test.ts
+++ b/apps/insights/src/delivery.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "bun:test";
+import { buildBlocks } from "./delivery";
+
+function sectionText(blocks: ReturnType<typeof buildBlocks>, index: number) {
+	return blocks[index]?.text?.text ?? "";
+}
+
+describe("Slack insight digest markdown", () => {
+	it("uses the website name with domain in the header", () => {
+		const blocks = buildBlocks(
+			"Databuddy",
+			"app.databuddy.cc",
+			[
+				{
+					actions: [{ label: "Switch goal to /billing contains" }],
+					description:
+						"The goal only matches /billing, but 15 of 32 billing visitors landed on /billing/plans or /billing/history.",
+					id: "insight-1",
+					impactSummary:
+						"Billing interest is stronger than the goal reports.",
+					severity: "warning",
+					sentiment: "negative",
+					suggestion:
+						"Edit the goal id 019d7dac-6c23-7000-b8b0-b5cacc81db79.",
+					title: "Pricing intent is undercounted by about 47%",
+					type: "conversion_leak",
+				},
+			],
+			[]
+		);
+
+		expect(blocks[0]?.text?.text).toBe(
+			"Insights for Databuddy (app.databuddy.cc)"
+		);
+	});
+
+	it("renders each card as label, title, evidence, impact, and next action", () => {
+		const blocks = buildBlocks(
+			"Databuddy",
+			"app.databuddy.cc",
+			[
+				{
+					actions: [{ label: "Switch goal to /billing contains" }],
+					description:
+						"The goal only matches /billing, but 15 of 32 billing visitors landed on /billing/plans or /billing/history.",
+					id: "goal-insight",
+					impactSummary:
+						"Billing interest is stronger than the goal reports.",
+					severity: "warning",
+					sentiment: "negative",
+					suggestion:
+						"Edit the Pricing viewers goal and include nested billing routes.",
+					title: "Pricing intent is undercounted by about 47%",
+					type: "conversion_leak",
+				},
+				{
+					actions: [{ label: "Fix clipboard copy on /onboarding" }],
+					description:
+						"A single /onboarding session produced 94% of this week's errors after Firefox blocked clipboard access.",
+					id: "error-insight",
+					impactSummary:
+						"The error feed is being distorted by one retry loop.",
+					severity: "warning",
+					sentiment: "negative",
+					suggestion:
+						"Wrap navigator.clipboard.writeText in a try/catch with document.execCommand('copy').",
+					title: "One Firefox session caused 168 clipboard errors",
+					type: "persistent_error_hotspot",
+				},
+			],
+			[]
+		);
+
+		expect(blocks).toHaveLength(3);
+		expect(sectionText(blocks, 1)).toContain("*Fix · Goal tracking*");
+		expect(sectionText(blocks, 1)).toContain(
+			"*Pricing intent is undercounted by about 47%*"
+		);
+		expect(sectionText(blocks, 1)).toContain("Evidence: The goal only matches");
+		expect(sectionText(blocks, 1)).toContain(
+			"Why it matters: Billing interest is stronger"
+		);
+		expect(sectionText(blocks, 1)).toContain(
+			"Next: Switch goal to /billing contains"
+		);
+		expect(sectionText(blocks, 2)).toContain("*Fix · Error volume*");
+		expect(sectionText(blocks, 2)).toContain(
+			"Next: Fix clipboard copy on /onboarding"
+		);
+		expect(sectionText(blocks, 1)).not.toContain("One Firefox");
+	});
+
+	it("does not expose raw IDs or code-heavy suggestions in visible Slack copy", () => {
+		const blocks = buildBlocks(
+			"Databuddy",
+			"app.databuddy.cc",
+			[
+				{
+					actions: [],
+					description:
+						"Two funnels share ids 019d7dac-6c23-7000-b8b0-b5cacc81db79 and 019d7dac-ef9b-... but have identical results.",
+					id: "duplicate-funnel",
+						severity: "warning",
+						sentiment: "negative",
+						suggestion:
+							"Delete funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 and run document.execCommand('copy') in the console.",
+						title:
+							"Duplicate funnel 019d7dac-6c23-7000-b8b0-b5cacc81db79 is active",
+						type: "funnel_regression",
+					},
+				],
+				[]
+		);
+
+			const text = sectionText(blocks, 1);
+			expect(text).toContain("*Cleanup · Funnel config*");
+			expect(text).toContain("*Duplicate funnel the affected item is active*");
+			expect(text).toContain("Evidence: Two funnels share ids the affected item");
+			expect(text).toContain(
+				"Next: Review the funnel configuration and remove duplicate setup if present."
+		);
+		expect(text).not.toContain("019d7dac");
+		expect(text).not.toContain("document.execCommand");
+		expect(text).not.toContain("Delete funnel");
+	});
+
+	it("falls back to the domain when no website name exists", () => {
+		const blocks = buildBlocks(
+			null,
+			"example.com",
+			[
+				{
+					description: "Traffic rose from 10 to 30 sessions.",
+					id: "traffic-insight",
+					severity: "info",
+					sentiment: "positive",
+					suggestion: "Annotate the campaign.",
+					title: "Traffic tripled this week",
+					type: "positive_trend",
+				},
+			],
+			[]
+		);
+
+		expect(blocks[0]?.text?.text).toBe("Insights for example.com");
+		expect(sectionText(blocks, 1)).toContain("*Opportunity · Acquisition*");
+	});
+});

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -22,9 +22,12 @@ interface DigestInsight {
 	actions?: { label: string }[] | null;
 	description: string;
 	id: string;
+	impactSummary?: string | null;
+	sentiment: string;
 	severity: string;
 	suggestion: string;
 	title: string;
+	type: string;
 }
 
 interface SlackBlock {
@@ -37,6 +40,26 @@ function escapeMrkdwn(value: string): string {
 		.replaceAll("&", "&amp;")
 		.replaceAll("<", "&lt;")
 		.replaceAll(">", "&gt;");
+}
+
+const FULL_UUID_PATTERN =
+	/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const TRUNCATED_UUID_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-\.\.\./gi;
+
+function userVisibleCopy(value: string): string {
+	return value
+		.replace(FULL_UUID_PATTERN, "the affected item")
+		.replace(TRUNCATED_UUID_PATTERN, "the affected item");
+}
+
+function formatWebsiteLabel(
+	websiteName: string | null | undefined,
+	websiteDomain: string
+): string {
+	const name = websiteName?.trim();
+	return name && name !== websiteDomain
+		? `${name} (${websiteDomain})`
+		: websiteDomain;
 }
 
 async function resolveDeliveries(
@@ -96,32 +119,119 @@ function chainSiteCount(insightId: string, chains: ChainAssignment[]): number {
 	return chain ? new Set(chain.websiteIds).size : 0;
 }
 
-function buildBlocks(
+function digestLabel(insight: DigestInsight): string {
+	switch (insight.type) {
+		case "referrer_change":
+		case "traffic_spike":
+		case "positive_trend":
+			return insight.sentiment === "positive"
+				? "Opportunity · Acquisition"
+				: "Review · Traffic";
+		case "conversion_leak":
+			return "Fix · Goal tracking";
+		case "funnel_regression":
+			return "Cleanup · Funnel config";
+		case "error_spike":
+		case "new_errors":
+		case "persistent_error_hotspot":
+		case "error_impact":
+			return "Fix · Error volume";
+		case "vitals_degraded":
+		case "performance":
+			return "Fix · Performance";
+		case "performance_improved":
+		case "reliability_improved":
+			return "Improvement · Reliability";
+		case "quality_shift":
+		case "segment_regression":
+			return "Review · Data quality";
+		default:
+			return insight.severity === "info"
+				? "Review · Signal"
+				: "Fix · Priority signal";
+	}
+}
+
+function fallbackWhyItMatters(insight: DigestInsight): string {
+	switch (insight.type) {
+		case "referrer_change":
+		case "traffic_spike":
+		case "positive_trend":
+			return "This is a channel or segment worth repeating while the context is fresh.";
+		case "conversion_leak":
+			return "Conversion analysis starts from bad data until this tracking is fixed.";
+		case "funnel_regression":
+			return "Funnel reports can double-count or hide the real drop-off until this is cleaned up.";
+		case "error_spike":
+		case "new_errors":
+		case "persistent_error_hotspot":
+		case "error_impact":
+			return "This can distort error reporting and may block affected users.";
+		case "vitals_degraded":
+		case "performance":
+			return "Slow or unstable pages can make the affected flow feel unreliable.";
+		default:
+			return "This changes which follow-up should happen next.";
+	}
+}
+
+function fallbackNextAction(insight: DigestInsight): string {
+	switch (insight.type) {
+		case "referrer_change":
+		case "traffic_spike":
+		case "positive_trend":
+			return "Add an annotation so future weeks have context.";
+		case "conversion_leak":
+			return "Fix the goal or funnel configuration.";
+		case "funnel_regression":
+			return "Review the funnel configuration and remove duplicate setup if present.";
+		case "error_spike":
+		case "new_errors":
+		case "persistent_error_hotspot":
+		case "error_impact":
+			return "Create a fix task for the affected flow.";
+		case "vitals_degraded":
+		case "performance":
+			return "Profile the affected route and fix the slowest step.";
+		default:
+			return "Review this insight in Databuddy.";
+	}
+}
+
+function nextAction(insight: DigestInsight): string {
+	const label = (insight.actions ?? [])
+		.map((action) => action.label.trim())
+		.find(Boolean);
+	return label ?? fallbackNextAction(insight);
+}
+
+export function buildBlocks(
+	websiteName: string | null | undefined,
 	websiteDomain: string,
 	insights: DigestInsight[],
 	chains: ChainAssignment[]
 ): SlackBlock[] {
+	const websiteLabel = formatWebsiteLabel(websiteName, websiteDomain);
 	const blocks: SlackBlock[] = [
 		{
 			type: "header",
 			text: {
 				type: "plain_text",
-				text: truncate(`Insights for ${websiteDomain}`, SLACK_HEADER_MAX),
+				text: truncate(`Insights for ${websiteLabel}`, SLACK_HEADER_MAX),
 			},
 		},
 	];
 	for (const insight of insights.slice(0, MAX_DIGEST_INSIGHTS)) {
+		const whyItMatters = insight.impactSummary?.trim()
+			? insight.impactSummary
+			: fallbackWhyItMatters(insight);
 		const lines = [
-			`*${escapeMrkdwn(insight.title)}*`,
-			escapeMrkdwn(insight.description),
-			`_${escapeMrkdwn(insight.suggestion)}_`,
+			`*${escapeMrkdwn(digestLabel(insight))}*`,
+			`*${escapeMrkdwn(userVisibleCopy(insight.title))}*`,
+			`Evidence: ${escapeMrkdwn(userVisibleCopy(insight.description))}`,
+			`Why it matters: ${escapeMrkdwn(userVisibleCopy(whyItMatters))}`,
+			`Next: ${escapeMrkdwn(userVisibleCopy(nextAction(insight)))}`,
 		];
-		const actionLabels = (insight.actions ?? [])
-			.map((action) => action.label)
-			.filter(Boolean);
-		if (actionLabels.length > 0) {
-			lines.push(`Next: ${actionLabels.map(escapeMrkdwn).join(" · ")}`);
-		}
 		const siteCount = chainSiteCount(insight.id, chains);
 		if (siteCount > 1) {
 			lines.push(
@@ -167,6 +277,7 @@ export async function deliverInsightDigests(params: {
 	organizationId: string;
 	websiteDomain: string;
 	websiteId: string;
+	websiteName?: string | null;
 }): Promise<void> {
 	if (params.insights.length === 0) {
 		return;
@@ -196,11 +307,12 @@ export async function deliverInsightDigests(params: {
 	}
 
 	const blocks = buildBlocks(
+		params.websiteName,
 		params.websiteDomain,
 		params.insights,
 		params.chains ?? []
 	);
-	const text = `Insights for ${params.websiteDomain}`;
+	const text = `Insights for ${formatWebsiteLabel(params.websiteName, params.websiteDomain)}`;
 	for (const channelId of slackChannelIds) {
 		try {
 			await postToSlack(token, channelId, blocks, text);

--- a/apps/insights/src/delivery.ts
+++ b/apps/insights/src/delivery.ts
@@ -44,6 +44,13 @@ function escapeMrkdwn(value: string): string {
 
 const FULL_UUID_PATTERN =
 	/\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
+const IMPLEMENTATION_DETAIL_MARKERS = [
+	"document.",
+	"navigator.",
+	"execcommand",
+	"writetext",
+	"try/catch",
+] as const;
 const TRUNCATED_UUID_PATTERN = /\b[0-9a-f]{8}-[0-9a-f]{4}-\.\.\./gi;
 
 function userVisibleCopy(value: string): string {
@@ -60,6 +67,15 @@ function formatWebsiteLabel(
 	return name && name !== websiteDomain
 		? `${name} (${websiteDomain})`
 		: websiteDomain;
+}
+
+export function buildFallbackText(
+	websiteName: string | null | undefined,
+	websiteDomain: string
+): string {
+	return escapeMrkdwn(
+		`Insights for ${formatWebsiteLabel(websiteName, websiteDomain)}`
+	);
 }
 
 async function resolveDeliveries(
@@ -198,11 +214,31 @@ function fallbackNextAction(insight: DigestInsight): string {
 	}
 }
 
+function visibleSuggestion(value: string): string | null {
+	const copy = userVisibleCopy(value).trim();
+	if (!copy) {
+		return null;
+	}
+
+	const lowerCopy = copy.toLowerCase();
+	if (
+		IMPLEMENTATION_DETAIL_MARKERS.some((marker) => lowerCopy.includes(marker))
+	) {
+		return null;
+	}
+
+	return copy;
+}
+
 function nextAction(insight: DigestInsight): string {
 	const label = (insight.actions ?? [])
 		.map((action) => action.label.trim())
 		.find(Boolean);
-	return label ?? fallbackNextAction(insight);
+	return (
+		label ??
+		visibleSuggestion(insight.suggestion) ??
+		fallbackNextAction(insight)
+	);
 }
 
 export function buildBlocks(
@@ -222,9 +258,8 @@ export function buildBlocks(
 		},
 	];
 	for (const insight of insights.slice(0, MAX_DIGEST_INSIGHTS)) {
-		const whyItMatters = insight.impactSummary?.trim()
-			? insight.impactSummary
-			: fallbackWhyItMatters(insight);
+		const whyItMatters =
+			insight.impactSummary?.trim() || fallbackWhyItMatters(insight);
 		const lines = [
 			`*${escapeMrkdwn(digestLabel(insight))}*`,
 			`*${escapeMrkdwn(userVisibleCopy(insight.title))}*`,
@@ -312,7 +347,7 @@ export async function deliverInsightDigests(params: {
 		params.insights,
 		params.chains ?? []
 	);
-	const text = `Insights for ${formatWebsiteLabel(params.websiteName, params.websiteDomain)}`;
+	const text = buildFallbackText(params.websiteName, params.websiteDomain);
 	for (const channelId of slackChannelIds) {
 		try {
 			await postToSlack(token, channelId, blocks, text);

--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -631,6 +631,7 @@ export async function generateWebsiteInsights(
 				organizationId: input.organizationId,
 				websiteId: site.id,
 				websiteDomain: site.domain,
+				websiteName: site.name,
 				insights: freshInsights,
 				chains: chainAssignments,
 			});

--- a/apps/insights/src/prompts.ts
+++ b/apps/insights/src/prompts.ts
@@ -415,10 +415,11 @@ export function buildSystemPrompt(
 
 RULES:
 - Titles: outcome-first, plain language, ≤80 chars. No hedging, no jargon (INP, LCP, TTFB, CLS, p75).
+- Titles should sound like a calm analyst, not an alert siren. Avoid "still", "again", "broken", and "not fixed" unless recurrence is the central evidence.
 - Title direction MUST match the primary metric. Mismatches are rejected.
 - Only report signals that change what someone does today. Silence > noise.
-- Suggestions: name the exact page, button, or query. Never say "monitor" or "watch".
-- ZERO REPETITION: title = what. description = so what (≤300 chars). rootCause = why. evidence = new facts only. suggestion = one action (≤300 chars).
+- Suggestions: name the exact page, button, or query. Never say "monitor" or "watch". Keep the visible suggestion human-readable; put raw object IDs only in action params.
+- ZERO REPETITION: title = what. description = evidence (≤300 chars). impactSummary = why it matters. rootCause = why. evidence = new facts only. suggestion = one action (≤300 chars).
 - Metrics: only verified numbers. Label segment-specific values clearly.
 - Low traffic (<50 sessions/week): no percentage claims on <10 absolute values.
 - Tools: batch queries in web_metrics (up to 8). search_console for keywords. summary_metrics for headline numbers.

--- a/packages/ai/src/ai/schemas/smart-insights-output.ts
+++ b/packages/ai/src/ai/schemas/smart-insights-output.ts
@@ -17,17 +17,17 @@ export const insightSchema = z.object({
 	title: z
 		.string()
 		.describe(
-			"Brief plain-English headline under 80 chars for a founder/operator. Avoid raw metric jargon like INP, LCP, FCP, TTFB, CLS, p75 in titles; translate to outcomes such as 'Interactions got slower' or 'Pages feel slower'. Never paste opaque URL slugs."
+			"Brief plain-English headline under 80 chars for a founder/operator. Avoid raw metric jargon like INP, LCP, FCP, TTFB, CLS, p75 in titles; translate to outcomes such as 'Interactions got slower' or 'Pages feel slower'. Never paste opaque IDs or URL slugs. Use calm recurrence wording; avoid 'again'/'still' unless recurrence is the main finding."
 		),
 	description: z
 		.string()
 		.describe(
-			"1-2 sentences: what changed and why it matters. Do NOT restate numbers from the title or metrics array. Add NEW context only. Under 300 characters."
+			"1-2 sentences: evidence for what changed. Do NOT restate numbers from the title or metrics array unless they are essential. Add NEW context only. Under 300 characters. Use object names, not raw IDs."
 		),
 	suggestion: z
 		.string()
 		.describe(
-			"One specific action. Name the exact page, button, query, or tool to use. Under 300 characters."
+			"One specific action in plain English. Name the exact page, button, query, or tool to use. Under 300 characters. Do not expose raw internal IDs; put IDs only in action params."
 		),
 	metrics: z
 		.array(insightMetricSchema)
@@ -106,7 +106,7 @@ export const insightSchema = z.object({
 		.string()
 		.optional()
 		.describe(
-			"Optional short statement of user or business impact. Use when the impact is clear from the available data. Keep to a single sentence."
+			"Optional short statement of why this matters to the operator. Use when the impact is clear from the available data. Keep to a single sentence."
 		),
 	rootCause: z
 		.string()


### PR DESCRIPTION
## Summary

- Rework Slack insight digests into a markdown-only operator flow: label, title, evidence, why it matters, and next action.
- Include the website name in digest headers as `Name (domain)` and fall back to the domain when no name exists.
- Redact UUID-like internal IDs from visible Slack copy and add regression coverage for the final markdown contract.
- Tighten insight prompt/schema guidance so investigations use calm wording, keep visible suggestions human-readable, and reserve raw IDs for action params.

## Validation

- `bun test src/delivery.test.ts`
- `cd apps/insights && bun run check-types`
- `cd apps/insights && bun test src`
- `bunx ultracite check apps/insights/src/delivery.ts apps/insights/src/delivery.test.ts apps/insights/src/generation.ts apps/insights/src/prompts.ts packages/ai/src/ai/schemas/smart-insights-output.ts`
- `dotenv -- bun run --cwd packages/evals src/cli.ts --surface slack --tag digest --limit 2 --skip-judge --no-save --concurrency 1`
- Commit hooks ran full `check-types`; push hook ran repo `test` successfully.