### PR TITLE
[superlog] Retry transient ClickHouse single-query drops

### DIFF
--- a/packages/ai/src/query/batch-executor.test.ts
+++ b/packages/ai/src/query/batch-executor.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { chQuery } from "@databuddy/db/clickhouse";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
 	areQueriesCompatible,
 	buildUnionQuery,
+	executeBatch,
 	extractOuterSelectColumns,
 	getCompatibleQueries,
 	getSchemaGroups,
@@ -9,6 +11,17 @@ import {
 import { QueryBuilders } from "./builders";
 import { SimpleQueryBuilder } from "./simple-builder";
 
+vi.mock("@databuddy/db/clickhouse", () => ({
+	chQuery: vi.fn(),
+}));
+
+type MockChQuery = {
+	mockRejectedValueOnce: (value: unknown) => MockChQuery;
+	mockReset: () => void;
+	mockResolvedValueOnce: (value: Record<string, unknown>[]) => MockChQuery;
+};
+
+const mockChQuery = chQuery as unknown as MockChQuery;
 const lastSelectColumns = extractOuterSelectColumns;
 
 function compileSql(type: string): string {
@@ -23,6 +36,26 @@ function compileSql(type: string): string {
 		to: "2026-04-11",
 	}).compile().sql;
 }
+
+const singleQueryRequest = {
+	projectId: "test-website",
+	type: "top_pages",
+	from: "2026-04-01",
+	to: "2026-04-11",
+};
+
+function transientClickHouseError(): Error {
+	const cause = Object.assign(new Error("socket connection was closed"), {
+		code: "ECONNRESET",
+	});
+	const error = new Error("ClickHouse query failed");
+	(error as Error & { cause: unknown }).cause = cause;
+	return error;
+}
+
+beforeEach(() => {
+	mockChQuery.mockReset();
+});
 
 describe("batch-executor schema signatures", () => {
 	const builderEntries = Object.entries(QueryBuilders);
@@ -81,6 +114,71 @@ describe("batch-executor schema signatures", () => {
 		for (const type of realtimeTypes) {
 			expect(QueryBuilders[type]?.noCache).toBe(true);
 		}
+	});
+});
+
+describe("executeBatch single query retry", () => {
+	it("retries a transient ClickHouse connection drop once and returns data", async () => {
+		mockChQuery
+			.mockRejectedValueOnce(transientClickHouseError())
+			.mockResolvedValueOnce([{ name: "/", pageviews: 2, visitors: 1 }]);
+
+		const [result] = await executeBatch([singleQueryRequest]);
+
+		expect(chQuery).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({
+			type: "top_pages",
+			data: [{ name: "/", pageviews: 2, visitors: 1 }],
+		});
+	});
+
+	it("reports the final transient error after the single retry also fails", async () => {
+		mockChQuery
+			.mockRejectedValueOnce(transientClickHouseError())
+			.mockRejectedValueOnce(
+				Object.assign(new Error("read ECONNRESET"), {
+					code: "ECONNRESET",
+				})
+			);
+
+		const [result] = await executeBatch([singleQueryRequest]);
+
+		expect(chQuery).toHaveBeenCalledTimes(2);
+		expect(result).toEqual({
+			type: "top_pages",
+			data: [],
+			error: "read ECONNRESET",
+		});
+	});
+
+	it("does not retry non-transient query errors", async () => {
+		mockChQuery.mockRejectedValueOnce(new Error("Syntax error near SELECT"));
+
+		const [result] = await executeBatch([singleQueryRequest]);
+
+		expect(chQuery).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			type: "top_pages",
+			data: [],
+			error: "Syntax error near SELECT",
+		});
+	});
+
+	it("does not retry AbortError", async () => {
+		mockChQuery.mockRejectedValueOnce(
+			Object.assign(new Error("The operation was aborted"), {
+				name: "AbortError",
+			})
+		);
+
+		const [result] = await executeBatch([singleQueryRequest]);
+
+		expect(chQuery).toHaveBeenCalledTimes(1);
+		expect(result).toEqual({
+			type: "top_pages",
+			data: [],
+			error: "The operation was aborted",
+		});
 	});
 });
 

--- a/packages/ai/src/query/batch-executor.ts
+++ b/packages/ai/src/query/batch-executor.ts
@@ -51,6 +51,80 @@ async function mapWithConcurrency<T, R>(
 	return results;
 }
 
+const TRANSIENT_CLICKHOUSE_ERROR_CODES = new Set([
+	"ECONNRESET",
+	"ECONNREFUSED",
+	"EPIPE",
+	"ETIMEDOUT",
+	"UND_ERR_CONNECT_TIMEOUT",
+	"UND_ERR_SOCKET",
+]);
+const TRANSIENT_CLICKHOUSE_ERROR_MESSAGES = [
+	"socket connection was closed",
+	"socket closed unexpectedly",
+	"connection refused",
+	"connection reset",
+	"econnrefused",
+	"econnreset",
+	"etimedout",
+	"network error",
+];
+const MAX_ERROR_CAUSE_DEPTH = 5;
+
+function getErrorField(
+	error: unknown,
+	field: "cause" | "code" | "message" | "name"
+) {
+	if (typeof error !== "object" || error === null || !(field in error)) {
+		return;
+	}
+	return (error as Record<string, unknown>)[field];
+}
+
+function hasAbortError(error: unknown): boolean {
+	let current: unknown = error;
+	for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH && current; depth++) {
+		if (
+			getErrorField(current, "name") === "AbortError" ||
+			getErrorField(current, "code") === "ABORT_ERR"
+		) {
+			return true;
+		}
+		current = getErrorField(current, "cause");
+	}
+	return false;
+}
+
+function isTransientClickHouseError(error: unknown): boolean {
+	if (hasAbortError(error)) {
+		return false;
+	}
+
+	let current: unknown = error;
+	for (let depth = 0; depth < MAX_ERROR_CAUSE_DEPTH && current; depth++) {
+		const code = getErrorField(current, "code");
+		if (
+			typeof code === "string" &&
+			TRANSIENT_CLICKHOUSE_ERROR_CODES.has(code.toUpperCase())
+		) {
+			return true;
+		}
+
+		const message = getErrorField(current, "message");
+		if (
+			typeof message === "string" &&
+			TRANSIENT_CLICKHOUSE_ERROR_MESSAGES.some((pattern) =>
+				message.toLowerCase().includes(pattern)
+			)
+		) {
+			return true;
+		}
+
+		current = getErrorField(current, "cause");
+	}
+	return false;
+}
+
 const ALIAS_REGEX = /\s+as\s+([\w]+)\s*$/i;
 const TAIL_SPLIT_REGEX = /[\s.]/;
 const QUOTE_STRIP_REGEX = /[`"']/g;
@@ -247,27 +321,35 @@ async function runSingle(
 		};
 	}
 
-	try {
-		const builder = new SimpleQueryBuilder(
-			config,
-			{ ...req, timezone: opts?.timezone ?? req.timezone },
-			opts?.websiteDomain
-		);
-		const data = await builder.execute(opts?.abortSignal);
+	for (let attempt = 0; attempt < 2; attempt++) {
+		try {
+			const builder = new SimpleQueryBuilder(
+				config,
+				{ ...req, timezone: opts?.timezone ?? req.timezone },
+				opts?.websiteDomain
+			);
+			const data = await builder.execute(opts?.abortSignal);
 
-		mergeWideEvent({
-			query_type: req.type,
-			query_from: req.from,
-			query_to: req.to,
-			query_rows: data.length,
-		});
+			mergeWideEvent({
+				query_type: req.type,
+				query_from: req.from,
+				query_to: req.to,
+				query_rows: data.length,
+			});
 
-		return { type: req.type, data };
-	} catch (e) {
-		const error = e instanceof Error ? e.message : "Query failed";
-		mergeWideEvent({ query_error: error });
-		return { type: req.type, data: [], error };
+			return { type: req.type, data };
+		} catch (e) {
+			if (attempt === 0 && isTransientClickHouseError(e)) {
+				continue;
+			}
+
+			const error = e instanceof Error ? e.message : "Query failed";
+			mergeWideEvent({ query_error: error });
+			return { type: req.type, data: [], error };
+		}
 	}
+
+	return { type: req.type, data: [], error: "Query failed" };
 }
 
 function groupBySchema(


### PR DESCRIPTION
## Summary
- retry single-query analytics executions once when ClickHouse fails with a transient connection drop
- inspect error `code`, `message`, and nested `cause` fields while explicitly skipping `AbortError`
- add regression coverage for retry success, retry final failure, non-transient no-retry, and AbortError no-retry

Supersedes the useful part of #505 from a clean `staging` branch. The original #505 is conflicted and polluted with stale already-landed history, so this PR carries only the intended AI query change.

## Verification
- `cd packages/ai && bun test src/query/batch-executor.test.ts`
- `cd packages/ai && bun run check-types`
- `bun run lint`
- `bun run check-types`
- `bun run test`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries single-query analytics once on transient ClickHouse connection drops to reduce flaky failures. AbortError and non-transient errors are not retried; if the retry also fails, the final error is returned.

- **Bug Fixes**
  - Detect transient failures via error `code`, `message`, and nested `cause` (e.g., ECONNRESET, ECONNREFUSED, EPIPE, ETIMEDOUT, undici socket errors); AbortError is excluded.
  - Applies to the single-query path only; query metrics are still recorded.
  - Added tests mocking `@databuddy/db/clickhouse` to cover retry success, final failure after retry, non-transient no-retry, and AbortError no-retry.

<sup>Written for commit 4dee431a6c54f7dfe6205260af4ec1d02afee558. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

