### PR TITLE
[superlog] Add manage:websites scope to insights service auth

### DIFF
--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -1,5 +1,4 @@
 import type { AppContext } from "@databuddy/ai/config/context";
-import { createServiceAuth } from "@databuddy/rpc";
 import {
 	ANTHROPIC_CACHE_1H,
 	createModelFromId,
@@ -38,6 +37,7 @@ import {
 } from "./persistence";
 import { reflectAndRank } from "./reflection";
 import { resolveInsightsForWebsite } from "./resolution";
+import { createInsightsServiceAuth } from "./service-auth";
 import {
 	buildInvestigationPrompt,
 	buildSystemPrompt,
@@ -314,7 +314,7 @@ async function runInsightsAgent(params: {
 			timezone: params.config.timezone,
 			currentDateTime: new Date().toISOString(),
 			chatId: `insights:${params.organizationId}:${params.websiteId}`,
-			serviceAuth: createServiceAuth(params.organizationId, ["read:data"]),
+			serviceAuth: createInsightsServiceAuth(params.organizationId),
 		};
 
 		const collected: ParsedInsight[] = [];

--- a/apps/insights/src/service-auth.test.ts
+++ b/apps/insights/src/service-auth.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it, mock } from "bun:test";
+
+const mockCreateServiceAuth = mock((organizationId: string, scopes: string[]) => ({
+	apiKey: { organizationId, scopes },
+	session: null,
+}));
+
+mock.module("@databuddy/rpc", () => ({
+	createServiceAuth: mockCreateServiceAuth,
+}));
+
+const { createInsightsServiceAuth, INSIGHTS_SERVICE_AUTH_SCOPES } = await import(
+	"./service-auth"
+);
+
+describe("createInsightsServiceAuth", () => {
+	it("grants read data and website management scopes to insights agents", () => {
+		const auth = createInsightsServiceAuth("org_1");
+
+		expect(auth.apiKey?.organizationId).toBe("org_1");
+		expect(auth.apiKey?.scopes).toEqual(["read:data", "manage:websites"]);
+		expect(INSIGHTS_SERVICE_AUTH_SCOPES).toEqual([
+			"read:data",
+			"manage:websites",
+		]);
+	});
+});

--- a/apps/insights/src/service-auth.ts
+++ b/apps/insights/src/service-auth.ts
@@ -1,0 +1,10 @@
+import { createServiceAuth } from "@databuddy/rpc";
+
+export const INSIGHTS_SERVICE_AUTH_SCOPES = [
+	"read:data",
+	"manage:websites",
+] as const;
+
+export function createInsightsServiceAuth(organizationId: string) {
+	return createServiceAuth(organizationId, [...INSIGHTS_SERVICE_AUTH_SCOPES]);
+}


### PR DESCRIPTION
## Summary
- grant insights service auth the manage:websites scope required by insight website updates
- centralize the insights service auth scope list behind a small helper
- add a focused unit test for the service auth scopes

Supersedes #471 with a clean branch from current staging.

## Verification
- cd apps/insights && bun test src/service-auth.test.ts
- cd apps/insights && bun run check-types
- bunx ultracite check apps/insights/src/generation.ts apps/insights/src/service-auth.ts apps/insights/src/service-auth.test.ts
- cd apps/insights && bun test src
- bun run lint
- bun run check-types
- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the `manage:websites` scope to insights service auth so insights can update websites. This unblocks website updates and centralizes the scope list behind a small helper with tests.

- **Bug Fixes**
  - Grant `manage:websites` to insights service auth to allow website updates without permission errors.

- **Refactors**
  - Centralize scopes via `createInsightsServiceAuth` and `INSIGHTS_SERVICE_AUTH_SCOPES` in service-auth, and switch the agent in `generation.ts` to use it (wraps `@databuddy/rpc`).
  - Add a focused unit test that verifies the exact scopes.

<sup>Written for commit b42063e3d1253e81b39f1e1c3f3948220d8e454b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

