### PR TITLE
[superlog] Log batch_union fallback as WARN instead of ERROR

### DIFF
--- a/packages/ai/src/lib/tracing.ts
+++ b/packages/ai/src/lib/tracing.ts
@@ -13,6 +13,29 @@ export function mergeWideEvent<Fields extends object = Record<string, unknown>>(
 	log.info({ service: "api", ...payload });
 }
 
+export function captureWarning<Fields extends object = Record<string, unknown>>(
+	error: unknown,
+	fields?: Partial<Fields>
+): void {
+	const err = error instanceof Error ? error : new Error(String(error));
+	const payload = fields as Record<string, unknown> | undefined;
+	const requestLog = getActiveAiRequestLogger();
+	if (requestLog) {
+		if (payload) {
+			requestLog.warn(err.message, payload);
+		} else {
+			requestLog.warn(err.message);
+		}
+		return;
+	}
+	log.warn({
+		service: "api",
+		error_message: err.message,
+		...(err.stack ? { error_stack: err.stack } : {}),
+		...(payload ?? {}),
+	});
+}
+
 export function captureError<Fields extends object = Record<string, unknown>>(
 	error: unknown,
 	fields?: Partial<Fields>

--- a/packages/ai/src/query/batch-executor.test.ts
+++ b/packages/ai/src/query/batch-executor.test.ts
@@ -1,5 +1,7 @@
 import { chQuery } from "@databuddy/db/clickhouse";
+import type { RequestLogger } from "evlog";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { setAiRequestLoggerProvider } from "../lib/request-logger";
 import {
 	areQueriesCompatible,
 	buildUnionQuery,
@@ -55,6 +57,7 @@ function transientClickHouseError(): Error {
 
 beforeEach(() => {
 	mockChQuery.mockReset();
+	setAiRequestLoggerProvider(null);
 });
 
 describe("batch-executor schema signatures", () => {
@@ -179,6 +182,47 @@ describe("executeBatch single query retry", () => {
 			data: [],
 			error: "The operation was aborted",
 		});
+	});
+});
+
+describe("executeBatch union fallback logging", () => {
+	it("logs batch union fallback as a warning when single queries recover", async () => {
+		const mockLogger = {
+			error: vi.fn(),
+			set: vi.fn(),
+			warn: vi.fn(),
+		} as unknown as RequestLogger;
+		setAiRequestLoggerProvider(() => mockLogger);
+		mockChQuery
+			.mockRejectedValueOnce(new Error("Union query failed"))
+			.mockResolvedValueOnce([{ name: "/", pageviews: 2, visitors: 1 }])
+			.mockResolvedValueOnce([{ name: "/pricing", pageviews: 1, visitors: 1 }]);
+
+		const results = await executeBatch([
+			{ ...singleQueryRequest, type: "top_pages" },
+			{ ...singleQueryRequest, type: "top_pages" },
+		]);
+
+		expect(chQuery).toHaveBeenCalledTimes(3);
+		expect(mockLogger.warn).toHaveBeenCalledWith(
+			"Union query failed",
+			expect.objectContaining({
+				batch_size: 2,
+				batch_types: "top_pages,top_pages",
+				operation: "batch_union",
+			})
+		);
+		expect(mockLogger.error).not.toHaveBeenCalled();
+		expect(results).toEqual([
+			{
+				type: "top_pages",
+				data: [{ name: "/", pageviews: 2, visitors: 1 }],
+			},
+			{
+				type: "top_pages",
+				data: [{ name: "/pricing", pageviews: 1, visitors: 1 }],
+			},
+		]);
 	});
 });
 

--- a/packages/ai/src/query/batch-executor.ts
+++ b/packages/ai/src/query/batch-executor.ts
@@ -1,5 +1,5 @@
 import { chQuery } from "@databuddy/db/clickhouse";
-import { captureError, mergeWideEvent } from "../lib/tracing";
+import { captureWarning, mergeWideEvent } from "../lib/tracing";
 import { QueryBuilders, suggestQueryTypes } from "./builders";
 import {
 	getClickHouseQuerySettings,
@@ -529,15 +529,18 @@ export async function executeBatch(
 			}
 			return { unionCount: 1, singleCount: 0 };
 		} catch (error) {
-			captureError(error, {
+			const batchUnionError =
+				error instanceof Error ? error.message : "Union query failed";
+			captureWarning(error, {
 				operation: "batch_union",
 				batch_types: compiledItems.map((g) => g.req.type).join(","),
 				batch_size: compiledItems.length,
+				batch_union_fallback: 1,
+				batch_union_error: batchUnionError,
 			});
 			mergeWideEvent({
 				batch_union_fallback: 1,
-				batch_union_error:
-					error instanceof Error ? error.message : "Union query failed",
+				batch_union_error: batchUnionError,
 			});
 			for (const { index, req } of compiledItems) {
 				results[index] = await runSingle(req, opts);


### PR DESCRIPTION
## Summary
- add a request-aware `captureWarning` helper for recovered AI warnings
- log recovered batch_union fallback failures at WARN instead of ERROR
- preserve batch fallback metadata on the warning event
- add focused coverage that recovered union fallback warns without error logging

Supersedes #502 with a clean branch from current `staging`.

## Verification
- cd packages/ai && bun test src/query/batch-executor.test.ts
- cd packages/ai && bun run check-types
- bun run lint
- bun run check-types
- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Logs recovered batch_union fallbacks as WARN instead of ERROR to reduce noise while keeping context. Adds a request-aware captureWarning and preserves fallback metadata on the warning event.

- **Bug Fixes**
  - Use captureWarning to log union failures at WARN when single-query fallbacks succeed.
  - Preserve batch_union metadata on the warning: batch_union_fallback, batch_union_error, batch_size, batch_types.
  - Add tests to assert WARN (no ERROR) on recovered union fallback and correct results.

<sup>Written for commit 6dfcd52bbef44203bbe702516577ef7a6ed17768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

