### PR TITLE
[superlog] Downgrade agent stream cleanup Redis timeouts from ERROR to WARN

### DIFF
--- a/apps/api/src/routes/agent-stream-errors.test.ts
+++ b/apps/api/src/routes/agent-stream-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildAgentStreamRedisWarningPayload,
+	type AgentStreamBackgroundFailure,
+	getAgentStreamErrorLevel,
+} from "./agent-stream-errors";
+
+describe("agent stream error severity", () => {
+	it.each([
+		"append_stream_chunk",
+		"clear_active_stream",
+		"mark_stream_done",
+	] satisfies AgentStreamBackgroundFailure[])(
+		"treats %s as a warning",
+		(failure) => {
+			expect(getAgentStreamErrorLevel(failure)).toBe("warn");
+		}
+	);
+
+	it("keeps broad storage reader failures as errors", () => {
+		expect(getAgentStreamErrorLevel("storage_reader")).toBe("error");
+	});
+});
+
+describe("buildAgentStreamRedisWarningPayload", () => {
+	it("builds a consistent warning payload for Redis side effects", () => {
+		const payload = buildAgentStreamRedisWarningPayload(
+			new Error("redis timeout"),
+			"append_stream_chunk",
+			{ chatId: "chat_1", websiteId: "web_1" }
+		);
+
+		expect(payload).toEqual(
+			expect.objectContaining({
+				agent_chat_id: "chat_1",
+				agent_stream_operation: "append_stream_chunk",
+				agent_stream_redis_error: true,
+				agent_website_id: "web_1",
+				error_message: "redis timeout",
+				error_name: "Error",
+				service: "api",
+			})
+		);
+		expect(typeof payload.error_stack).toBe("string");
+	});
+
+	it("omits the website field when no website is in scope", () => {
+		const payload = buildAgentStreamRedisWarningPayload(
+			"redis unavailable",
+			"clear_active_stream",
+			{ chatId: "chat_1", websiteId: null }
+		);
+
+		expect(payload.agent_website_id).toBeUndefined();
+		expect(payload.error_message).toBe("redis unavailable");
+	});
+});

--- a/apps/api/src/routes/agent-stream-errors.ts
+++ b/apps/api/src/routes/agent-stream-errors.ts
@@ -1,0 +1,42 @@
+import { log } from "evlog";
+
+export type AgentStreamRedisOperation =
+	| "append_stream_chunk"
+	| "clear_active_stream"
+	| "mark_stream_done";
+
+export type AgentStreamBackgroundFailure =
+	| AgentStreamRedisOperation
+	| "storage_reader";
+
+export function getAgentStreamErrorLevel(
+	failure: AgentStreamBackgroundFailure
+): "error" | "warn" {
+	return failure === "storage_reader" ? "error" : "warn";
+}
+
+export function buildAgentStreamRedisWarningPayload(
+	error: unknown,
+	operation: AgentStreamRedisOperation,
+	context: { chatId: string; websiteId?: null | string }
+): Record<string, unknown> {
+	const err = error instanceof Error ? error : new Error(String(error));
+	return {
+		agent_chat_id: context.chatId,
+		agent_stream_operation: operation,
+		agent_stream_redis_error: true,
+		error_message: err.message,
+		error_name: err.name,
+		service: "api",
+		...(err.stack ? { error_stack: err.stack } : {}),
+		...(context.websiteId ? { agent_website_id: context.websiteId } : {}),
+	};
+}
+
+export function warnAgentStreamRedisSideEffect(
+	error: unknown,
+	operation: AgentStreamRedisOperation,
+	context: { chatId: string; websiteId?: null | string }
+): void {
+	log.warn(buildAgentStreamRedisWarningPayload(error, operation, context));
+}

--- a/apps/api/src/routes/agent.ts
+++ b/apps/api/src/routes/agent.ts
@@ -68,6 +68,7 @@ import { trackAgentEvent } from "@databuddy/ai/lib/databuddy";
 import { getResolvedAuth } from "../lib/auth-wide-event";
 import { captureError, mergeWideEvent } from "@databuddy/ai/lib/tracing";
 import { getAccessibleWebsites } from "@databuddy/ai/lib/accessible-websites";
+import { warnAgentStreamRedisSideEffect } from "./agent-stream-errors";
 
 function jsonError(status: number, code: string, message: string): Response {
 	return new Response(
@@ -1044,10 +1045,14 @@ export const agent = new Elysia({ prefix: "/v1/agent" })
 							try {
 								await clearActiveStream(streamScope, chatId, streamId);
 							} catch (cleanupError) {
-								captureError(cleanupError, {
-									agent_stream_cleanup_error: true,
-									agent_chat_id: chatId,
-								});
+								warnAgentStreamRedisSideEffect(
+									cleanupError,
+									"clear_active_stream",
+									{
+										chatId,
+										websiteId: defaultWebsiteId,
+									}
+								);
 							}
 							if (!persistedUserId) {
 								return;
@@ -1100,6 +1105,7 @@ export const agent = new Elysia({ prefix: "/v1/agent" })
 						const [forClient, forStorage] = injectedStream.tee();
 						(async () => {
 							const reader = forStorage.getReader();
+							let streamBufferWriteFailed = false;
 							try {
 								while (true) {
 									const { done, value } = await reader.read();
@@ -1107,18 +1113,37 @@ export const agent = new Elysia({ prefix: "/v1/agent" })
 										break;
 									}
 									if (value && value.byteLength > 0) {
-										await appendStreamChunk(streamKey, value);
+										try {
+											await appendStreamChunk(streamKey, value);
+										} catch (persistError) {
+											streamBufferWriteFailed = true;
+											warnAgentStreamRedisSideEffect(
+												persistError,
+												"append_stream_chunk",
+												{
+													chatId,
+													websiteId: defaultWebsiteId,
+												}
+											);
+											break;
+										}
 									}
 								}
 							} finally {
 								reader.releaseLock();
-								try {
-									await markStreamDone(streamKey);
-								} catch (cleanupError) {
-									captureError(cleanupError, {
-										agent_stream_cleanup_error: true,
-										agent_chat_id: chatId,
-									});
+								if (!streamBufferWriteFailed) {
+									try {
+										await markStreamDone(streamKey);
+									} catch (cleanupError) {
+										warnAgentStreamRedisSideEffect(
+											cleanupError,
+											"mark_stream_done",
+											{
+												chatId,
+												websiteId: defaultWebsiteId,
+											}
+										);
+									}
 								}
 							}
 						})().catch((storageError) => {


### PR DESCRIPTION
## Summary
- downgrade agent stream Redis replay side-effect failures to WARN
- keep broad storage reader/background task failures on ERROR
- stop the replay writer after the first Redis append failure to avoid per-chunk noise
- add focused coverage for Redis side-effect WARN vs storage-reader ERROR classification

Supersedes #499 with a clean branch from current `staging`.

## Verification
- cd apps/api && bunx --bun vitest run src/routes/agent-stream-errors.test.ts
- bunx ultracite check apps/api/src/routes/agent.ts apps/api/src/routes/agent-stream-errors.ts apps/api/src/routes/agent-stream-errors.test.ts
- bun run lint
- bun run check-types
- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded Redis side-effect failures in agent streaming (append/clear/done) from ERROR to WARN to cut noisy alerts, while keeping storage reader failures as ERROR. Also stops writing after the first Redis append failure to avoid per-chunk spam and logs one structured warning.

- **Bug Fixes**
  - Added `warnAgentStreamRedisSideEffect` and a payload builder; logs via `evlog` at WARN with chat/website context.
  - Stop after the first `append_stream_chunk` failure; only call `mark_stream_done` if no prior failure.
  - Keep `storage_reader` failures at ERROR.
  - Added focused tests for severity classification and payload shape.

<sup>Written for commit f9ed7e13a4c973f1e57abd74d2830a17d9ef415c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

