### PR TITLE
[superlog] Warn on stalled insights worker jobs

### DIFF
--- a/apps/insights/src/worker-events.test.ts
+++ b/apps/insights/src/worker-events.test.ts
@@ -1,0 +1,53 @@
+import {
+	INSIGHTS_DISPATCH_JOB_NAME,
+	INSIGHTS_GENERATE_WEBSITE_JOB_NAME,
+	INSIGHTS_MAINTENANCE_JOB_NAME,
+	INSIGHTS_ROLLUP_JOB_NAME,
+} from "@databuddy/redis";
+import { describe, expect, it } from "bun:test";
+import {
+	buildInsightsStalledJobEvent,
+	inferInsightsStalledJobName,
+	UNKNOWN_INSIGHTS_JOB_NAME,
+} from "./worker-events";
+
+describe("inferInsightsStalledJobName", () => {
+	it("infers website generation jobs from stable job ids", () => {
+		expect(inferInsightsStalledJobName("insights-website-run_1-web_1")).toBe(
+			INSIGHTS_GENERATE_WEBSITE_JOB_NAME
+		);
+	});
+
+	it("infers rollup jobs from stable job ids", () => {
+		expect(inferInsightsStalledJobName("insights-rollup-run_1")).toBe(
+			INSIGHTS_ROLLUP_JOB_NAME
+		);
+	});
+
+	it("infers dispatch scheduler jobs from repeat ids", () => {
+		expect(
+			inferInsightsStalledJobName("repeat:insights-dispatch:1234567890")
+		).toBe(INSIGHTS_DISPATCH_JOB_NAME);
+	});
+
+	it("infers maintenance scheduler jobs from repeat ids", () => {
+		expect(
+			inferInsightsStalledJobName("repeat:insights-maintenance:1234567890")
+		).toBe(INSIGHTS_MAINTENANCE_JOB_NAME);
+	});
+
+	it("falls back to unknown for unrecognized stalled job ids", () => {
+		expect(inferInsightsStalledJobName("custom-job-id")).toBe(
+			UNKNOWN_INSIGHTS_JOB_NAME
+		);
+	});
+});
+
+describe("buildInsightsStalledJobEvent", () => {
+	it("builds the warning event context without Redis lookups", () => {
+		expect(buildInsightsStalledJobEvent("insights-rollup-run_1")).toEqual({
+			job_id: "insights-rollup-run_1",
+			job_name: INSIGHTS_ROLLUP_JOB_NAME,
+		});
+	});
+});

--- a/apps/insights/src/worker-events.ts
+++ b/apps/insights/src/worker-events.ts
@@ -1,0 +1,34 @@
+import {
+	INSIGHTS_DISPATCH_JOB_NAME,
+	INSIGHTS_GENERATE_WEBSITE_JOB_NAME,
+	INSIGHTS_MAINTENANCE_JOB_NAME,
+	INSIGHTS_ROLLUP_JOB_NAME,
+} from "@databuddy/redis";
+
+export const UNKNOWN_INSIGHTS_JOB_NAME = "unknown";
+
+export function inferInsightsStalledJobName(jobId: string): string {
+	if (jobId.startsWith("insights-website-")) {
+		return INSIGHTS_GENERATE_WEBSITE_JOB_NAME;
+	}
+	if (jobId.startsWith("insights-rollup-")) {
+		return INSIGHTS_ROLLUP_JOB_NAME;
+	}
+	if (jobId.startsWith("repeat:insights-dispatch:")) {
+		return INSIGHTS_DISPATCH_JOB_NAME;
+	}
+	if (jobId.startsWith("repeat:insights-maintenance:")) {
+		return INSIGHTS_MAINTENANCE_JOB_NAME;
+	}
+	return UNKNOWN_INSIGHTS_JOB_NAME;
+}
+
+export function buildInsightsStalledJobEvent(jobId: string): {
+	job_id: string;
+	job_name: string;
+} {
+	return {
+		job_id: jobId,
+		job_name: inferInsightsStalledJobName(jobId),
+	};
+}

--- a/apps/insights/src/worker.ts
+++ b/apps/insights/src/worker.ts
@@ -9,6 +9,7 @@ import { Worker } from "bullmq";
 import { processInsightsJob } from "./jobs";
 import { emitInsightsEvent } from "./lib/evlog-insights";
 import { getInsightsWorkerErrorLevel } from "./worker-errors";
+import { buildInsightsStalledJobEvent } from "./worker-events";
 
 const DEFAULT_INSIGHTS_WORKER_CONCURRENCY = 5;
 
@@ -72,8 +73,8 @@ export function startInsightsWorker() {
 	});
 
 	worker.on("stalled", (jobId) => {
-		emitInsightsEvent("error", "worker.job_stalled", {
-			job_id: jobId,
+		emitInsightsEvent("warn", "worker.job_stalled", {
+			...buildInsightsStalledJobEvent(jobId),
 		});
 	});
 


### PR DESCRIPTION
Clean replacement for #501, based on staging.\n\nWhat changed:\n- Downgrades insights worker stalled-job telemetry from ERROR to WARN.\n- Adds deterministic stalled job-name inference for website, rollup, dispatch, and maintenance jobs.\n- Preserves the existing transient Redis worker error WARN helper from #482.\n\nVerification:\n- cd apps/insights && bun test src/worker-events.test.ts src/worker-errors.test.ts\n- bunx ultracite check apps/insights/src/worker.ts apps/insights/src/worker-events.ts apps/insights/src/worker-events.test.ts\n- bun run lint\n- bun run check-types\n- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Warn instead of error on stalled insights worker jobs and attach a deterministic job_name based on the job ID. This reduces noisy alerts and makes stalled events easier to triage.

- New Features
  - Added `inferInsightsStalledJobName` and an event builder to map website, rollup, dispatch, and maintenance IDs from `@databuddy/redis`.
  - Stalled handler now emits "warn" with {job_id, job_name} built locally (no Redis lookup).
  - Added tests for job-name inference and event payload.

<sup>Written for commit 6aa7ed79db4d7910f1096258b2cf7822a6d15cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

