### PR TITLE
[superlog] Warn on tracking health ClickHouse timeouts

### DIFF
--- a/packages/rpc/src/routers/tracking-health-errors.test.ts
+++ b/packages/rpc/src/routers/tracking-health-errors.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import {
+	CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE,
+	getTrackingHealthErrorLogLevel,
+} from "./tracking-health-errors";
+
+describe("getTrackingHealthErrorLogLevel", () => {
+	it("downgrades canonical ClickHouse tracking health timeouts to warn", () => {
+		expect(
+			getTrackingHealthErrorLogLevel(
+				new Error(CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE)
+			)
+		).toBe("warn");
+	});
+
+	it("keeps non-timeout errors at error", () => {
+		expect(getTrackingHealthErrorLogLevel(new Error("ClickHouse is down"))).toBe(
+			"error"
+		);
+	});
+
+	it("keeps non-Error values at error", () => {
+		expect(getTrackingHealthErrorLogLevel("ClickHouse query timeout")).toBe(
+			"error"
+		);
+	});
+});

--- a/packages/rpc/src/routers/tracking-health-errors.ts
+++ b/packages/rpc/src/routers/tracking-health-errors.ts
@@ -1,0 +1,13 @@
+export const CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE =
+	"ClickHouse query timeout";
+
+export type TrackingHealthErrorLogLevel = "error" | "warn";
+
+export function getTrackingHealthErrorLogLevel(
+	error: unknown
+): TrackingHealthErrorLogLevel {
+	return error instanceof Error &&
+		error.message === CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE
+		? "warn"
+		: "error";
+}

--- a/packages/rpc/src/routers/websites.ts
+++ b/packages/rpc/src/routers/websites.ts
@@ -39,6 +39,10 @@ import {
 } from "../services/export-service";
 import { mergeWebsiteSecuritySettings } from "./website-settings";
 import {
+	CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE,
+	getTrackingHealthErrorLogLevel,
+} from "./tracking-health-errors";
+import {
 	type ChartDataRow,
 	type ProcessedMiniChartData,
 	processChartData,
@@ -162,7 +166,10 @@ async function getTrackingEventsStatus(
 				{ websiteId }
 			),
 			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error("ClickHouse query timeout")), 10_000)
+				setTimeout(
+					() => reject(new Error(CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE)),
+					10_000
+				)
 			),
 		]);
 
@@ -175,7 +182,8 @@ async function getTrackingEventsStatus(
 	} catch (error) {
 		const message =
 			error instanceof Error ? error.message : "Unknown error checking events";
-		logger.error({ websiteId }, `Error checking tracking events: ${message}`);
+		const level = getTrackingHealthErrorLogLevel(error);
+		logger[level]({ websiteId }, `Error checking tracking events: ${message}`);
 		return { hasEvents: false, recentEvents: 0, error: message };
 	}
 }
@@ -237,7 +245,10 @@ async function getRecentBlockedTrackingIssue(
 				}
 			),
 			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error("ClickHouse query timeout")), 10_000)
+				setTimeout(
+					() => reject(new Error(CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE)),
+					10_000
+				)
 			),
 		]);
 
@@ -250,7 +261,8 @@ async function getRecentBlockedTrackingIssue(
 			error instanceof Error
 				? error.message
 				: "Unknown error checking blocked traffic";
-		logger.error({ websiteId }, `Error checking blocked traffic: ${message}`);
+		const level = getTrackingHealthErrorLogLevel(error);
+		logger[level]({ websiteId }, `Error checking blocked traffic: ${message}`);
 		return null;
 	}
 }


### PR DESCRIPTION
Clean replacement for #468, based on staging.\n\nWhat changed:\n- Adds a tested tracking-health log-level helper.\n- Downgrades only the canonical ClickHouse tracking-health timeout to WARN.\n- Keeps unexpected tracking event / blocked-traffic failures at ERROR.\n- Reuses one timeout message constant for both tracking-health ClickHouse probes.\n\nVerification:\n- cd packages/rpc && bun test src/routers/tracking-health-errors.test.ts\n- bunx ultracite check packages/rpc/src/routers/websites.ts packages/rpc/src/routers/tracking-health-errors.ts packages/rpc/src/routers/tracking-health-errors.test.ts\n- cd packages/rpc && bun run check-types\n- cd packages/rpc && bun run test\n- bun run lint\n- bun run check-types\n- bun run test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded the canonical ClickHouse tracking-health timeout to warn to reduce noisy error logs. Added a small helper and constant to centralize log-level handling while keeping unexpected failures at error.

- **Bug Fixes**
  - Websites router logs tracking-health ClickHouse timeouts as warn; unexpected/blocked-traffic errors stay at error.
  - Introduced `CLICKHOUSE_TRACKING_HEALTH_TIMEOUT_MESSAGE` and `getTrackingHealthErrorLogLevel()` and applied to both probes.
  - Added tests for log-level behavior.

<sup>Written for commit 3b5da1d359b7d81d4e569f9f830dfdb4faa8f41a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

