### PR TITLE
refactor(types): remove forced tokenlens and cache casts

### DIFF
--- a/apps/dashboard/components/ai-elements/context.tsx
+++ b/apps/dashboard/components/ai-elements/context.tsx
@@ -13,12 +13,11 @@ import { computeTokenCostsForModel } from "tokenlens/helpers";
 import { vercelModels } from "tokenlens/providers/vercel";
 import { Button, Progress } from "@databuddy/ui";
 
-type VercelModelId = keyof typeof vercelModels.models;
-
 const lookupModel = (modelId: string): SourceModel | undefined => {
-	const model = vercelModels.models[modelId as VercelModelId];
+	const model =
+		vercelModels.models[modelId as keyof typeof vercelModels.models];
 	return model
-		? ({ canonical_id: model.id, ...model } as unknown as SourceModel)
+		? ({ canonical_id: model.id, ...model } satisfies SourceModel)
 		: undefined;
 };
 

--- a/apps/links/src/routes/redirect.ts
+++ b/apps/links/src/routes/redirect.ts
@@ -23,8 +23,11 @@ const EXPIRED_URL = `${config.urls.dashboard}/dby/expired`;
 const NOT_FOUND_URL = `${config.urls.dashboard}/dby/not-found`;
 const OG_PROXY_URL = `${config.urls.dashboard}/dby/l`;
 
-const NULL_SENTINEL = Object.freeze({ __null: true }) as unknown as CachedLink;
-const linkCache = new LRUCache<string, CachedLink>({ max: 1000, ttl: 5000 });
+const NULL_SENTINEL = Symbol("null");
+const linkCache = new LRUCache<string, CachedLink | typeof NULL_SENTINEL>({
+	max: 1000,
+	ttl: 5000,
+});
 const etagCache = new LRUCache<string, string>({ max: 1000, ttl: 60_000 });
 const dedupCache = new LRUCache<string, true>({ max: 10_000, ttl: 300_000 });
 const botCache = new LRUCache<string, { isBot: boolean; isSocial: boolean }>({

--- a/packages/ai/src/lib/usage-telemetry.ts
+++ b/packages/ai/src/lib/usage-telemetry.ts
@@ -9,19 +9,10 @@ import type { SourceModel } from "tokenlens";
 import { computeTokenCostsForModel } from "tokenlens/helpers";
 import { vercelModels } from "tokenlens/providers/vercel";
 
-type VercelModelId = keyof typeof vercelModels.models;
-
 interface CostModel {
 	fallback: boolean;
 	id: string;
 	model: SourceModel;
-}
-
-function createSourceModel(
-	id: string,
-	cost: AgentModelCostUsdPerMillion
-): SourceModel {
-	return { canonical_id: id, cost, id } as unknown as SourceModel;
 }
 
 function createCostModel(
@@ -29,28 +20,33 @@ function createCostModel(
 	cost: AgentModelCostUsdPerMillion,
 	fallback = false
 ): CostModel {
-	return { fallback, id, model: createSourceModel(id, cost) };
-}
-
-function lookupConfiguredModel(modelId: string): CostModel | null {
-	const resolved = lookupAgentModelCost(modelId);
-	return resolved ? createCostModel(resolved.id, resolved.cost) : null;
+	return {
+		fallback,
+		id,
+		model: { canonical_id: id, cost, id, name: id } satisfies SourceModel,
+	};
 }
 
 function lookupTokenlensModel(modelId: string): CostModel | null {
-	const model = vercelModels.models[modelId as VercelModelId];
+	const model =
+		vercelModels.models[modelId as keyof typeof vercelModels.models];
 	if (!model?.cost) {
 		return null;
 	}
 	return {
 		fallback: false,
 		id: model.id,
-		model: { canonical_id: model.id, ...model } as unknown as SourceModel,
+		model: { canonical_id: model.id, ...model } satisfies SourceModel,
 	};
 }
 
 function resolveCostModel(modelId: string): CostModel {
-	const model = lookupConfiguredModel(modelId) ?? lookupTokenlensModel(modelId);
+	const configured = lookupAgentModelCost(modelId);
+	if (configured) {
+		return createCostModel(configured.id, configured.cost);
+	}
+
+	const model = lookupTokenlensModel(modelId);
 	if (model) {
 		return model;
 	}


### PR DESCRIPTION
## Summary
- remove forced `as unknown as SourceModel` casts from AI usage telemetry and dashboard token cost lookup
- replace the links cache null object cast with an in-memory `Symbol` sentinel and honest cache union type
- inline the small configured-model lookup wrapper while preserving fallback cost behavior

## Verification
- `bun run check-types`
- `bun run lint`
- `bun run test`
- `cd packages/ai && bun test src/lib/usage-telemetry.test.ts`
- `cd apps/links && bun test src`
- `bunx ultracite check packages/ai/src/lib/usage-telemetry.ts apps/dashboard/components/ai-elements/context.tsx apps/links/src/routes/redirect.ts`

## AI Disclosure
- Prepared with AI assistance and human-reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unsafe casts in model cost lookups and caches to improve type safety, with no behavior changes. This makes `tokenlens` integrations and link caching clearer and safer.

- **Refactors**
  - AI usage telemetry: construct `SourceModel` with `satisfies`, resolve costs via configured `lookupAgentModelCost` first, then fall back to `tokenlens` models.
  - Dashboard model lookup: remove forced casts; use `satisfies` for `SourceModel`.
  - Links redirect cache: replace null-object cast with a `Symbol("null")` sentinel and a precise union type in `LRUCache`.

<sup>Written for commit 0f9ac322132216fdf6a075ffc82d01ebfbd290e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/517?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

