### PR TITLE
refactor(types): remove browser and funnel casts

### DIFF
--- a/apps/dashboard/contexts/chat-context.tsx
+++ b/apps/dashboard/contexts/chat-context.tsx
@@ -81,7 +81,6 @@ export function ChatProvider({
 		defaultWebsiteId
 	);
 	const queryClient = useQueryClient();
-	const chatRef = useRef<ChatApi>(null as unknown as ChatApi);
 
 	const { data: storedChat, isFetched } = useQuery({
 		...orpc.agentChats.get.queryOptions({ input: { id: chatId } }),
@@ -96,6 +95,7 @@ export function ChatProvider({
 		resume: Boolean(storedChat?.activeStreamId),
 	});
 
+	const chatRef = useRef(chat);
 	chatRef.current = chat;
 
 	const [hasRestored, setHasRestored] = useState(false);

--- a/apps/dashboard/hooks/use-funnels.ts
+++ b/apps/dashboard/hooks/use-funnels.ts
@@ -57,10 +57,7 @@ export function useFunnels(
 		const map = new Map<string, FunnelAnalyticsData | null>();
 		for (const [index, result] of analyticsResults.entries()) {
 			if (result.data && funnels[index]) {
-				map.set(
-					funnels[index].id,
-					result.data as unknown as FunnelAnalyticsData
-				);
+				map.set(funnels[index].id, result.data);
 			}
 		}
 		return map;

--- a/packages/sdk/src/core/flags/types.ts
+++ b/packages/sdk/src/core/flags/types.ts
@@ -88,3 +88,9 @@ export interface FlagsManager {
 	updateConfig(config: FlagsConfig): void;
 	updateUser(user: UserContext): void;
 }
+
+declare global {
+	interface Window {
+		__databuddyFlags?: FlagsManager;
+	}
+}

--- a/packages/sdk/src/react/flags/flags-provider.tsx
+++ b/packages/sdk/src/react/flags/flags-provider.tsx
@@ -56,13 +56,10 @@ export function FlagsProvider({ children, ...config }: FlagsProviderProps) {
 		if (typeof window === "undefined") {
 			return;
 		}
-		const w = window as unknown as {
-			__databuddyFlags?: BrowserFlagsManager;
-		};
-		w.__databuddyFlags = manager;
+		window.__databuddyFlags = manager;
 		return () => {
-			if (w.__databuddyFlags === manager) {
-				w.__databuddyFlags = undefined;
+			if (window.__databuddyFlags === manager) {
+				window.__databuddyFlags = undefined;
 			}
 		};
 	}, [manager]);

--- a/packages/sdk/src/vue/flags/flags-plugin.ts
+++ b/packages/sdk/src/vue/flags/flags-plugin.ts
@@ -22,13 +22,10 @@ export function createFlagsPlugin(options: FlagsConfig) {
 			});
 
 			if (typeof window !== "undefined") {
-				const w = window as unknown as {
-					__databuddyFlags?: BrowserFlagsManager;
-				};
-				w.__databuddyFlags = currentManager;
+				window.__databuddyFlags = currentManager;
 				app.onUnmount(() => {
-					if (w.__databuddyFlags === currentManager) {
-						w.__databuddyFlags = undefined;
+					if (window.__databuddyFlags === currentManager) {
+						window.__databuddyFlags = undefined;
 					}
 				});
 			}


### PR DESCRIPTION
## Summary
- initialize the dashboard chat ref from the real chat API instead of a `null as unknown as ChatApi` cast
- remove the funnel analytics double-cast now that ORPC result typing carries through
- add one SDK `window.__databuddyFlags` global type and delete duplicated React/Vue local window casts

## Verification
- `bun run check-types`
- `bun run lint`
- `bun run test`
- `cd apps/dashboard && bun run check-types`
- `cd packages/sdk && bun run check-types`
- `cd packages/sdk && bun run test:unit`
- `bunx ultracite check apps/dashboard/contexts/chat-context.tsx apps/dashboard/hooks/use-funnels.ts packages/sdk/src/core/flags/types.ts packages/sdk/src/react/flags/flags-provider.tsx packages/sdk/src/vue/flags/flags-plugin.ts`

## AI Disclosure
- Prepared with AI assistance and human-reviewed before submission.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unsafe casts in dashboard and SDK, and added a typed `window.__databuddyFlags` global for flags. Chat ref now initializes from the real API, and funnels mapping relies on ORPC types.

- **Refactors**
  - Dashboard: initialize `chatRef` from `chat` instead of `null as unknown as ChatApi`.
  - Funnels: remove double-cast; use typed ORPC `result.data` directly when mapping.
  - SDK: declare global `window.__databuddyFlags` type; update React/Vue providers to set/clear it without local window casts.

<sup>Written for commit a6585ad72083417416f59253b8d090227ac05871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

