### PR TITLE
refactor(tracker): simplify config value parsing

### DIFF
--- a/packages/tracker/src/core/utils.ts
+++ b/packages/tracker/src/core/utils.ts
@@ -21,6 +21,27 @@ export const isLocalhost = () => {
 const DATA_ATTR_REGEX = /-./g;
 const NUMBER_REGEX = /^\d+$/;
 
+function parseConfigValue(
+	value: string,
+	emptyStringIsTrue = false
+): boolean | number | string {
+	if (value === "true" || (emptyStringIsTrue && value === "")) {
+		return true;
+	}
+	if (value === "false") {
+		return false;
+	}
+	return NUMBER_REGEX.test(value) ? Number(value) : value;
+}
+
+function parseJsonAttribute(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch {
+		return [];
+	}
+}
+
 export const generateUUIDv4 = () => {
 	if (typeof crypto !== "undefined" && crypto.randomUUID) {
 		return crypto.randomUUID();
@@ -78,48 +99,28 @@ export function getTrackerConfig(): TrackerOptions {
 	}
 
 	const globalConfig = window.databuddyConfig || {};
-	let config: TrackerOptions = { clientId: "", ...globalConfig };
+	const config: TrackerOptions & Record<string, unknown> = {
+		clientId: "",
+		...globalConfig,
+	};
 
 	if (script) {
-		const dataAttributes: Record<string, any> = {};
 		for (const attr of script.attributes) {
 			if (attr.name.startsWith("data-")) {
 				const key = attr.name
 					.slice(5)
 					.replace(DATA_ATTR_REGEX, (x: string) => x[1].toUpperCase());
-				let value: any = attr.value;
-
-				if (key === "skipPatterns" || key === "maskPatterns") {
-					try {
-						value = JSON.parse(value);
-					} catch {
-						value = [];
-					}
-				} else if (value === "true" || value === "") {
-					value = true;
-				} else if (value === "false") {
-					value = false;
-				} else if (NUMBER_REGEX.test(value)) {
-					value = Number(value);
-				}
-
-				dataAttributes[key] = value;
+				config[key] =
+					key === "skipPatterns" || key === "maskPatterns"
+						? parseJsonAttribute(attr.value)
+						: parseConfigValue(attr.value, true);
 			}
 		}
-		config = { ...config, ...dataAttributes };
 
 		try {
 			const srcUrl = new URL(script.src);
 			srcUrl.searchParams.forEach((value, key) => {
-				if (value === "true") {
-					(config as any)[key] = true;
-				} else if (value === "false") {
-					(config as any)[key] = false;
-				} else if (NUMBER_REGEX.test(value)) {
-					(config as any)[key] = Number(value);
-				} else {
-					(config as any)[key] = value;
-				}
+				config[key] = parseConfigValue(value);
 			});
 		} catch {
 			/* ignore */

--- a/packages/tracker/tests/unit/utils.test.ts
+++ b/packages/tracker/tests/unit/utils.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getTrackerConfig } from "../../src/core/utils";
+
+const originalDocument = globalThis.document;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+	Object.defineProperty(globalThis, "document", {
+		configurable: true,
+		value: originalDocument,
+	});
+	Object.defineProperty(globalThis, "window", {
+		configurable: true,
+		value: originalWindow,
+	});
+});
+
+function setTrackerScript({
+	attributes,
+	src,
+}: {
+	attributes: Array<{ name: string; value: string }>;
+	src: string;
+}) {
+	const script = { attributes, src };
+
+	Object.defineProperty(globalThis, "document", {
+		configurable: true,
+		value: {
+			currentScript: script,
+			getElementsByTagName: () => [script],
+		},
+	});
+}
+
+describe("getTrackerConfig", () => {
+	test("preserves empty strings in URL query params while data attributes treat them as true", () => {
+		Object.defineProperty(globalThis, "window", {
+			configurable: true,
+			value: {
+				databuddyConfig: {
+					apiUrl: "https://global.example",
+					clientId: "global-client",
+				},
+			},
+		});
+		setTrackerScript({
+			attributes: [
+				{ name: "data-client-id", value: "data-client" },
+				{ name: "data-track-attributes", value: "" },
+			],
+			src: "https://cdn.example.com/databuddy-debug.js?clientId=&apiUrl=&ignoreBotDetection=&batchSize=10&disabled=false",
+		});
+
+		const config = getTrackerConfig();
+
+		expect(config.clientId).toBe("");
+		expect(config.apiUrl).toBe("");
+		expect(config.trackAttributes).toBe(true);
+		expect(config.ignoreBotDetection).toBe("");
+		expect(config.batchSize).toBe(10);
+		expect(config.disabled).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
- remove forced `any` writes from tracker config parsing
- share scalar coercion for script `data-*` attributes and script URL query params
- keep config precedence unchanged: global config, then script data attributes, then script URL params

## Verification
- `bunx ultracite check packages/tracker/src/core/utils.ts`
- `cd packages/tracker && bun run check-types`
- `cd packages/tracker && bun run test`
- `bun run check-types`
- `bun run lint`
- `bun run test`

## AI disclosure
- Prepared with AI assistance and human-reviewed before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies tracker config parsing by centralizing value coercion and removing unsafe `any` writes. Shared parsers handle booleans, numbers, and JSON for both `data-*` attributes and script URL params, preserving empty strings in URL params and treating empty `data-*` values as true, with precedence unchanged.

- **Refactors**
  - Added `parseConfigValue` and `parseJsonAttribute` for consistent coercion.
  - Removed intermediate `any` maps; tightened config typing.
  - Added unit test covering precedence and empty-string semantics.

<sup>Written for commit 31e90672deb24b19285260a34f0aebc26efc4c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/519?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

