### PR TITLE
fix(notifications): fan out alarm destinations

### DIFF
--- a/apps/uptime/src/uptime-transition-alerts.ts
+++ b/apps/uptime/src/uptime-transition-alerts.ts
@@ -9,7 +9,7 @@ import { uptimeSchedules } from "@databuddy/db/schema";
 import { config } from "@databuddy/env/app";
 import {
 	NotificationClient,
-	buildAlarmNotificationConfig,
+	buildAlarmNotificationTargets,
 } from "@databuddy/notifications";
 import { Cache, Context, Data, Duration, Effect, Layer, Option } from "effect";
 import type { ScheduleData } from "./actions";
@@ -27,6 +27,7 @@ class AlarmLookupError extends Data.TaggedError("AlarmLookupError")<{
 
 class NotificationSendError extends Data.TaggedError("NotificationSendError")<{
 	alarmId: string;
+	channel: string;
 	cause: unknown;
 }> {}
 
@@ -184,19 +185,57 @@ const sendToAlarm = (
 	alarm: LinkedAlarm,
 	payload: Parameters<NotificationClient["send"]>[0]
 ) => {
-	const { clientConfig, channels } = buildAlarmNotificationConfig(
-		alarm.destinations
-	);
-	if (channels.length === 0) {
+	const targets = buildAlarmNotificationTargets(alarm.destinations);
+	if (targets.length === 0) {
 		return Effect.succeed(false);
 	}
 
-	return Effect.tryPromise({
-		try: () =>
-			new NotificationClient(clientConfig)
-				.send(payload, { channels })
-				.then(() => true),
-		catch: (cause) => new NotificationSendError({ alarmId: alarm.id, cause }),
+	return Effect.gen(function* () {
+		const results = yield* Effect.all(
+			targets.map((target) =>
+				Effect.tryPromise({
+					try: () =>
+						new NotificationClient(target.clientConfig).send(payload, {
+							channels: [target.channel],
+						}),
+					catch: (cause) =>
+						new NotificationSendError({
+							alarmId: alarm.id,
+							channel: target.channel,
+							cause,
+						}),
+				}).pipe(
+					Effect.map((deliveryResults) => {
+						for (const result of deliveryResults) {
+							if (!result.success) {
+								captureError(
+									new Error(
+										result.error ??
+											`Notification delivery failed for ${result.channel}`
+									),
+									{
+										error_step: "alarm_notification_result",
+										alarm_id: alarm.id,
+										channel: result.channel,
+									}
+								);
+							}
+						}
+						return deliveryResults.some((result) => result.success);
+					}),
+					Effect.catchTag("NotificationSendError", (e) => {
+						captureError(e.cause, {
+							error_step: "alarm_notification",
+							alarm_id: e.alarmId,
+							channel: e.channel,
+						});
+						return Effect.succeed(false);
+					})
+				)
+			),
+			{ concurrency: "unbounded" }
+		);
+		return results.some(Boolean);
 	});
 };
 
@@ -311,17 +350,7 @@ const handleTransition = (options: {
 			.filter((alarm) => alarm.destinations.length > 0);
 
 		const results = yield* Effect.all(
-			sendable.map((alarm) =>
-				sendToAlarm(alarm, payload).pipe(
-					Effect.catchTag("NotificationSendError", (e) => {
-						captureError(e.cause, {
-							error_step: "alarm_notification",
-							alarm_id: e.alarmId,
-						});
-						return Effect.succeed(false);
-					})
-				)
-			),
+			sendable.map((alarm) => sendToAlarm(alarm, payload)),
 			{ concurrency: "unbounded" }
 		);
 

--- a/apps/uptime/src/uptime-transition-alerts.ts
+++ b/apps/uptime/src/uptime-transition-alerts.ts
@@ -187,7 +187,7 @@ const sendToAlarm = (
 ) => {
 	const targets = buildAlarmNotificationTargets(alarm.destinations);
 	if (targets.length === 0) {
-		return Effect.succeed(false);
+		return Effect.succeed(0);
 	}
 
 	return Effect.gen(function* () {
@@ -206,8 +206,11 @@ const sendToAlarm = (
 						}),
 				}).pipe(
 					Effect.map((deliveryResults) => {
+						let successes = 0;
 						for (const result of deliveryResults) {
-							if (!result.success) {
+							if (result.success) {
+								successes += 1;
+							} else {
 								captureError(
 									new Error(
 										result.error ??
@@ -221,7 +224,7 @@ const sendToAlarm = (
 								);
 							}
 						}
-						return deliveryResults.some((result) => result.success);
+						return successes;
 					}),
 					Effect.catchTag("NotificationSendError", (e) => {
 						captureError(e.cause, {
@@ -229,13 +232,13 @@ const sendToAlarm = (
 							alarm_id: e.alarmId,
 							channel: e.channel,
 						});
-						return Effect.succeed(false);
+						return Effect.succeed(0);
 					})
 				)
 			),
 			{ concurrency: "unbounded" }
 		);
-		return results.some(Boolean);
+		return results.reduce((total, count) => total + count, 0);
 	});
 };
 
@@ -354,7 +357,7 @@ const handleTransition = (options: {
 			{ concurrency: "unbounded" }
 		);
 
-		const fired = results.filter(Boolean).length;
+		const fired = results.reduce((total, count) => total + count, 0);
 		return { alarms_fired: fired, transition_kind: kind };
 	});
 

--- a/packages/notifications/src/__tests__/alarm-config.test.ts
+++ b/packages/notifications/src/__tests__/alarm-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { buildAlarmNotificationTargets } from "../alarm-config";
+
+describe("buildAlarmNotificationTargets", () => {
+	test("keeps same-channel destinations as separate delivery targets", () => {
+		const firstSlack = "https://hooks.slack.com/services/T000/B000/first";
+		const secondSlack = "https://hooks.slack.com/services/T000/B000/second";
+
+		const targets = buildAlarmNotificationTargets([
+			{ type: "slack", identifier: firstSlack, config: {} },
+			{ type: "slack", identifier: secondSlack, config: {} },
+			{
+				type: "webhook",
+				identifier: "https://example.com/alarm",
+				config: {
+					headers: {
+						authorization: "drop-me",
+						"X-Array": ["drop-me"],
+						"X-Alarm": "keep-me",
+						"X-Bad\r\nName": "drop-me",
+						"X-Bad-Value": "drop\r\nme",
+					},
+				},
+			},
+		]);
+
+		expect(targets.map((target) => target.channel)).toEqual([
+			"slack",
+			"slack",
+			"webhook",
+		]);
+		expect(targets[0]?.clientConfig.slack?.webhookUrl).toBe(firstSlack);
+		expect(targets[1]?.clientConfig.slack?.webhookUrl).toBe(secondSlack);
+		expect(targets[2]?.clientConfig.webhook).toEqual({
+			url: "https://example.com/alarm",
+			headers: { "X-Alarm": "keep-me" },
+		});
+	});
+});

--- a/packages/notifications/src/__tests__/alarm-config.test.ts
+++ b/packages/notifications/src/__tests__/alarm-config.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { buildAlarmNotificationTargets } from "../alarm-config";
+import {
+	buildAlarmNotificationConfig,
+	buildAlarmNotificationTargets,
+} from "../alarm-config";
 
 describe("buildAlarmNotificationTargets", () => {
 	test("keeps same-channel destinations as separate delivery targets", () => {
@@ -35,5 +38,26 @@ describe("buildAlarmNotificationTargets", () => {
 			url: "https://example.com/alarm",
 			headers: { "X-Alarm": "keep-me" },
 		});
+	});
+});
+
+describe("buildAlarmNotificationConfig", () => {
+	test("keeps legacy channels unique when duplicate destination types are provided", () => {
+		const firstSlack = "https://hooks.slack.com/services/T000/B000/first";
+		const secondSlack = "https://hooks.slack.com/services/T000/B000/second";
+
+		const config = buildAlarmNotificationConfig([
+			{ type: "slack", identifier: firstSlack, config: {} },
+			{ type: "slack", identifier: secondSlack, config: {} },
+			{
+				type: "webhook",
+				identifier: "https://example.com/alarm",
+				config: {},
+			},
+		]);
+
+		expect(config.channels).toEqual(["slack", "webhook"]);
+		expect(config.clientConfig.slack?.webhookUrl).toBe(firstSlack);
+		expect(config.clientConfig.webhook?.url).toBe("https://example.com/alarm");
 	});
 });

--- a/packages/notifications/src/alarm-config.ts
+++ b/packages/notifications/src/alarm-config.ts
@@ -62,16 +62,23 @@ function sanitizeWebhookHeaders(
 	return Object.keys(out).length > 0 ? out : undefined;
 }
 
+/**
+ * Legacy adapter for callers that can only represent one provider per channel.
+ * Use buildAlarmNotificationTargets for per-destination fanout.
+ */
 export function buildAlarmNotificationConfig(destinations: AlarmDestination[]) {
 	const clientConfig: NotificationClientConfig = {};
-	const channels: NotificationChannel[] = [];
+	const channels = new Set<NotificationChannel>();
 
 	for (const target of buildAlarmNotificationTargets(destinations)) {
+		if (channels.has(target.channel)) {
+			continue;
+		}
 		Object.assign(clientConfig, target.clientConfig);
-		channels.push(target.channel);
+		channels.add(target.channel);
 	}
 
-	return { clientConfig, channels };
+	return { clientConfig, channels: Array.from(channels) };
 }
 
 export function buildAlarmNotificationTargets(

--- a/packages/notifications/src/alarm-config.ts
+++ b/packages/notifications/src/alarm-config.ts
@@ -1,9 +1,15 @@
+import type { NotificationClientConfig } from "./client";
 import type { NotificationChannel } from "./types";
 
 interface AlarmDestination {
 	config: unknown;
 	identifier: string;
 	type: string;
+}
+
+export interface AlarmNotificationTarget {
+	channel: NotificationChannel;
+	clientConfig: NotificationClientConfig;
 }
 
 const FORBIDDEN_WEBHOOK_HEADERS = new Set([
@@ -57,8 +63,21 @@ function sanitizeWebhookHeaders(
 }
 
 export function buildAlarmNotificationConfig(destinations: AlarmDestination[]) {
-	const clientConfig: Record<string, Record<string, unknown>> = {};
+	const clientConfig: NotificationClientConfig = {};
 	const channels: NotificationChannel[] = [];
+
+	for (const target of buildAlarmNotificationTargets(destinations)) {
+		Object.assign(clientConfig, target.clientConfig);
+		channels.push(target.channel);
+	}
+
+	return { clientConfig, channels };
+}
+
+export function buildAlarmNotificationTargets(
+	destinations: AlarmDestination[]
+): AlarmNotificationTarget[] {
+	const targets: AlarmNotificationTarget[] = [];
 
 	for (const dest of destinations) {
 		const cfg = (dest.config ?? {}) as Record<string, unknown>;
@@ -67,42 +86,55 @@ export function buildAlarmNotificationConfig(destinations: AlarmDestination[]) {
 			if (!isAllowedSlackWebhook(dest.identifier)) {
 				continue;
 			}
-			clientConfig.slack = { webhookUrl: dest.identifier };
-			channels.push("slack");
+			targets.push({
+				channel: "slack",
+				clientConfig: { slack: { webhookUrl: dest.identifier } },
+			});
 		} else if (dest.type === "webhook") {
-			clientConfig.webhook = {
-				url: dest.identifier,
-				headers: sanitizeWebhookHeaders(cfg.headers),
-			};
-			channels.push("webhook");
-		} else if (dest.type === "email") {
-			clientConfig.email = {
-				defaultTo: dest.identifier,
-				from: (cfg.from as string) || "Databuddy <alerts@databuddy.cc>",
-				sendEmailAction: async (payload: {
-					to: string | string[];
-					subject: string;
-					html?: string;
-					text?: string;
-					from?: string;
-				}) => {
-					const { Resend } = await import("resend");
-					const apiKey = process.env.RESEND_API_KEY;
-					if (!apiKey) {
-						return;
-					}
-					const resend = new Resend(apiKey);
-					await resend.emails.send({
-						from: payload.from || "Databuddy <alerts@databuddy.cc>",
-						to: Array.isArray(payload.to) ? payload.to : [payload.to],
-						subject: payload.subject,
-						html: payload.html || payload.text || "",
-					});
+			targets.push({
+				channel: "webhook",
+				clientConfig: {
+					webhook: {
+						url: dest.identifier,
+						headers: sanitizeWebhookHeaders(cfg.headers),
+					},
 				},
-			};
-			channels.push("email");
+			});
+		} else if (dest.type === "email") {
+			targets.push({
+				channel: "email",
+				clientConfig: {
+					email: {
+						defaultTo: dest.identifier,
+						from:
+							typeof cfg.from === "string"
+								? cfg.from
+								: "Databuddy <alerts@databuddy.cc>",
+						sendEmailAction: async (payload: {
+							to: string | string[];
+							subject: string;
+							html?: string;
+							text?: string;
+							from?: string;
+						}) => {
+							const { Resend } = await import("resend");
+							const apiKey = process.env.RESEND_API_KEY;
+							if (!apiKey) {
+								return;
+							}
+							const resend = new Resend(apiKey);
+							await resend.emails.send({
+								from: payload.from || "Databuddy <alerts@databuddy.cc>",
+								to: Array.isArray(payload.to) ? payload.to : [payload.to],
+								subject: payload.subject,
+								html: payload.html || payload.text || "",
+							});
+						},
+					},
+				},
+			});
 		}
 	}
 
-	return { clientConfig, channels };
+	return targets;
 }

--- a/packages/notifications/src/index.ts
+++ b/packages/notifications/src/index.ts
@@ -5,4 +5,7 @@ export * from "./providers";
 export * from "./templates/anomaly";
 export * from "./templates/uptime";
 export * from "./types";
-export { buildAlarmNotificationConfig } from "./alarm-config";
+export {
+	buildAlarmNotificationConfig,
+	buildAlarmNotificationTargets,
+} from "./alarm-config";

--- a/packages/rpc/src/lib/alarm-notifications.ts
+++ b/packages/rpc/src/lib/alarm-notifications.ts
@@ -1,4 +1,37 @@
-export {
-	buildAlarmNotificationConfig as toNotificationConfig,
-	buildAlarmNotificationTargets as toNotificationTargets,
+import {
+	NotificationClient,
+	buildAlarmNotificationConfig,
+	buildAlarmNotificationTargets,
+	type NotificationPayload,
+	type NotificationResult,
 } from "@databuddy/notifications";
+
+export const toNotificationConfig = buildAlarmNotificationConfig;
+export const toNotificationTargets = buildAlarmNotificationTargets;
+
+type NotificationTarget = ReturnType<
+	typeof buildAlarmNotificationTargets
+>[number];
+
+function getErrorMessage(error: unknown): string {
+	return error instanceof Error ? error.message : String(error);
+}
+
+export async function sendNotificationTarget(
+	target: NotificationTarget,
+	payload: NotificationPayload
+): Promise<NotificationResult[]> {
+	try {
+		return await new NotificationClient(target.clientConfig).send(payload, {
+			channels: [target.channel],
+		});
+	} catch (error) {
+		return [
+			{
+				success: false,
+				channel: target.channel,
+				error: getErrorMessage(error),
+			},
+		];
+	}
+}

--- a/packages/rpc/src/lib/alarm-notifications.ts
+++ b/packages/rpc/src/lib/alarm-notifications.ts
@@ -1,1 +1,4 @@
-export { buildAlarmNotificationConfig as toNotificationConfig } from "@databuddy/notifications";
+export {
+	buildAlarmNotificationConfig as toNotificationConfig,
+	buildAlarmNotificationTargets as toNotificationTargets,
+} from "@databuddy/notifications";

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -4,12 +4,14 @@ import {
 	alarms,
 	alarmTriggerTypeValues,
 } from "@databuddy/db/schema";
-import { NotificationClient } from "@databuddy/notifications";
 import { ratelimit } from "@databuddy/redis/rate-limit";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { toNotificationTargets } from "../lib/alarm-notifications";
+import {
+	sendNotificationTarget,
+	toNotificationTargets,
+} from "../lib/alarm-notifications";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, protectedProcedure, trackedProcedure } from "../orpc";
 import { withResource } from "../procedures/with-resource";
@@ -419,11 +421,7 @@ export const alarmsRouter = {
 			};
 			const raw = (
 				await Promise.all(
-					targets.map((target) =>
-						new NotificationClient(target.clientConfig).send(payload, {
-							channels: [target.channel],
-						})
-					)
+					targets.map((target) => sendNotificationTarget(target, payload))
 				)
 			).flat();
 

--- a/packages/rpc/src/routers/alarms.ts
+++ b/packages/rpc/src/routers/alarms.ts
@@ -9,7 +9,7 @@ import { ratelimit } from "@databuddy/redis/rate-limit";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { toNotificationConfig } from "../lib/alarm-notifications";
+import { toNotificationTargets } from "../lib/alarm-notifications";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, protectedProcedure, trackedProcedure } from "../orpc";
 import { withResource } from "../procedures/with-resource";
@@ -406,24 +406,26 @@ export const alarmsRouter = {
 				throw rpcError.badRequest("Alarm has no destinations configured");
 			}
 
-			const { clientConfig, channels } = toNotificationConfig(
-				alarm.destinations
-			);
-			const client = new NotificationClient(clientConfig);
-
-			const raw = await client.send(
-				{
-					title: `Test: ${alarm.name}`,
-					message: `This is a test notification from your "${alarm.name}" alarm. If you're reading this, the channel is working.`,
-					priority: "normal",
-					metadata: {
-						template: "test",
-						alarmId: alarm.id,
-						alarmName: alarm.name,
-					},
+			const targets = toNotificationTargets(alarm.destinations);
+			const payload = {
+				title: `Test: ${alarm.name}`,
+				message: `This is a test notification from your "${alarm.name}" alarm. If you're reading this, the channel is working.`,
+				priority: "normal" as const,
+				metadata: {
+					template: "test",
+					alarmId: alarm.id,
+					alarmName: alarm.name,
 				},
-				{ channels }
-			);
+			};
+			const raw = (
+				await Promise.all(
+					targets.map((target) =>
+						new NotificationClient(target.clientConfig).send(payload, {
+							channels: [target.channel],
+						})
+					)
+				)
+			).flat();
 
 			return {
 				results: raw.map((r) => ({

--- a/packages/rpc/src/routers/anomalies.ts
+++ b/packages/rpc/src/routers/anomalies.ts
@@ -3,15 +3,15 @@ import {
 	normalizeEmailNotificationSettings,
 	type OrganizationEmailNotificationSettings,
 } from "@databuddy/db";
-import {
-	buildAnomalyNotificationPayload,
-	NotificationClient,
-} from "@databuddy/notifications";
+import { buildAnomalyNotificationPayload } from "@databuddy/notifications";
 import { redis } from "@databuddy/redis";
 import { ratelimit } from "@databuddy/redis/rate-limit";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { toNotificationTargets } from "../lib/alarm-notifications";
+import {
+	sendNotificationTarget,
+	toNotificationTargets,
+} from "../lib/alarm-notifications";
 import {
 	detectAnomalies,
 	fetchAnomalyTimeSeries,
@@ -247,11 +247,7 @@ export const anomaliesRouter = {
 
 					const results = (
 						await Promise.all(
-							targets.map((target) =>
-								new NotificationClient(target.clientConfig).send(payload, {
-									channels: [target.channel],
-								})
-							)
+							targets.map((target) => sendNotificationTarget(target, payload))
 						)
 					).flat();
 					notificationsSent += results.filter((r) => r.success).length;

--- a/packages/rpc/src/routers/anomalies.ts
+++ b/packages/rpc/src/routers/anomalies.ts
@@ -11,7 +11,7 @@ import { redis } from "@databuddy/redis";
 import { ratelimit } from "@databuddy/redis/rate-limit";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { toNotificationConfig } from "../lib/alarm-notifications";
+import { toNotificationTargets } from "../lib/alarm-notifications";
 import {
 	detectAnomalies,
 	fetchAnomalyTimeSeries,
@@ -240,13 +240,20 @@ export const anomaliesRouter = {
 					const destinations = emailEnabled
 						? alarm.destinations
 						: alarm.destinations.filter((dest) => dest.type !== "email");
-					const { clientConfig, channels } = toNotificationConfig(destinations);
-					if (channels.length === 0) {
+					const targets = toNotificationTargets(destinations);
+					if (targets.length === 0) {
 						continue;
 					}
 
-					const client = new NotificationClient(clientConfig);
-					const results = await client.send(payload, { channels });
+					const results = (
+						await Promise.all(
+							targets.map((target) =>
+								new NotificationClient(target.clientConfig).send(payload, {
+									channels: [target.channel],
+								})
+							)
+						)
+					).flat();
 					notificationsSent += results.filter((r) => r.success).length;
 				}
 			}


### PR DESCRIPTION
## Summary
- add per-destination notification targets so duplicate same-channel alarm destinations do not collapse to the last config
- update uptime transition alerts, anomaly notifications, and alarm test sends to deliver one target at a time
- capture failed uptime `NotificationResult[]` entries and count only successful target sends as fired
- add regression coverage for same-channel target fanout and webhook header sanitization

## PR #407 follow-up
- PR #407 is stale/conflicted because uptime transition alerts moved from `apps/uptime/src/uptime-transition-emails.ts` to `apps/uptime/src/uptime-transition-alerts.ts` on `staging`
- this carries forward the actionable same-channel/failure-result review feedback from #407 against the current staging implementation

## Verification
- `bunx ultracite check packages/notifications/src/alarm-config.ts packages/notifications/src/__tests__/alarm-config.test.ts apps/uptime/src/uptime-transition-alerts.ts packages/rpc/src/routers/alarms.ts packages/rpc/src/routers/anomalies.ts packages/rpc/src/lib/alarm-notifications.ts packages/notifications/src/index.ts`
- `cd packages/notifications && bun run test && bun run check-types`
- `cd apps/uptime && bun run test && bun run check-types`
- `cd packages/rpc && bun run check-types`
- `bun run lint`
- `bun run check-types`
- `bun run test`

## AI disclosure
- Implemented and verified with AI assistance; changes were reviewed against the current staging code path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes alarm destination collisions by sending each destination separately and tracking per-channel results, so multiple Slack/webhook/email targets don’t overwrite each other. Also improves error handling and counts only successful deliveries.

- **Bug Fixes**
  - Added `buildAlarmNotificationTargets` in `@databuddy/notifications` to fan out destinations; kept `buildAlarmNotificationConfig` as a legacy, de-duplicated adapter.
  - Switched uptime alerts, anomaly notifications, and alarm “test send” to send per target via `sendNotificationTarget` in `@databuddy/rpc`, aggregate `NotificationResult[]`, and sum only successes.
  - Captures and logs failures with channel context; sanitizes webhook headers. Added tests for header sanitization, same-channel fan-out, and legacy config dedupe.

<sup>Written for commit ce0a06a4afd686cd9a465a4a91e5a7a002f41ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

