### PR TITLE
fix(dashboard): prevent date picker layout shift

### DIFF
--- a/apps/dashboard/components/date-range-picker.tsx
+++ b/apps/dashboard/components/date-range-picker.tsx
@@ -206,7 +206,11 @@ export function DateRangePicker({
 					<span className="truncate">{formatDisplayRange(value)}</span>
 				</Popover.Trigger>
 
-				<Popover.Content className="w-auto overflow-hidden p-0" side="bottom">
+				<Popover.Content
+					className="w-auto overflow-hidden p-0"
+					disableAnchorTracking
+					side="bottom"
+				>
 					<div className="flex">
 						<div className="hidden w-36 shrink-0 border-border/60 border-r sm:block">
 							<div className="p-1.5">

--- a/packages/ui/src/components/popover.tsx
+++ b/packages/ui/src/components/popover.tsx
@@ -29,11 +29,15 @@ function Content({
 	className,
 	children,
 	align = "center",
+	disableAnchorTracking = false,
 	side = "bottom",
 	sideOffset = 6,
 	...rest
 }: ComponentPropsWithoutRef<typeof BasePopover.Popup> & {
 	align?: ComponentPropsWithoutRef<typeof BasePopover.Positioner>["align"];
+	disableAnchorTracking?: ComponentPropsWithoutRef<
+		typeof BasePopover.Positioner
+	>["disableAnchorTracking"];
 	side?: ComponentPropsWithoutRef<typeof BasePopover.Positioner>["side"];
 	sideOffset?: ComponentPropsWithoutRef<
 		typeof BasePopover.Positioner
@@ -44,6 +48,7 @@ function Content({
 			<BasePopover.Positioner
 				align={align}
 				className="z-50"
+				disableAnchorTracking={disableAnchorTracking}
 				side={side}
 				sideOffset={sideOffset}
 			>


### PR DESCRIPTION
## Summary
- transplant the useful part of #416 onto current staging
- add optional `disableAnchorTracking` support to `@databuddy/ui` Popover.Content
- enable it for the dashboard date range picker to avoid popup-trigger layout shift

## Why
PR #416 targets main from an external fork and now conflicts with the shared UI package migration. The underlying fix is still missing on staging, so this reapplies only the semantic change in the current file layout.

## Verification
- `bunx ultracite check packages/ui/src/components/popover.tsx apps/dashboard/components/date-range-picker.tsx`
- `bun run lint`
- `bun run check-types`
- `bun run test`

Refs #416

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents layout shift in the dashboard date range picker by adding optional `disableAnchorTracking` to `@databuddy/ui` `Popover.Content` and enabling it for the picker. This removes popup-trigger jumps when opening the calendar.

<sup>Written for commit 64391b596c0e83d37bd3be38cbde9db374ea8fc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/521?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

