### PR TITLE
Trait history, billing lifecycle events, and ingestion credential scrubbing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,7 @@ NOTRA_API_KEY=
 # Superlog OTLP logs export. When set, evlog drains in api/basket/insights/slack/uptime
 # also ship wide events to https://intake.superlog.sh/v1/logs.
 SUPERLOG_API_KEY=""
+
+# Website id used for dogfooding our own product analytics (billing lifecycle
+# events and plan traits written server-side). Leave empty to disable.
+SELF_ANALYTICS_WEBSITE_ID=""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,19 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      clickhouse:
+        image: clickhouse/clickhouse-server:25.5.1-alpine
+        env:
+          CLICKHOUSE_DB: databuddy_analytics
+          CLICKHOUSE_USER: default
+          CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT: 1
+        ports:
+          - 8123:8123
+        options: >-
+          --health-cmd "clickhouse-client --query 'SELECT 1'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -132,6 +145,10 @@ jobs:
       - run: bun install --frozen-lockfile --ignore-scripts
       - name: Push test schema
         run: cd packages/db && bunx drizzle-kit push
+      - name: Init ClickHouse schema
+        env:
+          CLICKHOUSE_URL: http://default:@localhost:8123
+        run: bun run --cwd packages/db clickhouse:init
       - name: Test
         env:
           NODE_ENV: test

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -23,6 +23,7 @@
     "@databuddy/redis": "workspace:*",
     "@databuddy/rpc": "workspace:*",
     "@databuddy/sdk": "workspace:*",
+    "@databuddy/services": "workspace:*",
     "@databuddy/shared": "workspace:*",
     "@databuddy/validation": "workspace:*",
     "@elysiajs/cors": "^1.4.1",

--- a/apps/api/src/routes/query.ts
+++ b/apps/api/src/routes/query.ts
@@ -7,8 +7,10 @@ import {
 	hasKeyScope,
 	isApiKeyPresent,
 } from "@databuddy/api-keys/resolve";
-import { db } from "@databuddy/db";
+import { and, db, eq, inArray } from "@databuddy/db";
+import { profiles } from "@databuddy/db/schema";
 import { config } from "@databuddy/env/app";
+import { revealPii } from "@databuddy/services/identity";
 import { validateTimezone } from "@databuddy/validation";
 import { readBooleanEnv } from "@databuddy/env/boolean";
 import { ratelimit } from "@databuddy/redis/rate-limit";
@@ -880,6 +882,53 @@ interface QueryResult {
 	success: boolean;
 }
 
+const PROFILE_ENRICHED_TYPES = new Set(["profile_list"]);
+
+async function attachProfileIdentities(
+	websiteId: string,
+	results: QueryResult[]
+) {
+	const profileIds = new Set<string>();
+	for (const result of results) {
+		for (const row of result.data) {
+			if (typeof row.profile_id === "string" && row.profile_id) {
+				profileIds.add(row.profile_id);
+			}
+		}
+	}
+	if (profileIds.size === 0) {
+		return;
+	}
+
+	const identities = await db
+		.select({
+			profileId: profiles.profileId,
+			displayName: profiles.displayName,
+			email: profiles.email,
+		})
+		.from(profiles)
+		.where(
+			and(
+				eq(profiles.websiteId, websiteId),
+				inArray(profiles.profileId, [...profileIds])
+			)
+		);
+	const identityByProfileId = new Map(
+		identities.map((identity) => [identity.profileId, identity])
+	);
+
+	for (const result of results) {
+		for (const row of result.data) {
+			const identity =
+				typeof row.profile_id === "string"
+					? identityByProfileId.get(row.profile_id)
+					: undefined;
+			row.display_name = identity ? revealPii(identity.displayName) : null;
+			row.email = identity ? revealPii(identity.email) : null;
+		}
+	}
+}
+
 async function executeDynamicQuery(
 	request: DynamicQueryRequestType,
 	projectId: string,
@@ -1024,6 +1073,22 @@ async function executeDynamicQuery(
 					data: result?.data || [],
 					error: result?.error ? QUERY_EXECUTION_ERROR_MESSAGE : undefined,
 				});
+			}
+		}
+
+		if (projectType === "website") {
+			const profileResults = validParameters
+				.filter((p) => PROFILE_ENRICHED_TYPES.has(p.request.type))
+				.flatMap((p) => resultMap.get(p.id) ?? []);
+			if (profileResults.length > 0) {
+				await attachProfileIdentities(projectId, profileResults).catch(
+					(error) => {
+						captureError(error, {
+							route: "v1/query",
+							step: "attach_profile_identities",
+						});
+					}
+				);
 			}
 		}
 	}

--- a/apps/api/src/routes/webhooks/autumn.test.ts
+++ b/apps/api/src/routes/webhooks/autumn.test.ts
@@ -92,6 +92,10 @@ vi.mock("@databuddy/redis", () => ({
 	invalidateBillingOwnerCaches: vi.fn(async () => ({ attempted: 0, failed: 0 })),
 }));
 
+vi.mock("@databuddy/services/billing-lifecycle", () => ({
+	recordPlanChange: vi.fn(async () => undefined),
+}));
+
 vi.mock("elysia", () => ({
 	Elysia: class {
 		post() {

--- a/apps/api/src/routes/webhooks/autumn.ts
+++ b/apps/api/src/routes/webhooks/autumn.ts
@@ -17,6 +17,7 @@ import {
 	invalidateAgentContextSnapshotsForOwner,
 	invalidateBillingOwnerCaches,
 } from "@databuddy/redis";
+import { recordPlanChange } from "@databuddy/services/billing-lifecycle";
 import { Elysia } from "elysia";
 import { useLogger } from "evlog/elysia";
 import { Resend } from "resend";
@@ -324,9 +325,24 @@ async function handleProductsUpdated(
 	});
 	await invalidatePlanCaches(customer.id);
 
-	const shouldSkipSlack =
-		!slack ||
-		(process.env.NODE_ENV === "production" && customer.env === "sandbox");
+	const isSandboxInProduction =
+		process.env.NODE_ENV === "production" && customer.env === "sandbox";
+
+	if (customer.id && !isSandboxInProduction) {
+		try {
+			await recordPlanChange({
+				customerId: customer.id,
+				planId: updated_product.id,
+				scenario,
+			});
+		} catch (error) {
+			log.error(error instanceof Error ? error : new Error(String(error)), {
+				autumn: { step: "record_plan_change", customerId: customer.id },
+			});
+		}
+	}
+
+	const shouldSkipSlack = !slack || isSandboxInProduction;
 
 	if (shouldSkipSlack) {
 		return { success: true, message: `Processed ${scenario}` };

--- a/apps/basket/src/lib/blocked-traffic.ts
+++ b/apps/basket/src/lib/blocked-traffic.ts
@@ -7,7 +7,11 @@ import { runFork, send } from "@lib/producer";
 import { captureError } from "@lib/tracing";
 import { extractIpFromRequest, getGeo } from "@utils/ip-geo";
 import { parseUserAgent } from "@utils/user-agent";
-import { sanitizeString, VALIDATION_LIMITS } from "@utils/validation";
+import {
+	sanitizeString,
+	sanitizeUrl,
+	VALIDATION_LIMITS,
+} from "@utils/validation";
 import { randomUUIDv7 } from "bun";
 
 async function _logBlockedTrafficAsync(
@@ -41,12 +45,12 @@ async function _logBlockedTrafficAsync(
 			client_id: clientId || "",
 			timestamp: now,
 
-			path: sanitizeString(body?.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
-			url: sanitizeString(
+			path: sanitizeUrl(body?.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
+			url: sanitizeUrl(
 				body?.url || body?.href,
 				VALIDATION_LIMITS.STRING_MAX_LENGTH
 			),
-			referrer: sanitizeString(
+			referrer: sanitizeUrl(
 				body?.referrer || request.headers.get("referer"),
 				VALIDATION_LIMITS.STRING_MAX_LENGTH
 			),

--- a/apps/basket/src/lib/event-service.ts
+++ b/apps/basket/src/lib/event-service.ts
@@ -17,6 +17,7 @@ import { extractTrustedClientIp, getGeo } from "@utils/ip-geo";
 import { parseUserAgent } from "@utils/user-agent";
 import {
 	sanitizeString,
+	sanitizeUrl,
 	VALIDATION_LIMITS,
 	validatePerformanceMetric,
 	validateSessionId,
@@ -77,12 +78,12 @@ export function buildTrackEvent(
 		event_id: ctx.eventId,
 		session_start_time: sessionStartTime,
 		timestamp,
-		referrer: sanitizeString(
+		referrer: sanitizeUrl(
 			trackData.referrer,
 			VALIDATION_LIMITS.STRING_MAX_LENGTH
 		),
-		url: sanitizeString(trackData.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
-		path: sanitizeString(trackData.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
+		url: sanitizeUrl(trackData.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
+		path: sanitizeUrl(trackData.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
 		title: sanitizeString(trackData.title, VALIDATION_LIMITS.STRING_MAX_LENGTH),
 		ip: ctx.geo.anonymizedIP || "",
 		user_agent: "",
@@ -242,7 +243,7 @@ export function insertOutgoingLink(
 				salt
 			),
 			session_id: validateSessionId(linkData.sessionId),
-			href: sanitizeString(linkData.href, VALIDATION_LIMITS.PATH_MAX_LENGTH),
+			href: sanitizeUrl(linkData.href, VALIDATION_LIMITS.PATH_MAX_LENGTH),
 			text: sanitizeString(linkData.text, VALIDATION_LIMITS.TEXT_MAX_LENGTH),
 			properties: linkData.properties
 				? JSON.stringify(linkData.properties)
@@ -293,7 +294,7 @@ export function insertErrorSpans(
 			),
 			session_id: validateSessionId(error.sessionId),
 			timestamp: typeof error.timestamp === "number" ? error.timestamp : now,
-			path: sanitizeString(error.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
+			path: sanitizeUrl(error.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
 			message: sanitizeString(
 				error.message,
 				VALIDATION_LIMITS.STRING_MAX_LENGTH
@@ -342,7 +343,7 @@ export function insertIndividualVitals(
 			),
 			session_id: validateSessionId(vital.sessionId),
 			timestamp: typeof vital.timestamp === "number" ? vital.timestamp : now,
-			path: sanitizeString(vital.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
+			path: sanitizeUrl(vital.path, VALIDATION_LIMITS.STRING_MAX_LENGTH),
 			metric_name: vital.metricName,
 			metric_value: vital.metricValue,
 		}));
@@ -407,7 +408,7 @@ export function insertCustomEvents(
 					)
 				: undefined,
 			path: event.path
-				? sanitizeString(event.path, VALIDATION_LIMITS.STRING_MAX_LENGTH)
+				? sanitizeUrl(event.path, VALIDATION_LIMITS.STRING_MAX_LENGTH)
 				: undefined,
 			properties: event.properties ? JSON.stringify(event.properties) : "{}",
 			anonymous_id: event.anonymous_id

--- a/apps/basket/src/routes/identify.test.ts
+++ b/apps/basket/src/routes/identify.test.ts
@@ -4,7 +4,10 @@ vi.mock("@databuddy/db", () => ({
 	db: {},
 	profiles: {},
 	profileAliases: {},
+	profileTraitChanges: {},
 	sql: () => {},
+	and: vi.fn(),
+	eq: vi.fn(),
 }));
 vi.mock("@databuddy/redis/rate-limit", () => ({ ratelimit: vi.fn() }));
 vi.mock("@lib/request-validation", () => ({
@@ -19,6 +22,7 @@ vi.mock("@lib/api-key", () => ({
 vi.mock("evlog/elysia", () => ({ useLogger: () => ({ set: vi.fn() }) }));
 
 import {
+	applyTraits,
 	emailLookupHash,
 	protectPii,
 	revealPii,
@@ -92,6 +96,52 @@ describe("splitTraits", () => {
 		expect(result.removeKeys).toEqual([]);
 		expect(result.displayName).toBeUndefined();
 		expect(result.email).toBeUndefined();
+	});
+});
+
+describe("applyTraits", () => {
+	test("first identify reports every trait as a change from null", () => {
+		const { changes, traits } = applyTraits({}, { plan: "free", seats: 1 }, []);
+		expect(traits).toEqual({ plan: "free", seats: 1 });
+		expect(changes).toEqual([
+			{ traitKey: "plan", oldValue: null, newValue: "free" },
+			{ traitKey: "seats", oldValue: null, newValue: 1 },
+		]);
+	});
+
+	test("changed value carries old and new, unchanged values are silent", () => {
+		const { changes, traits } = applyTraits(
+			{ plan: "free", seats: 1 },
+			{ plan: "pro", seats: 1 },
+			[]
+		);
+		expect(traits).toEqual({ plan: "pro", seats: 1 });
+		expect(changes).toEqual([
+			{ traitKey: "plan", oldValue: "free", newValue: "pro" },
+		]);
+	});
+
+	test("removed keys drop from the snapshot and report null", () => {
+		const { changes, traits } = applyTraits(
+			{ plan: "pro", beta: true },
+			{},
+			["beta"]
+		);
+		expect(traits).toEqual({ plan: "pro" });
+		expect(changes).toEqual([
+			{ traitKey: "beta", oldValue: true, newValue: null },
+		]);
+	});
+
+	test("removing an absent key changes nothing", () => {
+		const { changes, traits } = applyTraits({ plan: "pro" }, {}, ["missing"]);
+		expect(traits).toEqual({ plan: "pro" });
+		expect(changes).toEqual([]);
+	});
+
+	test("type changes between same-looking values are detected", () => {
+		const { changes } = applyTraits({ seats: "1" }, { seats: 1 }, []);
+		expect(changes).toEqual([{ traitKey: "seats", oldValue: "1", newValue: 1 }]);
 	});
 });
 

--- a/apps/basket/src/routes/identify.ts
+++ b/apps/basket/src/routes/identify.ts
@@ -147,7 +147,7 @@ export const identifyRoute = new Elysia().post(
 				hasAlias: Boolean(anonymousId),
 			});
 
-			await Promise.all([
+			const [update] = await Promise.all([
 				record("upsertProfile", () =>
 					upsertProfile(websiteId, profileId, splitTraits(traits))
 				),
@@ -157,6 +157,10 @@ export const identifyRoute = new Elysia().post(
 						)
 					: Promise.resolve(),
 			]);
+
+			if (update && update.changes.length > 0) {
+				log.set({ traitChanges: update.changes.length });
+			}
 
 			return Response.json({ status: "success", type: "identify" });
 		} catch (error) {

--- a/apps/basket/src/utils/validation.test.ts
+++ b/apps/basket/src/utils/validation.test.ts
@@ -6,7 +6,9 @@ import {
 	XSS_PAYLOADS,
 } from "../test-helpers";
 import {
+	redactSensitiveQueryParams,
 	sanitizeString,
+	sanitizeUrl,
 	VALIDATION_LIMITS,
 	validateNumeric,
 	validatePayloadSize,
@@ -75,6 +77,72 @@ describe("sanitizeString", () => {
 			}
 		}
 	});
+});
+
+// ── redactSensitiveQueryParams ──
+
+describe("redactSensitiveQueryParams", () => {
+	const table: [string, string, string][] = [
+		[
+			"password redacted",
+			"https://a.com/login?email=x%40y.com&password=hunter2",
+			"https://a.com/login?email=REDACTED&password=REDACTED",
+		],
+		[
+			"case-insensitive param names",
+			"/login?Email=x%40y.com&PASSWORD=abc",
+			"/login?Email=REDACTED&PASSWORD=REDACTED",
+		],
+		[
+			"safe params untouched",
+			"/pricing?utm_source=x&plan=pro",
+			"/pricing?utm_source=x&plan=pro",
+		],
+		["no query string untouched", "/login", "/login"],
+		[
+			"token and api_key redacted",
+			"/cb?token=abc&api_key=k123&page=2",
+			"/cb?token=REDACTED&api_key=REDACTED&page=2",
+		],
+		[
+			"oauth fragment redacted",
+			"/cb#access_token=abc&state=xyz",
+			"/cb#access_token=REDACTED&state=xyz",
+		],
+		["plain fragment untouched", "/docs?page=1#install", "/docs?page=1#install"],
+		[
+			"relative path with otp",
+			"/verify?otp=123456",
+			"/verify?otp=REDACTED",
+		],
+		["empty string", "", ""],
+	];
+
+	for (const [label, input, expected] of table) {
+		test(label, () =>
+			expect(redactSensitiveQueryParams(input)).toBe(expected));
+	}
+});
+
+// ── sanitizeUrl ──
+
+describe("sanitizeUrl", () => {
+	test("non-string → ''", () => expect(sanitizeUrl(123)).toBe(""));
+
+	test("redacts before sanitizing", () => {
+		const result = sanitizeUrl(
+			"https://a.com/login?email=x%40y.com&password=hunter2"
+		);
+		expect(result).not.toContain("hunter2");
+		expect(result).not.toContain("x@y.com");
+		expect(result).toContain("REDACTED");
+	});
+
+	test("applies sanitizeString rules", () =>
+		expect(sanitizeUrl("/a<script>b</script>?q=1")).toBe("/ab?q=1"));
+
+	test("respects maxLength", () =>
+		expect(sanitizeUrl("/abcdefghij", 5)).toBe("/abcd"));
 });
 
 // ── validateSessionId ──

--- a/apps/basket/src/utils/validation.ts
+++ b/apps/basket/src/utils/validation.ts
@@ -61,6 +61,79 @@ export function sanitizeString(input: unknown, maxLength?: number): string {
 	return result.replace(/[<>'"&]/g, "").replace(/\s+/g, " ");
 }
 
+const SENSITIVE_QUERY_PARAMS = new Set([
+	"password",
+	"passwd",
+	"pwd",
+	"pass",
+	"new_password",
+	"old_password",
+	"confirm_password",
+	"password_confirmation",
+	"secret",
+	"client_secret",
+	"token",
+	"access_token",
+	"refresh_token",
+	"id_token",
+	"auth_token",
+	"session_token",
+	"auth",
+	"authorization",
+	"api_key",
+	"apikey",
+	"api-key",
+	"otp",
+	"pin",
+	"mfa_code",
+	"verification_code",
+	"credit_card",
+	"card_number",
+	"cvv",
+	"ssn",
+	"email",
+	"e-mail",
+	"phone",
+	"tel",
+	"username",
+]);
+
+const REDACTED_VALUE = "REDACTED";
+
+function redactParams(query: string): string {
+	const params = new URLSearchParams(query);
+	let changed = false;
+	for (const key of [...params.keys()]) {
+		if (SENSITIVE_QUERY_PARAMS.has(key.toLowerCase())) {
+			params.set(key, REDACTED_VALUE);
+			changed = true;
+		}
+	}
+	return changed ? params.toString() : query;
+}
+
+export function redactSensitiveQueryParams(input: string): string {
+	const hashIndex = input.indexOf("#");
+	const beforeHash = hashIndex === -1 ? input : input.slice(0, hashIndex);
+	const queryIndex = beforeHash.indexOf("?");
+
+	let result =
+		queryIndex === -1
+			? beforeHash
+			: `${beforeHash.slice(0, queryIndex)}?${redactParams(beforeHash.slice(queryIndex + 1))}`;
+	if (hashIndex !== -1) {
+		result += `#${redactParams(input.slice(hashIndex + 1))}`;
+	}
+	return result;
+}
+
+export function sanitizeUrl(input: unknown, maxLength?: number): string {
+	if (typeof input !== "string") {
+		return "";
+	}
+	return sanitizeString(redactSensitiveQueryParams(input), maxLength);
+}
+
 const sessionIdRegex = /^[a-zA-Z0-9_-]+$/;
 
 export function validateSessionId(sessionId: unknown): string {

--- a/apps/dashboard/app/(main)/layout.tsx
+++ b/apps/dashboard/app/(main)/layout.tsx
@@ -9,6 +9,7 @@ import {
 import { SidebarNavigationProvider } from "@/components/layout/sidebar-navigation-provider";
 import { TopBar, TopBarProvider } from "@/components/layout/top-bar";
 import { BillingProvider } from "@/components/providers/billing-provider";
+import { IdentifyBillingTraits } from "@/components/providers/identify-billing-traits";
 import { SessionGuard } from "@/components/providers/session-guard";
 import { CommandSearchProvider } from "@/components/ui/command-search";
 import { Skeleton } from "@databuddy/ui";
@@ -45,6 +46,7 @@ export default function MainLayout({
 			<CommandSearchProvider>
 				<SidebarNavigationProvider>
 					<SessionGuard>
+						<IdentifyBillingTraits />
 						<SidebarLayout>
 							<TopBarProvider>
 								<div className="flex min-h-0 flex-1 flex-col overflow-hidden text-foreground">

--- a/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
@@ -12,7 +12,6 @@ import {
 	TableRow,
 } from "@/components/ui/table";
 import { useDateFilters } from "@/hooks/use-date-filters";
-import { useProfileIdentities } from "@/hooks/use-profiles";
 import { getDeviceIcon } from "@/components/device-icon";
 import { dynamicQueryFiltersAtom } from "@/stores/jotai/filterAtoms";
 import type { DynamicQueryFilter } from "@/stores/jotai/filterAtoms";
@@ -37,7 +36,7 @@ import {
 import { useAtomValue } from "jotai";
 import Image from "next/image";
 import { notFound, useParams, useRouter } from "next/navigation";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { generateProfileName } from "./[userId]/_components/generate-profile-name";
 import { type ProfileSort, useProfilesData } from "./use-users";
 import { useEventNames } from "./use-event-names";
@@ -185,13 +184,11 @@ export default function UsersPage() {
 	const [eventFilter, setEventFilter] = useState<string | null>(null);
 	const [page, setPage] = useState(1);
 	const [allUsers, setAllUsers] = useState<ProfileData[]>([]);
-	const [isReplacing, setIsReplacing] = useState(false);
 	const [loadMoreRef, setLoadMoreRef] = useState<HTMLTableCellElement | null>(
 		null
 	);
 	const [scrollContainerRef, setScrollContainerRef] =
 		useState<HTMLDivElement | null>(null);
-	const [isInitialLoad, setIsInitialLoad] = useState(true);
 
 	const { eventNames } = useEventNames(websiteId, dateRange);
 
@@ -226,23 +223,13 @@ export default function UsersPage() {
 		profileSort
 	);
 
-	const identifiedIds = useMemo(
-		() => allUsers.map((user) => user.profile_id).filter(Boolean),
-		[allUsers]
-	);
-	const { identityMap } = useProfileIdentities(websiteId, identifiedIds);
-
-	const hasUsersRef = useRef(false);
-	hasUsersRef.current = allUsers.length > 0;
-
 	useEffect(() => {
 		setPage(1);
-		if (hasUsersRef.current) {
-			setIsReplacing(true);
-		} else {
-			setIsInitialLoad(true);
-		}
 	}, [dateRange, mergedFilters, sort]);
+
+	const isInitialLoad = isLoading && allUsers.length === 0;
+	const isReplacing =
+		isLoading && page === 1 && profiles.length === 0 && allUsers.length > 0;
 
 	const handleSort = useCallback((field: SortField) => {
 		setSort((prev) => {
@@ -293,21 +280,15 @@ export default function UsersPage() {
 	}, [loadMoreRef, scrollContainerRef, handleIntersection]);
 
 	useEffect(() => {
-		if (!profiles?.length) {
-			if (!isLoading && isReplacing) {
-				setAllUsers([]);
-				setIsReplacing(false);
+		if (page === 1) {
+			if (profiles.length > 0 || !isLoading) {
+				setAllUsers(profiles);
 			}
 			return;
 		}
-
-		if (isReplacing) {
-			setAllUsers(profiles);
-			setIsReplacing(false);
-			setIsInitialLoad(false);
+		if (isLoading) {
 			return;
 		}
-
 		setAllUsers((prev) => {
 			const existingUsers = new Map(prev.map((u) => [u.visitor_id, u]));
 			let hasNewUsers = false;
@@ -319,14 +300,9 @@ export default function UsersPage() {
 				}
 			}
 
-			if (hasNewUsers) {
-				return Array.from(existingUsers.values());
-			}
-
-			return prev;
+			return hasNewUsers ? Array.from(existingUsers.values()) : prev;
 		});
-		setIsInitialLoad(false);
-	}, [profiles, isLoading, isReplacing]);
+	}, [profiles, isLoading, page]);
 
 	const columns = useMemo<ColumnDef<ProfileData>[]>(
 		() => [
@@ -335,17 +311,13 @@ export default function UsersPage() {
 				header: "User",
 				accessorKey: "visitor_id",
 				cell: ({ row }) => {
-					const identity = row.original.profile_id
-						? identityMap.get(row.original.profile_id)
-						: undefined;
+					const { display_name, email, profile_id, visitor_id } = row.original;
 					const displayName =
-						identity?.displayName ||
-						identity?.email ||
-						(row.original.profile_id
-							? row.original.profile_id
-							: generateProfileName(row.original.visitor_id));
-					const secondary =
-						identity?.displayName && identity?.email ? identity.email : null;
+						display_name ||
+						email ||
+						profile_id ||
+						generateProfileName(visitor_id);
+					const secondary = display_name && email ? email : null;
 					return (
 						<div className="flex items-center gap-2.5">
 							<Image
@@ -532,7 +504,7 @@ export default function UsersPage() {
 				size: 100,
 			},
 		],
-		[sort, handleSort, identityMap]
+		[sort, handleSort]
 	);
 
 	const table = useReactTable({
@@ -607,7 +579,7 @@ export default function UsersPage() {
 		</div>
 	);
 
-	if (isLoading && isInitialLoad) {
+	if (isInitialLoad) {
 		return (
 			<div className="flex h-full flex-col">
 				<TopBar.Title>
@@ -662,7 +634,7 @@ export default function UsersPage() {
 		);
 	}
 
-	if (!(isReplacing || isInitialLoad) && (!allUsers || allUsers.length === 0)) {
+	if (!isLoading && allUsers.length === 0) {
 		return (
 			<div className="flex h-full flex-col">
 				<TopBar.Title>

--- a/apps/dashboard/components/providers/identify-billing-traits.tsx
+++ b/apps/dashboard/components/providers/identify-billing-traits.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { authClient } from "@databuddy/auth/client";
+import { identify, setGlobalProperties } from "@databuddy/sdk";
+import { useEffect } from "react";
+import { isDashboardE2E } from "@/lib/e2e-mode";
+import { useBillingContext } from "./billing-provider";
+
+export function IdentifyBillingTraits() {
+	const { data: session } = authClient.useSession();
+	const {
+		currentPlanId,
+		hasActiveSubscription,
+		isOrganizationBilling,
+		isLoading,
+	} = useBillingContext();
+	const userId = session?.user?.id;
+
+	useEffect(() => {
+		if (isDashboardE2E || isLoading || !(userId && currentPlanId)) {
+			return;
+		}
+		identify(userId, {
+			plan: currentPlanId,
+			has_active_subscription: hasActiveSubscription,
+			billing_scope: isOrganizationBilling ? "organization" : "personal",
+		});
+		setGlobalProperties({ plan: currentPlanId });
+	}, [
+		userId,
+		currentPlanId,
+		hasActiveSubscription,
+		isOrganizationBilling,
+		isLoading,
+	]);
+
+	return null;
+}

--- a/apps/dashboard/hooks/use-profiles.ts
+++ b/apps/dashboard/hooks/use-profiles.ts
@@ -1,50 +1,5 @@
-import { useQueries, useQuery } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { orpc } from "@/lib/orpc";
-
-export interface ProfileIdentity {
-	displayName: string | null;
-	email: string | null;
-	firstSeenAt: Date;
-	profileId: string;
-	traits: Record<string, unknown>;
-	updatedAt: Date;
-}
-
-const BATCH_SIZE = 100;
-
-export function useProfileIdentities(websiteId: string, profileIds: string[]) {
-	const batches = useMemo(() => {
-		const uniqueIds = [...new Set(profileIds.filter(Boolean))];
-		const chunks: string[][] = [];
-		for (let i = 0; i < uniqueIds.length; i += BATCH_SIZE) {
-			chunks.push(uniqueIds.slice(i, i + BATCH_SIZE));
-		}
-		return chunks;
-	}, [profileIds]);
-
-	return useQueries({
-		queries: batches.map((batch) => ({
-			...orpc.profiles.getByIds.queryOptions({
-				input: { websiteId, profileIds: batch },
-			}),
-			enabled: Boolean(websiteId) && batch.length > 0,
-			staleTime: 5 * 60 * 1000,
-		})),
-		combine: (results) => {
-			const identityMap = new Map<string, ProfileIdentity>();
-			for (const result of results) {
-				for (const profile of result.data ?? []) {
-					identityMap.set(profile.profileId, profile);
-				}
-			}
-			return {
-				identityMap,
-				isLoading: results.some((result) => result.isLoading),
-			};
-		},
-	});
-}
 
 export function useProfileIdentity(websiteId: string, profileId: string) {
 	return useQuery({

--- a/apps/dashboard/types/analytics.ts
+++ b/apps/dashboard/types/analytics.ts
@@ -10,6 +10,8 @@ export interface ProfileData {
 	country: string;
 	custom_event_count: number;
 	device_type: string;
+	display_name: string | null;
+	email: string | null;
 	first_visit: string;
 	last_visit: string;
 	os_name: string;

--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "@databuddy/redis": "workspace:*",
         "@databuddy/rpc": "workspace:*",
         "@databuddy/sdk": "workspace:*",
+        "@databuddy/services": "workspace:*",
         "@databuddy/shared": "workspace:*",
         "@databuddy/validation": "workspace:*",
         "@elysiajs/cors": "^1.4.1",

--- a/bun.lock
+++ b/bun.lock
@@ -718,6 +718,7 @@
         "@databuddy/db": "workspace:*",
         "@databuddy/encryption": "workspace:*",
         "@databuddy/redis": "workspace:*",
+        "@databuddy/shared": "workspace:*",
       },
       "devDependencies": {
         "typescript": "^5.9.3",

--- a/packages/ai/src/ai/tools/profiles.ts
+++ b/packages/ai/src/ai/tools/profiles.ts
@@ -1,3 +1,4 @@
+import { and, db, desc, eq, profileTraitChanges } from "@databuddy/db";
 import { tool, type ToolSet } from "ai";
 import { z } from "zod";
 import { getWebsiteDomain } from "../../lib/website-utils";
@@ -123,6 +124,40 @@ export function buildProfileTools(opts: ProfileToolsOptions): ToolSet {
 					visitorId,
 				});
 				return { profile: data.at(0), period: `Last ${days} days` };
+			},
+		}),
+
+		get_profile_history: tool({
+			description: `Trait change timeline for an identified profile (profile_id). Each entry shows which traits changed (old and new values) plus the full trait snapshot after the change — answers "when did the plan change" and "what were the traits at time T" directly.${suffix}`,
+			inputSchema: z.object({
+				websiteId: opts.websiteIdSchema,
+				profileId: z.string(),
+				limit: z.number().min(1).max(200).default(50),
+			}),
+			execute: async ({ websiteId, profileId, limit }, options) => {
+				const site = await opts.resolveSite(websiteId, options);
+				const history = await db
+					.select({
+						changes: profileTraitChanges.changes,
+						traits: profileTraitChanges.traits,
+						source: profileTraitChanges.source,
+						changedAt: profileTraitChanges.createdAt,
+					})
+					.from(profileTraitChanges)
+					.where(
+						and(
+							eq(profileTraitChanges.websiteId, site.websiteId),
+							eq(profileTraitChanges.profileId, profileId)
+						)
+					)
+					.orderBy(desc(profileTraitChanges.createdAt))
+					.limit(limit);
+				logger.info("Fetched profile trait history", {
+					websiteId: site.websiteId,
+					profileId,
+					changeCount: history.length,
+				});
+				return { history, count: history.length };
 			},
 		}),
 

--- a/packages/ai/src/query/builder-execution.test.ts
+++ b/packages/ai/src/query/builder-execution.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { QueryBuilders } from "./builders";
+import { SimpleQueryBuilder } from "./simple-builder";
+import type { Filter, QueryRequest, SimpleQueryConfig } from "./types";
+
+const TEST_CLICKHOUSE_URL = "http://default:@localhost:8123";
+
+const isClickHouseUp = await fetch(`${TEST_CLICKHOUSE_URL}/?query=SELECT+1`, {
+	signal: AbortSignal.timeout(1500),
+})
+	.then((response) => response.ok)
+	.catch(() => false);
+
+// The db client reads CLICKHOUSE_URL at import time; hard-assign localhost so
+// this suite can never touch a real deployment from a developer's .env.
+process.env.CLICKHOUSE_URL = TEST_CLICKHOUSE_URL;
+const { clickHouse } = await import("@databuddy/db/clickhouse");
+
+const iit = isClickHouseUp ? it : it.skip;
+
+if (!isClickHouseUp) {
+	console.warn(
+		"builder-execution: ClickHouse not reachable on localhost:8123 — EXPLAIN suite skipped"
+	);
+}
+
+afterAll(async () => {
+	if (isClickHouseUp) {
+		await clickHouse.close();
+	}
+});
+
+function requestFor(name: string, config: SimpleQueryConfig): QueryRequest {
+	const filters: Filter[] = (config.requiredFilters ?? []).map((field) => ({
+		field,
+		op: "eq",
+		value: `test-${field}`,
+	}));
+
+	return {
+		projectId: "builder-explain-test",
+		type: name,
+		from: "2026-01-01",
+		to: "2026-01-02",
+		filters,
+		limit: 5,
+		offset: 0,
+	};
+}
+
+describe("query builders execute against ClickHouse", () => {
+	for (const [name, config] of Object.entries(QueryBuilders)) {
+		iit(`${name} compiles to valid ClickHouse SQL`, async () => {
+			const { sql, params } = new SimpleQueryBuilder(
+				config,
+				requestFor(name, config)
+			).compile();
+
+			const result = await clickHouse.query({
+				query: `EXPLAIN ${sql}`,
+				query_params: params,
+				format: "TSVRaw",
+			});
+			await result.text();
+
+			expect(sql.length).toBeGreaterThan(0);
+		});
+	}
+});

--- a/packages/ai/src/query/builders/sessions.ts
+++ b/packages/ai/src/query/builders/sessions.ts
@@ -263,21 +263,21 @@ export const SessionsBuilders: Record<string, SimpleQueryConfig> = {
 				),
 				top_sessions AS (
 					SELECT
-						bs.session_id,
-						bs.visitor_id,
-						bs.first_visit,
-						bs.last_visit,
-						bs.duration_seconds,
-						bs.page_views,
-						bs.unique_pages,
-						bs.analytics_engagement_events,
+						bs.session_id AS session_id,
+						bs.visitor_id AS visitor_id,
+						bs.first_visit AS first_visit,
+						bs.last_visit AS last_visit,
+						bs.duration_seconds AS duration_seconds,
+						bs.page_views AS page_views,
+						bs.unique_pages AS unique_pages,
+						bs.analytics_engagement_events AS analytics_engagement_events,
 						ifNull(cc.custom_events, 0) as custom_events,
 						ifNull(es.errors, 0) as errors,
-						bs.country,
-						bs.referrer,
-						bs.device_type,
-						bs.browser_name,
-						bs.os_name,
+						bs.country AS country,
+						bs.referrer AS referrer,
+						bs.device_type AS device_type,
+						bs.browser_name AS browser_name,
+						bs.os_name AS os_name,
 						(
 							least(bs.page_views, 10) * 2
 							+ least(bs.unique_pages, 8) * 3
@@ -301,7 +301,7 @@ export const SessionsBuilders: Record<string, SimpleQueryConfig> = {
 						client_id = {websiteId:String}
 						AND time >= toDateTime({startDate:String})
 						AND time <= toDateTime({endDate:String})
-						AND session_id IN (SELECT session_id FROM top_sessions)
+						AND session_id != ''
 					GROUP BY session_id
 				),
 				names_for_top AS (
@@ -313,7 +313,7 @@ export const SessionsBuilders: Record<string, SimpleQueryConfig> = {
 						website_id = {websiteId:String}
 						AND timestamp >= toDateTime({startDate:String})
 						AND timestamp <= toDateTime({endDate:String})
-						AND session_id IN (SELECT session_id FROM top_sessions)
+						AND session_id != ''
 					GROUP BY session_id
 				)
 				SELECT

--- a/packages/db/src/drizzle/schema/identity.ts
+++ b/packages/db/src/drizzle/schema/identity.ts
@@ -40,6 +40,44 @@ export const profiles = pgTable(
 	]
 );
 
+export const profileTraitChanges = pgTable(
+	"profile_trait_changes",
+	{
+		id: text().primaryKey(),
+		websiteId: text("website_id")
+			.notNull()
+			.references(() => websites.id, { onDelete: "cascade" }),
+		profileId: text("profile_id").notNull(),
+		// Full merged non-PII traits after this change — state at time T is the
+		// latest row with createdAt <= T, no diff folding needed.
+		traits: jsonb().$type<Record<string, unknown>>().default({}).notNull(),
+		changes: jsonb()
+			.$type<
+				Record<
+					string,
+					{
+						old: string | number | boolean | null;
+						new: string | number | boolean | null;
+					}
+				>
+			>()
+			.default({})
+			.notNull(),
+		source: text().default("identify").notNull(),
+		createdAt: timestamp({ precision: 3, withTimezone: true })
+			.defaultNow()
+			.notNull(),
+	},
+	(table) => [
+		index("profile_trait_changes_profile_idx").on(
+			table.websiteId,
+			table.profileId,
+			table.createdAt
+		),
+		index("profile_trait_changes_changes_gin_idx").using("gin", table.changes),
+	]
+);
+
 export const profileAliases = pgTable(
 	"profile_aliases",
 	{

--- a/packages/sdk/src/core/tracker.ts
+++ b/packages/sdk/src/core/tracker.ts
@@ -60,6 +60,13 @@ export function setTraits(traits: ProfileTraits): void {
 	callTracker("setTraits", (tracker) => tracker.setTraits(traits));
 }
 
+/** Set properties attached to ALL future events (plan, role, A/B variant, etc.). */
+export function setGlobalProperties(properties: Record<string, unknown>): void {
+	callTracker("setGlobalProperties", (tracker) =>
+		tracker.setGlobalProperties(properties)
+	);
+}
+
 /** Forget the identified user (call on logout). Anonymous ID is kept. */
 export function clearProfile(): void {
 	callTracker("clearProfile", (tracker) => tracker.clearProfile());

--- a/packages/sdk/src/react/index.ts
+++ b/packages/sdk/src/react/index.ts
@@ -12,6 +12,7 @@ export {
 	getTrackingParams,
 	identify,
 	isTrackerAvailable,
+	setGlobalProperties,
 	setTraits,
 	track,
 	trackError,

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "type": "module",
   "exports": {
+    "./billing-lifecycle": "./src/billing-lifecycle.ts",
     "./identity": "./src/identity.ts",
     "./websites": "./src/websites.ts"
   },
@@ -13,7 +14,8 @@
   "dependencies": {
     "@databuddy/db": "workspace:*",
     "@databuddy/encryption": "workspace:*",
-    "@databuddy/redis": "workspace:*"
+    "@databuddy/redis": "workspace:*",
+    "@databuddy/shared": "workspace:*"
   },
   "devDependencies": {
     "typescript": "^5.9.3"

--- a/packages/services/src/billing-lifecycle.ts
+++ b/packages/services/src/billing-lifecycle.ts
@@ -1,9 +1,9 @@
-import { db, eq, websites as websitesTable } from "@databuddy/db";
+import { db, eq, websites } from "@databuddy/db";
 import { clickHouse, TABLE_NAMES } from "@databuddy/db/clickhouse";
 import { PLAN_IDS } from "@databuddy/shared/types/features";
 import { splitTraits, upsertProfile } from "./identity";
 
-const SCENARIO_EVENTS: Record<string, string> = {
+const SCENARIO_EVENTS = {
 	new: "subscription_started",
 	upgrade: "plan_upgraded",
 	downgrade: "plan_downgraded",
@@ -12,20 +12,21 @@ const SCENARIO_EVENTS: Record<string, string> = {
 	expired: "subscription_expired",
 	past_due: "payment_past_due",
 	scheduled: "plan_change_scheduled",
-};
+} as const;
 
-const PLAN_SETTING_SCENARIOS = new Set([
+export type BillingScenario = keyof typeof SCENARIO_EVENTS;
+
+const PLAN_SETTING_SCENARIOS = new Set<BillingScenario>([
 	"new",
 	"upgrade",
 	"downgrade",
 	"renew",
 ]);
 
-function selfWebsiteId(): string {
-	return process.env.SELF_ANALYTICS_WEBSITE_ID || "";
-}
-
-function planAfterScenario(scenario: string, planId: string): string | null {
+function planAfterScenario(
+	scenario: BillingScenario,
+	planId: string
+): string | null {
 	if (PLAN_SETTING_SCENARIOS.has(scenario)) {
 		return planId;
 	}
@@ -42,9 +43,9 @@ async function insertLifecycleEvent(
 	properties: Record<string, string>
 ): Promise<void> {
 	const [website] = await db
-		.select({ organizationId: websitesTable.organizationId })
-		.from(websitesTable)
-		.where(eq(websitesTable.id, websiteId))
+		.select({ organizationId: websites.organizationId })
+		.from(websites)
+		.where(eq(websites.id, websiteId))
 		.limit(1);
 	if (!website) {
 		return;
@@ -69,15 +70,14 @@ async function insertLifecycleEvent(
 export async function recordPlanChange(opts: {
 	customerId: string;
 	planId: string;
-	scenario: string;
+	scenario: BillingScenario;
 }): Promise<void> {
-	const websiteId = selfWebsiteId();
+	const websiteId = process.env.SELF_ANALYTICS_WEBSITE_ID;
 	if (!websiteId) {
 		return;
 	}
 
 	const plan = planAfterScenario(opts.scenario, opts.planId);
-	const eventName = SCENARIO_EVENTS[opts.scenario];
 
 	await Promise.all([
 		plan
@@ -88,11 +88,14 @@ export async function recordPlanChange(opts: {
 					"billing"
 				)
 			: Promise.resolve(null),
-		eventName
-			? insertLifecycleEvent(websiteId, opts.customerId, eventName, {
-					plan: opts.planId,
-					scenario: opts.scenario,
-				})
-			: Promise.resolve(),
+		insertLifecycleEvent(
+			websiteId,
+			opts.customerId,
+			SCENARIO_EVENTS[opts.scenario],
+			{
+				plan: opts.planId,
+				scenario: opts.scenario,
+			}
+		),
 	]);
 }

--- a/packages/services/src/billing-lifecycle.ts
+++ b/packages/services/src/billing-lifecycle.ts
@@ -1,0 +1,98 @@
+import { db, eq, websites as websitesTable } from "@databuddy/db";
+import { clickHouse, TABLE_NAMES } from "@databuddy/db/clickhouse";
+import { PLAN_IDS } from "@databuddy/shared/types/features";
+import { splitTraits, upsertProfile } from "./identity";
+
+const SCENARIO_EVENTS: Record<string, string> = {
+	new: "subscription_started",
+	upgrade: "plan_upgraded",
+	downgrade: "plan_downgraded",
+	renew: "subscription_renewed",
+	cancel: "subscription_canceled",
+	expired: "subscription_expired",
+	past_due: "payment_past_due",
+	scheduled: "plan_change_scheduled",
+};
+
+const PLAN_SETTING_SCENARIOS = new Set([
+	"new",
+	"upgrade",
+	"downgrade",
+	"renew",
+]);
+
+function selfWebsiteId(): string {
+	return process.env.SELF_ANALYTICS_WEBSITE_ID || "";
+}
+
+function planAfterScenario(scenario: string, planId: string): string | null {
+	if (PLAN_SETTING_SCENARIOS.has(scenario)) {
+		return planId;
+	}
+	if (scenario === "expired") {
+		return PLAN_IDS.FREE;
+	}
+	return null;
+}
+
+async function insertLifecycleEvent(
+	websiteId: string,
+	customerId: string,
+	eventName: string,
+	properties: Record<string, string>
+): Promise<void> {
+	const [website] = await db
+		.select({ organizationId: websitesTable.organizationId })
+		.from(websitesTable)
+		.where(eq(websitesTable.id, websiteId))
+		.limit(1);
+	if (!website) {
+		return;
+	}
+	await clickHouse.insert({
+		table: TABLE_NAMES.custom_events,
+		values: [
+			{
+				owner_id: website.organizationId,
+				website_id: websiteId,
+				timestamp: Date.now(),
+				event_name: eventName,
+				properties: JSON.stringify(properties),
+				profile_id: customerId,
+				source: "billing",
+			},
+		],
+		format: "JSONEachRow",
+	});
+}
+
+export async function recordPlanChange(opts: {
+	customerId: string;
+	planId: string;
+	scenario: string;
+}): Promise<void> {
+	const websiteId = selfWebsiteId();
+	if (!websiteId) {
+		return;
+	}
+
+	const plan = planAfterScenario(opts.scenario, opts.planId);
+	const eventName = SCENARIO_EVENTS[opts.scenario];
+
+	await Promise.all([
+		plan
+			? upsertProfile(
+					websiteId,
+					opts.customerId,
+					splitTraits({ plan }),
+					"billing"
+				)
+			: Promise.resolve(null),
+		eventName
+			? insertLifecycleEvent(websiteId, opts.customerId, eventName, {
+					plan: opts.planId,
+					scenario: opts.scenario,
+				})
+			: Promise.resolve(),
+	]);
+}

--- a/packages/services/src/identity.ts
+++ b/packages/services/src/identity.ts
@@ -1,5 +1,13 @@
 import { createHash, createHmac } from "node:crypto";
-import { db, profileAliases, profiles, sql } from "@databuddy/db";
+import {
+	and,
+	db,
+	eq,
+	profileAliases,
+	profiles,
+	profileTraitChanges,
+	sql,
+} from "@databuddy/db";
 import { decrypt, encrypt } from "@databuddy/encryption";
 
 const ENCRYPTED_PREFIX = "v1:";
@@ -83,11 +91,64 @@ export function splitTraits(
 	};
 }
 
+export interface TraitChange {
+	newValue: TraitValue;
+	oldValue: TraitValue;
+	traitKey: string;
+}
+
+export interface ProfileTraitUpdate {
+	changes: TraitChange[];
+	traits: Record<string, unknown>;
+}
+
+function asTraitValue(value: unknown): TraitValue {
+	return typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+		? value
+		: null;
+}
+
+export function applyTraits(
+	existing: Record<string, unknown>,
+	rest: Record<string, unknown>,
+	removeKeys: string[]
+): ProfileTraitUpdate {
+	const changes: TraitChange[] = [];
+	const traits = { ...existing };
+
+	for (const [key, value] of Object.entries(rest)) {
+		if (asTraitValue(existing[key]) !== asTraitValue(value)) {
+			changes.push({
+				traitKey: key,
+				oldValue: asTraitValue(existing[key]),
+				newValue: asTraitValue(value),
+			});
+		}
+		traits[key] = value;
+	}
+
+	for (const key of removeKeys) {
+		if (key in existing) {
+			changes.push({
+				traitKey: key,
+				oldValue: asTraitValue(existing[key]),
+				newValue: null,
+			});
+		}
+		delete traits[key];
+	}
+
+	return { changes, traits };
+}
+
 export async function upsertProfile(
 	websiteId: string,
 	profileId: string,
-	split: SplitTraits
-): Promise<void> {
+	split: SplitTraits,
+	source = "identify"
+): Promise<ProfileTraitUpdate | null> {
 	const { displayName, email, rest, removeKeys } = split;
 	const hasTraitUpdates =
 		displayName !== undefined ||
@@ -99,18 +160,18 @@ export async function upsertProfile(
 	const protectedEmail = email ? protectPii(email) : null;
 	const emailHash = email ? emailLookupHash(email) : null;
 
-	const insert = db.insert(profiles).values({
+	const values = {
 		websiteId,
 		profileId,
 		displayName: protectedDisplayName,
 		email: protectedEmail,
 		emailHash,
 		traits: rest,
-	});
+	};
 
 	if (!hasTraitUpdates) {
-		await insert.onConflictDoNothing();
-		return;
+		await db.insert(profiles).values(values).onConflictDoNothing();
+		return null;
 	}
 
 	const mergedTraits =
@@ -118,14 +179,55 @@ export async function upsertProfile(
 			? sql`(${profiles.traits} - ${removeKeys}::text[]) || ${JSON.stringify(rest)}::jsonb`
 			: sql`${profiles.traits} || ${JSON.stringify(rest)}::jsonb`;
 
-	await insert.onConflictDoUpdate({
-		target: [profiles.websiteId, profiles.profileId],
-		set: {
-			...(displayName !== undefined && { displayName: protectedDisplayName }),
-			...(email !== undefined && { email: protectedEmail, emailHash }),
-			traits: mergedTraits,
-			updatedAt: sql`now()`,
-		},
+	return await db.transaction(async (tx) => {
+		const existingRows = await tx
+			.select({ traits: profiles.traits })
+			.from(profiles)
+			.where(
+				and(
+					eq(profiles.websiteId, websiteId),
+					eq(profiles.profileId, profileId)
+				)
+			)
+			.limit(1)
+			.for("update");
+		const existingTraits = (existingRows[0]?.traits ?? {}) as Record<
+			string,
+			unknown
+		>;
+
+		await tx
+			.insert(profiles)
+			.values(values)
+			.onConflictDoUpdate({
+				target: [profiles.websiteId, profiles.profileId],
+				set: {
+					...(displayName !== undefined && {
+						displayName: protectedDisplayName,
+					}),
+					...(email !== undefined && { email: protectedEmail, emailHash }),
+					traits: mergedTraits,
+					updatedAt: sql`now()`,
+				},
+			});
+
+		const update = applyTraits(existingTraits, rest, removeKeys);
+		if (update.changes.length > 0) {
+			await tx.insert(profileTraitChanges).values({
+				id: crypto.randomUUID(),
+				websiteId,
+				profileId,
+				traits: update.traits,
+				changes: Object.fromEntries(
+					update.changes.map((change) => [
+						change.traitKey,
+						{ old: change.oldValue, new: change.newValue },
+					])
+				),
+				source,
+			});
+		}
+		return update;
 	});
 }
 

--- a/packages/tracker/deploy-utils.ts
+++ b/packages/tracker/deploy-utils.ts
@@ -1,7 +1,7 @@
-import { hash } from "bun";
+import { createHash } from "node:crypto";
 
 export function getContentHash(content: string): string {
-	return hash(content).toString();
+	return createHash("sha256").update(content).digest("hex");
 }
 
 export async function generateSriHash(content: string): Promise<string> {

--- a/packages/tracker/src/core/tracker.ts
+++ b/packages/tracker/src/core/tracker.ts
@@ -28,7 +28,7 @@ const DID_PARAMS_KEY = "did_params";
 const HEADLESS_CHROME_REGEX = /\bHeadlessChrome\b/i;
 const PHANTOMJS_REGEX = /\bPhantomJS\b/i;
 const ANON_ID_PATTERN = /^anon_[0-9a-f-]{36}$/;
-const SESSION_ID_PATTERN = /^[0-9a-f-]{36}$/;
+const SESSION_ID_PATTERN = /^sess_[0-9a-f-]{36}$/;
 const MAX_PROFILE_ID_LENGTH = 128;
 
 interface QueueMeta<T> {

--- a/packages/tracker/tests/edge-cases.spec.ts
+++ b/packages/tracker/tests/edge-cases.spec.ts
@@ -3,7 +3,29 @@ import { countEvents, expect, findEvent, hasEvent, test } from "./test-utils";
 test.describe("Edge Cases", () => {
 
 	test.describe("URL-based ID Override", () => {
-		test("uses anonId from URL query param", async ({ page }) => {
+		test("uses a well-formed anonId from URL query param", async ({ page }) => {
+			const anonId = "anon_00000000-0000-4000-8000-000000000001";
+			await page.goto(`/test?anonId=${anonId}`);
+			await page.evaluate(() => {
+				(window as any).databuddyConfig = {
+					clientId: "test-url-override",
+					ignoreBotDetection: true,
+					batchTimeout: 200,
+				};
+			});
+			await page.addScriptTag({ url: "/dist/databuddy-debug.js" });
+
+			await expect
+				.poll(async () => await page.evaluate(() => !!(window as any).db))
+				.toBeTruthy();
+
+			const storedId = await page.evaluate(() => localStorage.getItem("did"));
+			expect(storedId).toBe(anonId);
+		});
+
+		test("rejects a malformed anonId from URL query param", async ({
+			page,
+		}) => {
 			await page.goto("/test?anonId=custom-anon-123");
 			await page.evaluate(() => {
 				(window as any).databuddyConfig = {
@@ -19,10 +41,36 @@ test.describe("Edge Cases", () => {
 				.toBeTruthy();
 
 			const storedId = await page.evaluate(() => localStorage.getItem("did"));
-			expect(storedId).toBe("custom-anon-123");
+			expect(storedId).toMatch(/^anon_[0-9a-f-]{36}$/);
 		});
 
-		test("uses sessionId from URL query param", async ({ page }) => {
+		test("uses a well-formed sessionId from URL query param", async ({
+			page,
+		}) => {
+			const sessionId = "sess_00000000-0000-4000-8000-000000000002";
+			await page.goto(`/test?sessionId=${sessionId}`);
+			await page.evaluate(() => {
+				(window as any).databuddyConfig = {
+					clientId: "test-url-override",
+					ignoreBotDetection: true,
+					batchTimeout: 200,
+				};
+			});
+			await page.addScriptTag({ url: "/dist/databuddy-debug.js" });
+
+			await expect
+				.poll(async () => await page.evaluate(() => !!(window as any).db))
+				.toBeTruthy();
+
+			const storedId = await page.evaluate(() =>
+				sessionStorage.getItem("did_session")
+			);
+			expect(storedId).toBe(sessionId);
+		});
+
+		test("rejects a malformed sessionId from URL query param", async ({
+			page,
+		}) => {
 			await page.goto("/test?sessionId=custom-session-456");
 			await page.evaluate(() => {
 				(window as any).databuddyConfig = {
@@ -40,7 +88,7 @@ test.describe("Edge Cases", () => {
 			const storedId = await page.evaluate(() =>
 				sessionStorage.getItem("did_session")
 			);
-			expect(storedId).toBe("custom-session-456");
+			expect(storedId).toMatch(/^sess_[0-9a-f-]{36}$/);
 		});
 	});
 

--- a/packages/tracker/tests/unit/deploy-utils.test.ts
+++ b/packages/tracker/tests/unit/deploy-utils.test.ts
@@ -36,9 +36,9 @@ describe("getContentHash", () => {
 		expect(hash1).not.toBe(hash2);
 	});
 
-	test("returns a numeric string", () => {
+	test("returns a sha256 hex digest", () => {
 		const hash = getContentHash("test content");
-		expect(hash).toMatch(/^\d+$/);
+		expect(hash).toMatch(/^[0-9a-f]{64}$/);
 	});
 });
 


### PR DESCRIPTION
## Summary

Ships the identity/trait-history work plus the credential-leak hardening from this week, alongside the tracker/dashboard fixes already on staging.

### Security: sensitive query params scrubbed at ingestion
- Basket now redacts a denylist of query params (`password`, `token`, `api_key`, `email`, `otp`, ...) from `url`/`path`/`referrer`/`href` on every write path, including hash fragments (OAuth implicit flow). Values become `REDACTED`, keys stay visible so leaky customer forms remain detectable.
- Context: found real plaintext credentials in stored URLs (ours and customers'); leaked rows were purged from ClickHouse directly.

### Profile trait history (Postgres)
- New `profile_trait_changes` table: each row is a full post-change trait snapshot plus a `{key: {old, new}}` diff, written transactionally inside `upsertProfile` (SELECT ... FOR UPDATE). Answers "when did the plan change" and "what were the traits at time T" without diff folding.
- Deliberately Postgres, not ClickHouse: transactional with the upsert, trivial GDPR deletes, and events already carry `plan` at event time so point-in-time joins aren't needed.

### Billing lifecycle events
- Autumn `customer.products.updated` webhook now calls `recordPlanChange`: plan trait upsert (`source: "billing"`) + lifecycle custom events (`plan_upgraded`, `subscription_canceled`, ...) with `profile_id` attached. Gated on `SELF_ANALYTICS_WEBSITE_ID` (unset = no-op); scenario type is compile-checked against the webhook's zod enum.

### Agent/MCP
- `get_profile_history` tool added to `buildProfileTools` — available to both the in-app agent and MCP with website-access enforcement.

### Dogfooding
- Dashboard identifies with `plan` / `has_active_subscription` / `billing_scope` traits and stamps `plan` on every event via the newly exported `setGlobalProperties`.

## Deploy notes
- `SELF_ANALYTICS_WEBSITE_ID` must be set on the API service for lifecycle recording to activate (safe no-op until then).
- `profile_trait_changes` is already applied to production Postgres.

## Testing
- basket: 485 tests passing (incl. new redaction + trait diff coverage)
- api: 155 tests passing (autumn webhook mocks updated)
- db drift tests + full monorepo typecheck green

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Postgres-backed trait history and billing lifecycle recording, and scrubs sensitive query params at ingestion to stop credential leaks. Also enriches profile lists with identity info and adds small tracker/CI fixes.

- **New Features**
  - Scrub sensitive query params across all ingestion paths (`password`, `token`, `api_key`, `email`, `otp`, hash fragments). Values become REDACTED; keys stay.
  - Store profile trait change history in Postgres (`profile_trait_changes`) with full snapshots and diffs, written transactionally in `upsertProfile`; new `get_profile_history` tool.
  - Record billing lifecycle from Autumn webhooks via `@databuddy/services` (`recordPlanChange`): set `plan` trait (`source: "billing"`) and emit custom events (e.g., `plan_upgraded`). Gated by `SELF_ANALYTICS_WEBSITE_ID`.
  - Query API attaches `display_name` and `email` to `profile_list` results (PII-safe), and the dashboard users page uses these to avoid flicker.
  - Dashboard identifies billing traits and sets a global `plan` property; `@databuddy/sdk` now exports `setGlobalProperties`.

- **Bug Fixes**
  - Fix `interesting_sessions` builder and tighten session queries.
  - Tracker: enforce `sess_...` session IDs; reject malformed URL overrides; use sha256 in deploy utils.
  - CI: add ClickHouse service and init; new EXPLAIN suite validates all query builders.

<sup>Written for commit 4422b2ee6ecc5d81373fbd91986b51fdef759c43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

