### PR TITLE
Profile trait history: fixes + surface traits/history in UI

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -4,7 +4,7 @@
   "version": "1.0.1",
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development dotenv -- bun --hot src/index.ts --port 3001",
+    "dev": "NODE_ENV=development dotenv -- bun --hot src/index.ts",
     "test": "TZ=UTC bunx --bun vitest run",
     "test:integration": "TZ=UTC bunx --bun vitest run --config vitest.integration.config.ts",
     "test:watch": "TZ=UTC bunx --bun vitest"

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -109,6 +109,8 @@ registerShutdownHooks();
 
 export default {
 	fetch: app.fetch,
-	port: Number.parseInt(apiEnv.PORT, 10),
+	// In development env validation is skipped, so zod defaults never apply and
+	// apiEnv.PORT can be undefined — fall back explicitly or Bun binds a random port.
+	port: Number.parseInt(apiEnv.PORT ?? "3001", 10) || 3001,
 	idleTimeout: BUN_IDLE_TIMEOUT_SECONDS,
 };

--- a/apps/api/src/integration/profile-handlers.test.ts
+++ b/apps/api/src/integration/profile-handlers.test.ts
@@ -5,7 +5,9 @@ import {
 	profiles,
 	profileTraitChanges,
 } from "@databuddy/db/schema";
+import { eq } from "@databuddy/db";
 import { appRouter, type Context } from "@databuddy/rpc";
+import { splitTraits, upsertProfile } from "@databuddy/services/identity";
 import {
 	addToOrganization,
 	cleanup,
@@ -177,5 +179,70 @@ describe("profiles.getHistory", () => {
 			})({ websiteId: website.id, profileId: "user_1" }),
 			"FORBIDDEN"
 		);
+	});
+});
+
+describe("upsertProfile trait history", () => {
+	iit("records baseline on first identify, diff on the next", async () => {
+		const org = await insertOrganization();
+		const website = await insertWebsite({ organizationId: org.id });
+
+		await upsertProfile(website.id, "user_1", splitTraits({ plan: "free" }));
+		await upsertProfile(
+			website.id,
+			"user_1",
+			splitTraits({ plan: "pro" }),
+			"billing"
+		);
+
+		const rows = await db()
+			.select()
+			.from(profileTraitChanges)
+			.where(eq(profileTraitChanges.profileId, "user_1"))
+			.orderBy(profileTraitChanges.createdAt);
+
+		expect(rows).toHaveLength(2);
+		expect(rows[0]?.changes).toEqual({ plan: { old: null, new: "free" } });
+		expect(rows[0]?.source).toBe("identify");
+		expect(rows[1]?.changes).toEqual({ plan: { old: "free", new: "pro" } });
+		expect(rows[1]?.source).toBe("billing");
+		expect(rows[1]?.traits).toEqual({ plan: "pro" });
+	});
+
+	iit("writes no history row when traits are unchanged", async () => {
+		const org = await insertOrganization();
+		const website = await insertWebsite({ organizationId: org.id });
+
+		await upsertProfile(website.id, "user_1", splitTraits({ plan: "pro" }));
+		await upsertProfile(website.id, "user_1", splitTraits({ plan: "pro" }));
+
+		const rows = await db()
+			.select()
+			.from(profileTraitChanges)
+			.where(eq(profileTraitChanges.profileId, "user_1"));
+
+		expect(rows).toHaveLength(1);
+	});
+
+	iit("cascades history deletion when the profile is deleted", async () => {
+		const org = await insertOrganization();
+		const website = await insertWebsite({ organizationId: org.id });
+
+		await upsertProfile(website.id, "user_1", splitTraits({ plan: "pro" }));
+		expect(
+			await db()
+				.select()
+				.from(profileTraitChanges)
+				.where(eq(profileTraitChanges.profileId, "user_1"))
+		).toHaveLength(1);
+
+		await db().delete(profiles).where(eq(profiles.profileId, "user_1"));
+
+		expect(
+			await db()
+				.select()
+				.from(profileTraitChanges)
+				.where(eq(profileTraitChanges.profileId, "user_1"))
+		).toHaveLength(0);
 	});
 });

--- a/apps/api/src/integration/profile-handlers.test.ts
+++ b/apps/api/src/integration/profile-handlers.test.ts
@@ -1,6 +1,10 @@
 import "@databuddy/test/env";
 
-import { profileAliases, profiles } from "@databuddy/db/schema";
+import {
+	profileAliases,
+	profiles,
+	profileTraitChanges,
+} from "@databuddy/db/schema";
 import { appRouter, type Context } from "@databuddy/rpc";
 import {
 	addToOrganization,
@@ -118,5 +122,60 @@ describe("profiles.get", () => {
 		})({ websiteId: website.id, profileId: "user_ghost" });
 
 		expect(result).toBeNull();
+	});
+});
+
+describe("profiles.getHistory", () => {
+	iit("returns trait changes newest first", async () => {
+		const user = await signUp();
+		const org = await insertOrganization();
+		await addToOrganization(user.id, org.id, "member");
+		const website = await insertWebsite({ organizationId: org.id });
+		await seedProfile(website.id, "user_1");
+		await db()
+			.insert(profileTraitChanges)
+			.values([
+				{
+					id: "change_old",
+					websiteId: website.id,
+					profileId: "user_1",
+					traits: { plan: "free" },
+					changes: { plan: { old: null, new: "free" } },
+					source: "identify",
+					createdAt: new Date("2026-01-01T00:00:00Z"),
+				},
+				{
+					id: "change_new",
+					websiteId: website.id,
+					profileId: "user_1",
+					traits: { plan: "pro" },
+					changes: { plan: { old: "free", new: "pro" } },
+					source: "billing",
+					createdAt: new Date("2026-02-01T00:00:00Z"),
+				},
+			]);
+
+		const result = await call(appRouter.profiles.getHistory, {
+			...userContext(user, org.id),
+		})({ websiteId: website.id, profileId: "user_1" });
+
+		expect(result.map((r) => r.source)).toEqual(["billing", "identify"]);
+		expect(result[0]?.changes).toEqual({ plan: { old: "free", new: "pro" } });
+	});
+
+	iit("does not leak history from another organization's website", async () => {
+		const outsider = await signUp();
+		const outsiderOrg = await insertOrganization();
+		await addToOrganization(outsider.id, outsiderOrg.id, "member");
+
+		const org = await insertOrganization();
+		const website = await insertWebsite({ organizationId: org.id });
+
+		await expectCode(
+			call(appRouter.profiles.getHistory, {
+				...userContext(outsider, outsiderOrg.id),
+			})({ websiteId: website.id, profileId: "user_1" }),
+			"FORBIDDEN"
+		);
 	});
 });

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -7,7 +7,7 @@ import { type ElementType, type ReactNode, useCallback, useState } from "react";
 import { BrowserIcon, CountryFlag, OSIcon } from "@/components/icon";
 import { useDateFilters } from "@/hooks/use-date-filters";
 import { getDeviceIcon } from "@/components/device-icon";
-import { useProfileIdentity } from "@/hooks/use-profiles";
+import { useProfileHistory, useProfileIdentity } from "@/hooks/use-profiles";
 import { cn } from "@/lib/utils";
 import { generateProfileName } from "./_components/generate-profile-name";
 import { SessionRow } from "./_components/session-row";
@@ -15,10 +15,12 @@ import { useUserProfile } from "./use-user-profile";
 import {
 	ArrowLeftIcon,
 	ChartLineIcon,
+	ClockCounterClockwiseIcon,
 	ClockIcon,
 	DevicesIcon,
 	GaugeIcon,
 	GlobeIcon,
+	TagIcon,
 	UserIcon,
 } from "@databuddy/ui/icons";
 import {
@@ -317,6 +319,108 @@ function WebVitalsSection({
 	);
 }
 
+function formatTraitValue(value: unknown): string {
+	if (value === null || value === undefined) {
+		return "—";
+	}
+	if (typeof value === "boolean") {
+		return value ? "Yes" : "No";
+	}
+	if (typeof value === "object") {
+		return JSON.stringify(value);
+	}
+	return String(value);
+}
+
+function TraitsSection({
+	className,
+	traits,
+}: {
+	className?: string;
+	traits: Record<string, unknown> | undefined;
+}) {
+	const entries = Object.entries(traits ?? {}).sort(([a], [b]) =>
+		a.localeCompare(b)
+	);
+	if (entries.length === 0) {
+		return null;
+	}
+
+	return (
+		<SidebarSection className={className} icon={TagIcon} title="Traits">
+			{entries.map(([key, value]) => (
+				<div
+					className="flex min-h-10 items-center justify-between gap-3 py-2.5"
+					key={key}
+				>
+					<span className="text-muted-foreground text-xs">{key}</span>
+					<span className="truncate text-right font-medium text-foreground text-sm">
+						{formatTraitValue(value)}
+					</span>
+				</div>
+			))}
+		</SidebarSection>
+	);
+}
+
+interface TraitHistoryEntry {
+	changes: Record<string, { old: unknown; new: unknown }>;
+	createdAt: string | Date;
+	source: string;
+}
+
+function TraitHistorySection({
+	className,
+	history,
+}: {
+	className?: string;
+	history: TraitHistoryEntry[];
+}) {
+	if (history.length === 0) {
+		return null;
+	}
+
+	return (
+		<SidebarSection
+			className={className}
+			icon={ClockCounterClockwiseIcon}
+			title="Trait history"
+		>
+			<div className="flex flex-col gap-3">
+				{history.map((entry, index) => (
+					<div
+						className="border-border/60 border-l-2 pl-3"
+						key={`${entry.createdAt}-${index}`}
+					>
+						<div className="flex items-center justify-between gap-2">
+							<span className="text-muted-foreground text-xs">
+								{formatDateOnly(entry.createdAt)} ·{" "}
+								{formatLocalTime(entry.createdAt, "h:mm A")}
+							</span>
+							<span className="text-muted-foreground/60 text-xs">
+								{entry.source}
+							</span>
+						</div>
+						<div className="mt-1 flex flex-col gap-0.5">
+							{Object.entries(entry.changes).map(([key, change]) => (
+								<p className="text-sm" key={key}>
+									<span className="font-medium text-foreground">{key}</span>{" "}
+									<span className="text-muted-foreground/70 line-through">
+										{formatTraitValue(change.old)}
+									</span>{" "}
+									<span className="text-foreground">
+										→ {formatTraitValue(change.new)}
+									</span>
+								</p>
+							))}
+						</div>
+					</div>
+				))}
+			</div>
+		</SidebarSection>
+	);
+}
+
 function Header({
 	onBack,
 	userProfile,
@@ -404,6 +508,10 @@ export default function UserDetailPage() {
 		dateRange
 	);
 	const { data: identity } = useProfileIdentity(
+		websiteId,
+		userProfile?.profile_id ?? ""
+	);
+	const { data: traitHistory } = useProfileHistory(
 		websiteId,
 		userProfile?.profile_id ?? ""
 	);
@@ -496,6 +604,8 @@ export default function UserDetailPage() {
 						))}
 					</div>
 
+					<TraitsSection traits={identity?.traits} />
+
 					<WebVitalsSection vitals={webVitals} />
 
 					<SidebarSection icon={GlobeIcon} title="Location">
@@ -572,6 +682,8 @@ export default function UserDetailPage() {
 							value={userProfile.total_duration_formatted || "0s"}
 						/>
 					</SidebarSection>
+
+					<TraitHistorySection history={traitHistory ?? []} />
 				</aside>
 
 				<main className="min-w-0 flex-1 overflow-y-auto">
@@ -586,9 +698,19 @@ export default function UserDetailPage() {
 						))}
 					</div>
 
+					<TraitsSection
+						className="bg-background lg:hidden"
+						traits={identity?.traits}
+					/>
+
 					<WebVitalsSection
 						className="bg-background lg:hidden"
 						vitals={webVitals}
+					/>
+
+					<TraitHistorySection
+						className="bg-background lg:hidden"
+						history={traitHistory ?? []}
 					/>
 
 					<div className="sticky top-0 z-10 grid h-[39px] grid-cols-[24px_1fr_120px_80px_60px_60px_70px_80px] items-center gap-2 border-b bg-accent px-3 font-medium text-muted-foreground text-xs shadow-[0_0_0_0.5px_var(--border)] lg:grid-cols-[24px_1fr_120px_80px_100px_60px_60px_70px_80px]">

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { getCountryCode } from "@databuddy/shared/country-codes";
+import {
+	getCountryCode,
+	getCountryName,
+} from "@databuddy/shared/country-codes";
 import type { ProfileSession, Session } from "@/types/sessions";
 import { notFound, useParams, useRouter } from "next/navigation";
 import { type ElementType, type ReactNode, useCallback, useState } from "react";
@@ -440,6 +443,7 @@ function Header({
 	const countryCode = userProfile
 		? getCountryCode(userProfile.country || "")
 		: "";
+	const countryName = getCountryName(countryCode) || userProfile?.country || "";
 	const isReturning = (userProfile?.total_sessions ?? 0) > 1;
 
 	return (
@@ -482,7 +486,7 @@ function Header({
 								{userProfile.region && userProfile.region !== "Unknown"
 									? `${userProfile.region}, `
 									: ""}
-								{userProfile.country || "Unknown location"}
+								{countryName || "Unknown location"}
 							</p>
 						</div>
 					</div>
@@ -590,6 +594,10 @@ export default function UserDetailPage() {
 		userProfile.region && userProfile.region !== "Unknown"
 			? userProfile.region
 			: undefined;
+	const countryName =
+		getCountryName(getCountryCode(userProfile.country || "")) ||
+		userProfile.country ||
+		"Unknown";
 	const metrics = [
 		{ label: "Sessions", value: totalSessions },
 		{ label: "Pageviews", value: userProfile.total_pageviews ?? 0 },
@@ -632,7 +640,7 @@ export default function UserDetailPage() {
 							}
 							label="Country"
 							subValue={region}
-							value={userProfile.country || "Unknown"}
+							value={countryName}
 						/>
 					</SidebarSection>
 

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -465,7 +465,10 @@ function Header({
 										generateProfileName(userProfile.visitor_id)}
 								</h1>
 								{identity?.displayName || identity?.email ? (
-									<Tooltip content="Name and email are encrypted at rest">
+									<Tooltip
+										content="Name and email are encrypted at rest"
+										side="bottom"
+									>
 										<span className="flex items-center text-muted-foreground">
 											<LockSimpleIcon className="size-3" weight="duotone" />
 										</span>

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import {
+	formatCountryName,
 	getCountryCode,
-	getCountryName,
 } from "@databuddy/shared/country-codes";
 import type { ProfileSession, Session } from "@/types/sessions";
 import { notFound, useParams, useRouter } from "next/navigation";
@@ -443,7 +443,7 @@ function Header({
 	const countryCode = userProfile
 		? getCountryCode(userProfile.country || "")
 		: "";
-	const countryName = getCountryName(countryCode) || userProfile?.country || "";
+	const countryName = formatCountryName(userProfile?.country);
 	const isReturning = (userProfile?.total_sessions ?? 0) > 1;
 
 	return (
@@ -594,10 +594,7 @@ export default function UserDetailPage() {
 		userProfile.region && userProfile.region !== "Unknown"
 			? userProfile.region
 			: undefined;
-	const countryName =
-		getCountryName(getCountryCode(userProfile.country || "")) ||
-		userProfile.country ||
-		"Unknown";
+	const countryName = formatCountryName(userProfile.country) || "Unknown";
 	const metrics = [
 		{ label: "Sessions", value: totalSessions },
 		{ label: "Pageviews", value: userProfile.total_pageviews ?? 0 },

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -20,6 +20,7 @@ import {
 	DevicesIcon,
 	GaugeIcon,
 	GlobeIcon,
+	LockSimpleIcon,
 	TagIcon,
 	UserIcon,
 } from "@databuddy/ui/icons";
@@ -28,6 +29,7 @@ import {
 	EmptyState,
 	Spinner,
 	StatusDot,
+	Tooltip,
 	formatDateOnly,
 	formatLocalTime,
 } from "@databuddy/ui";
@@ -456,11 +458,21 @@ function Header({
 					<div className="flex items-center gap-2.5">
 						<CountryFlag country={countryCode} size="sm" />
 						<div>
-							<h1 className="font-medium text-foreground text-sm">
-								{identity?.displayName ||
-									identity?.email ||
-									generateProfileName(userProfile.visitor_id)}
-							</h1>
+							<div className="flex items-center gap-1.5">
+								<h1 className="font-medium text-foreground text-sm">
+									{identity?.displayName ||
+										identity?.email ||
+										generateProfileName(userProfile.visitor_id)}
+								</h1>
+								{identity?.displayName || identity?.email ? (
+									<Tooltip content="Name and email are encrypted at rest">
+										<LockSimpleIcon
+											className="size-3 text-muted-foreground"
+											weight="duotone"
+										/>
+									</Tooltip>
+								) : null}
+							</div>
 							<p className="text-muted-foreground text-xs">
 								{identity?.displayName && identity?.email
 									? `${identity.email} · `

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -353,8 +353,8 @@ function TraitsSection({
 					className="flex min-h-10 items-center justify-between gap-3 py-2.5"
 					key={key}
 				>
-					<span className="text-muted-foreground text-xs">{key}</span>
-					<span className="truncate text-right font-medium text-foreground text-sm">
+					<span className="shrink-0 text-muted-foreground text-xs">{key}</span>
+					<span className="min-w-0 truncate text-right font-medium text-foreground text-sm">
 						{formatTraitValue(value)}
 					</span>
 				</div>

--- a/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/[userId]/page.tsx
@@ -466,10 +466,9 @@ function Header({
 								</h1>
 								{identity?.displayName || identity?.email ? (
 									<Tooltip content="Name and email are encrypted at rest">
-										<LockSimpleIcon
-											className="size-3 text-muted-foreground"
-											weight="duotone"
-										/>
+										<span className="flex items-center text-muted-foreground">
+											<LockSimpleIcon className="size-3" weight="duotone" />
+										</span>
 									</Tooltip>
 								) : null}
 							</div>

--- a/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
@@ -22,6 +22,7 @@ import {
 import type { ProfileData } from "@/types/analytics";
 import {
 	ArrowDownIcon,
+	ArrowsClockwiseIcon,
 	ArrowUpIcon,
 	GlobeIcon,
 	LightningIcon,
@@ -40,7 +41,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { generateProfileName } from "./[userId]/_components/generate-profile-name";
 import { type ProfileSort, useProfilesData } from "./use-users";
 import { useEventNames } from "./use-event-names";
-import { Badge, EmptyState, Skeleton, Tooltip, dayjs } from "@databuddy/ui";
+import {
+	Badge,
+	Button,
+	EmptyState,
+	Skeleton,
+	Tooltip,
+	dayjs,
+} from "@databuddy/ui";
 import { DropdownMenu } from "@databuddy/ui/client";
 
 const wwwRegex = /^www\./;
@@ -213,7 +221,15 @@ export default function UsersPage() {
 		[sort.field, sort.order]
 	);
 
-	const { profiles, pagination, isLoading, isError, error } = useProfilesData(
+	const {
+		profiles,
+		pagination,
+		isLoading,
+		isFetching,
+		isError,
+		error,
+		refetch,
+	} = useProfilesData(
 		websiteId,
 		dateRange,
 		50,
@@ -579,12 +595,29 @@ export default function UsersPage() {
 		</div>
 	);
 
+	const refreshAction = (
+		<TopBar.Actions>
+			<Button
+				disabled={isFetching}
+				onClick={() => refetch()}
+				size="icon"
+				title="Refresh"
+				variant="ghost"
+			>
+				<ArrowsClockwiseIcon
+					className={`size-4${isFetching ? "animate-spin" : ""}`}
+				/>
+			</Button>
+		</TopBar.Actions>
+	);
+
 	if (isInitialLoad) {
 		return (
 			<div className="flex h-full flex-col">
 				<TopBar.Title>
 					<h1 className="font-semibold text-sm">Users</h1>
 				</TopBar.Title>
+				{refreshAction}
 
 				{presetBar}
 
@@ -622,6 +655,7 @@ export default function UsersPage() {
 				<TopBar.Title>
 					<h1 className="font-semibold text-sm">Users</h1>
 				</TopBar.Title>
+				{refreshAction}
 
 				<div className="flex min-h-0 flex-1 flex-col items-center justify-center py-24 text-center text-muted-foreground">
 					<UsersIcon className="mb-4 size-12 opacity-50" />
@@ -640,6 +674,7 @@ export default function UsersPage() {
 				<TopBar.Title>
 					<h1 className="font-semibold text-sm">Users</h1>
 				</TopBar.Title>
+				{refreshAction}
 
 				{presetBar}
 
@@ -658,6 +693,7 @@ export default function UsersPage() {
 			<TopBar.Title>
 				<h1 className="font-semibold text-sm">Users</h1>
 			</TopBar.Title>
+			{refreshAction}
 
 			{presetBar}
 

--- a/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
@@ -605,7 +605,7 @@ export default function UsersPage() {
 				variant="ghost"
 			>
 				<ArrowsClockwiseIcon
-					className={`size-4${isFetching ? "animate-spin" : ""}`}
+					className={isFetching ? "size-4 animate-spin" : "size-4"}
 				/>
 			</Button>
 		</TopBar.Actions>

--- a/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/users/page.tsx
@@ -16,8 +16,8 @@ import { getDeviceIcon } from "@/components/device-icon";
 import { dynamicQueryFiltersAtom } from "@/stores/jotai/filterAtoms";
 import type { DynamicQueryFilter } from "@/stores/jotai/filterAtoms";
 import {
+	formatCountryName,
 	getCountryCode,
-	getCountryName,
 } from "@databuddy/shared/country-codes";
 import type { ProfileData } from "@/types/analytics";
 import {
@@ -363,9 +363,8 @@ export default function UsersPage() {
 				id: "location",
 				header: "Location",
 				cell: ({ row }) => {
-					const country = row.original.country || "";
-					const countryCode = getCountryCode(country);
-					const countryName = getCountryName(countryCode);
+					const countryCode = getCountryCode(row.original.country || "");
+					const countryName = formatCountryName(row.original.country);
 					const isUnknown = !countryCode || countryCode === "Unknown";
 
 					return (
@@ -376,7 +375,7 @@ export default function UsersPage() {
 								<CountryFlag country={countryCode} size="sm" />
 							)}
 							<span className="truncate text-sm">
-								{isUnknown ? "Unknown" : countryName || countryCode}
+								{countryName || "Unknown"}
 							</span>
 						</div>
 					);

--- a/apps/dashboard/hooks/use-dynamic-query.ts
+++ b/apps/dashboard/hooks/use-dynamic-query.ts
@@ -191,8 +191,10 @@ export function useDynamicQuery<
 	return {
 		data: processedData,
 		isLoading: query.isLoading || query.isFetching || query.isPending,
+		isFetching: query.isFetching,
 		isError: query.isError,
 		error: query.error,
+		refetch: query.refetch,
 	};
 }
 

--- a/apps/dashboard/hooks/use-profiles.ts
+++ b/apps/dashboard/hooks/use-profiles.ts
@@ -10,3 +10,13 @@ export function useProfileIdentity(websiteId: string, profileId: string) {
 		staleTime: 5 * 60 * 1000,
 	});
 }
+
+export function useProfileHistory(websiteId: string, profileId: string) {
+	return useQuery({
+		...orpc.profiles.getHistory.queryOptions({
+			input: { websiteId, profileId },
+		}),
+		enabled: Boolean(websiteId && profileId),
+		staleTime: 5 * 60 * 1000,
+	});
+}

--- a/packages/db/src/drizzle/schema/identity.ts
+++ b/packages/db/src/drizzle/schema/identity.ts
@@ -1,4 +1,5 @@
 import {
+	foreignKey,
 	index,
 	jsonb,
 	pgTable,
@@ -44,9 +45,7 @@ export const profileTraitChanges = pgTable(
 	"profile_trait_changes",
 	{
 		id: text().primaryKey(),
-		websiteId: text("website_id")
-			.notNull()
-			.references(() => websites.id, { onDelete: "cascade" }),
+		websiteId: text("website_id").notNull(),
 		profileId: text("profile_id").notNull(),
 		// Full merged non-PII traits after this change — state at time T is the
 		// latest row with createdAt <= T, no diff folding needed.
@@ -75,6 +74,11 @@ export const profileTraitChanges = pgTable(
 			table.createdAt
 		),
 		index("profile_trait_changes_changes_gin_idx").using("gin", table.changes),
+		foreignKey({
+			columns: [table.websiteId, table.profileId],
+			foreignColumns: [profiles.websiteId, profiles.profileId],
+			name: "profile_trait_changes_profile_fkey",
+		}).onDelete("cascade"),
 	]
 );
 

--- a/packages/rpc/src/routers/profiles.ts
+++ b/packages/rpc/src/routers/profiles.ts
@@ -1,5 +1,9 @@
-import { and, eq, inArray } from "@databuddy/db";
-import { profileAliases, profiles } from "@databuddy/db/schema";
+import { and, desc, eq, inArray } from "@databuddy/db";
+import {
+	profileAliases,
+	profiles,
+	profileTraitChanges,
+} from "@databuddy/db/schema";
 import { revealPii } from "@databuddy/services/identity";
 import { z } from "zod";
 import { trackedProcedure } from "../orpc";
@@ -125,5 +129,61 @@ export const profilesRouter = {
 				email: revealPii(profile.email),
 				anonymousIds: aliases.map((alias) => alias.anonymousId),
 			};
+		}),
+
+	getHistory: trackedProcedure
+		.route({
+			method: "POST",
+			path: "/profiles/getHistory",
+			tags: ["Profiles"],
+			summary: "Get profile trait history",
+			description:
+				"Returns the trait change timeline for a profile, newest first. Each entry has the changed keys (old and new) and the full trait snapshot after the change. Requires website read permission.",
+		})
+		.input(
+			z.object({
+				websiteId: z.string(),
+				profileId: z.string().min(1).max(128),
+				limit: z.number().min(1).max(200).default(50),
+			})
+		)
+		.output(
+			z.array(
+				z.object({
+					changes: z.record(
+						z.string(),
+						z.object({
+							old: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+							new: z.union([z.string(), z.number(), z.boolean(), z.null()]),
+						})
+					),
+					traits: z.record(z.string(), z.unknown()),
+					source: z.string(),
+					createdAt: z.date(),
+				})
+			)
+		)
+		.handler(async ({ context, input }) => {
+			await withWorkspace(context, {
+				websiteId: input.websiteId,
+				permissions: ["read"],
+			});
+
+			return await context.db
+				.select({
+					changes: profileTraitChanges.changes,
+					traits: profileTraitChanges.traits,
+					source: profileTraitChanges.source,
+					createdAt: profileTraitChanges.createdAt,
+				})
+				.from(profileTraitChanges)
+				.where(
+					and(
+						eq(profileTraitChanges.websiteId, input.websiteId),
+						eq(profileTraitChanges.profileId, input.profileId)
+					)
+				)
+				.orderBy(desc(profileTraitChanges.createdAt))
+				.limit(input.limit);
 		}),
 };

--- a/packages/services/src/identity.ts
+++ b/packages/services/src/identity.ts
@@ -180,6 +180,13 @@ export async function upsertProfile(
 			: sql`${profiles.traits} || ${JSON.stringify(rest)}::jsonb`;
 
 	return await db.transaction(async (tx) => {
+		// FOR UPDATE can't lock a not-yet-existent row, so two concurrent
+		// first-time identifies would both read {} and write conflicting
+		// history. Serialize on the (websiteId, profileId) pair instead.
+		await tx.execute(
+			sql`SELECT pg_advisory_xact_lock(hashtextextended(${`profile:${websiteId}:${profileId}`}, 0))`
+		);
+
 		const existingRows = await tx
 			.select({ traits: profiles.traits })
 			.from(profiles)
@@ -189,8 +196,7 @@ export async function upsertProfile(
 					eq(profiles.profileId, profileId)
 				)
 			)
-			.limit(1)
-			.for("update");
+			.limit(1);
 		const existingTraits = (existingRows[0]?.traits ?? {}) as Record<
 			string,
 			unknown

--- a/packages/shared/src/country-codes.ts
+++ b/packages/shared/src/country-codes.ts
@@ -311,3 +311,16 @@ export function getCountryName(countryCode: string): string {
 
 	return countryCode;
 }
+
+/**
+ * Resolves a raw country value (ISO code or name) to a display name.
+ * Single source of truth for country display — use everywhere a country is
+ * shown so raw codes like "DE" never leak into the UI. Returns "" for
+ * empty/unknown so callers can apply their own fallback label.
+ */
+export function formatCountryName(raw: string | null | undefined): string {
+	if (!raw || raw === "Unknown") {
+		return "";
+	}
+	return getCountryName(getCountryCode(raw)) || raw;
+}


### PR DESCRIPTION
## Summary

Two data-correctness fixes for the trait-history work, plus the UI/RPC surface that finally exposes traits and trait history in the product (they were stored but rendered nowhere).

### Fixes (from #538 review)
- **GDPR cascade** (Greptile P1): composite FK `profile_trait_changes.(website_id, profile_id) → profiles` with `ON DELETE CASCADE`, replacing the standalone `website_id → websites` ref. Deleting a profile now takes its trait history with it.
- **First-identify race** (cubic + Greptile P1): `pg_advisory_xact_lock` on the `(websiteId, profileId)` pair at the top of the `upsertProfile` transaction (`FOR UPDATE` can't lock a not-yet-existent row). Serializes concurrent first-time identifies.

### New: expose traits + history in the users UI
- **`profiles.getHistory` RPC** — website-read-gated, returns `profile_trait_changes` newest-first (cap 200), each entry with changed keys (old/new) and the post-change snapshot. Two integration tests (ordering/shape + cross-org FORBIDDEN).
- **User detail page** — Traits section (renders stored `plan`/etc., hidden when empty) and a trait-history timeline (date, `source` badge, per-key `old → new` diffs). Desktop sidebar + mobile.
- **Users list page** — refresh button in the top bar (spins while fetching), wired to the query's `refetch`.

## Deploy notes
- Composite FK already applied to production Postgres (verified via `pg_constraint`: `on_delete: c`, 0 orphans before apply).

## Not addressed here
- `sessions.ts` CTE scan expansion (pre-existing) — separate perf PR.
- UI not yet eyeball-verified in a running renderer (dev server not started); typecheck + lint + unit tests green, integration tests run in CI.

## Testing
- monorepo typecheck 34/34, api 155/155, lint clean
- new getHistory integration tests (run in CI with Docker Postgres)