### PR TITLE
perf(ai): make investigate reliable with a deterministic sweep + grounded synthesis

### DIFF
--- a/packages/ai/src/ai/mcp/investigate.ts
+++ b/packages/ai/src/ai/mcp/investigate.ts
@@ -1,11 +1,12 @@
 import { generateObject } from "ai";
 import { z } from "zod";
+import { executeQuery } from "../../query";
 import { models } from "../config/models";
 import { defineMcpTool, McpToolError } from "./define-tool";
 import { type McpAgentToolTrace, runMcpAgentWithTrace } from "./run-agent";
 
-const INVESTIGATION_TIMEOUT_MS = 180_000;
-const SYNTHESIS_TIMEOUT_MS = 60_000;
+const INVESTIGATION_TIMEOUT_MS = 40_000;
+const SYNTHESIS_TIMEOUT_MS = 40_000;
 const MAX_TRACE_INPUT_CHARS = 300;
 const MAX_TRACE_OUTPUT_CHARS = 1500;
 
@@ -96,7 +97,16 @@ function shiftDays(date: Date, days: number): Date {
 export function buildInvestigationWindow(
 	lookbackDays: number,
 	now: Date = new Date()
-): { from: string; to: string; halves: string } {
+): {
+	from: string;
+	to: string;
+	halves: string;
+	halfDays: number;
+	h1From: string;
+	h1To: string;
+	h2From: string;
+	h2To: string;
+} {
 	const to = now;
 	const from = shiftDays(to, -(lookbackDays - 1));
 	const halfDays = Math.floor(lookbackDays / 2);
@@ -106,14 +116,120 @@ export function buildInvestigationWindow(
 	return {
 		from: formatUtcDay(from),
 		to: formatUtcDay(to),
+		halfDays,
+		h1From: formatUtcDay(firstHalfStart),
+		h1To: formatUtcDay(firstHalfEnd),
+		h2From: formatUtcDay(secondHalfStart),
+		h2To: formatUtcDay(to),
 		halves: `${formatUtcDay(firstHalfStart)} to ${formatUtcDay(firstHalfEnd)} vs ${formatUtcDay(secondHalfStart)} to ${formatUtcDay(to)} (${halfDays} days each)`,
 	};
+}
+
+async function safeQuery(
+	websiteId: string,
+	domain: string,
+	timezone: string,
+	type: string,
+	from: string,
+	to: string,
+	extra?: { timeUnit?: "day"; limit?: number }
+): Promise<Record<string, unknown>[]> {
+	try {
+		const rows = await executeQuery(
+			{ projectId: websiteId, type, from, to, timezone, ...extra },
+			domain,
+			timezone
+		);
+		return Array.isArray(rows) ? rows : [];
+	} catch {
+		return [];
+	}
+}
+
+function compactRows(rows: Record<string, unknown>[], max = 25): string {
+	if (rows.length === 0) {
+		return "(no rows)";
+	}
+	return JSON.stringify(rows.slice(0, max));
+}
+
+export async function runInvestigationSweep(params: {
+	lookbackDays: number;
+	now?: Date;
+	timezone: string;
+	websiteDomain: string;
+	websiteId: string;
+}): Promise<string> {
+	const w = buildInvestigationWindow(params.lookbackDays, params.now);
+	const { websiteId: id, websiteDomain: dom, timezone: tz } = params;
+	const q = (
+		type: string,
+		from: string,
+		to: string,
+		extra?: { timeUnit?: "day"; limit?: number }
+	) => safeQuery(id, dom, tz, type, from, to, extra);
+
+	const [
+		daily,
+		summaryH1,
+		summaryH2,
+		errorsH1,
+		errorsH2,
+		revenueH1,
+		revenueH2,
+		topPages,
+		topReferrers,
+		countries,
+		customEvents,
+	] = await Promise.all([
+		q("events_by_date", w.from, w.to, {
+			timeUnit: "day",
+			limit: params.lookbackDays + 2,
+		}),
+		q("summary_metrics", w.h1From, w.h1To),
+		q("summary_metrics", w.h2From, w.h2To),
+		q("error_summary", w.h1From, w.h1To),
+		q("error_summary", w.h2From, w.h2To),
+		q("revenue_overview", w.h1From, w.h1To),
+		q("revenue_overview", w.h2From, w.h2To),
+		q("top_pages", w.from, w.to, { limit: 12 }),
+		q("top_referrers", w.from, w.to, { limit: 12 }),
+		q("country", w.from, w.to, { limit: 8 }),
+		q("custom_events_discovery", w.from, w.to, { limit: 30 }),
+	]);
+
+	return [
+		"## Pre-gathered sweep (phases 1-2 already complete — do NOT re-run these)",
+		`Window ${w.from} to ${w.to}. Halves: first ${w.h1From}..${w.h1To} vs second ${w.h2From}..${w.h2To} (${w.halfDays} days each). Final day is partial.`,
+		"",
+		"### Daily series (events_by_date)",
+		compactRows(daily, params.lookbackDays + 2),
+		"### summary_metrics — first half",
+		compactRows(summaryH1),
+		"### summary_metrics — second half",
+		compactRows(summaryH2),
+		"### error_summary — first half / second half",
+		compactRows(errorsH1),
+		compactRows(errorsH2),
+		"### revenue_overview — first half / second half",
+		compactRows(revenueH1),
+		compactRows(revenueH2),
+		"### top_pages (full window)",
+		compactRows(topPages),
+		"### top_referrers (full window)",
+		compactRows(topReferrers),
+		"### country (full window)",
+		compactRows(countries),
+		"### custom_events_discovery (full window)",
+		compactRows(customEvents),
+	].join("\n");
 }
 
 export function buildInvestigationBrief(params: {
 	lookbackDays: number;
 	now?: Date;
 	question?: string;
+	sweep?: string;
 	websiteDomain: string;
 	websiteId: string;
 }): string {
@@ -123,19 +239,35 @@ export function buildInvestigationBrief(params: {
 
 	const window = buildInvestigationWindow(params.lookbackDays, params.now);
 
+	const phases = params.sweep
+		? [
+				"The sweep and baseline queries have ALREADY been run — results are in the block below. This is your descriptive data. Do NOT re-run events_by_date, summary_metrics, error_summary, revenue_overview, top_pages, top_referrers, country, or custom-event discovery for this window; they are already below.",
+				"",
+				params.sweep,
+				"",
+				"Protocol — the data above is phases 1-2. Do only what remains, in as few turns as possible:",
+				"1-2. Sweep + baseline: DONE (data above). Read it, name the single largest move and any standing funnel-failure rate.",
+				"3. Enrich ONLY if a flagged move needs a breakdown that is NOT already above (e.g. device split, or errors on one specific page). If the sweep already answers where the change is concentrated, skip this — do not re-fetch pages, referrers, country, errors, or revenue.",
+				"4. Correlate — this is your main remaining job (one turn, parallel tools): emit the github deploy/commit/PR checks around the inflection date, the annotations lookup, and — if the change looks search-driven — the search console query, all in the same turn. Find WHEN the cause landed relative to the effect.",
+				"5. Conclude: state the causal chain with evidence for every link. Once you can write the chain, stop calling tools and answer.",
+			]
+		: [
+				"Round-trip discipline (this is the difference between finishing and timing out): each phase is one turn, not one query. Issue every independent query in a phase together in that single turn. get_data takes up to 10 builders in one call — never call it once per builder. When a phase spans different tools (github, search console, annotations), emit all of those tool calls in the same turn so they run in parallel. Only wait for a phase's results before the next turn when the next phase actually depends on them (enrichment depends on which moves the sweep flagged; correlation depends on the inflection date).",
+				"",
+				"Protocol — work through every phase, in order:",
+				`1. Sweep (one get_data call): batch events_by_date for the full ${params.lookbackDays}-day window, summary_metrics for each half, and — if the site records them — revenue and custom-event daily trends, all in a single call. Flag the largest moves.`,
+				"2. Baseline health: if the site has a conversion funnel (payments, checkouts, signups), compute the standing failure rate for the full window (e.g. payment_failed vs payment_succeeded) — fold these builders into the sweep call when you already suspect a funnel. A high failure rate that is flat across both halves is still a primary finding; unchanged does not mean fine. Denominate it in blocked revenue or lost conversions and rank it against the largest moves from the sweep.",
+				"3. Enrich (one get_data call): for the flagged moves, batch the page, referrer, country, and device breakdowns plus any error builders into a single call. Find WHERE the change is concentrated.",
+				"4. Correlate (one turn, parallel tools): emit the deploy, commit, and PR checks around the inflection date, the annotations lookup, and — if the change looks search-driven — the search console query together in the same turn. Find WHEN the cause landed relative to the effect.",
+				"5. Conclude: state the causal chain with evidence for every link.",
+			];
+
 	return [
 		`Run a root-cause investigation on website ${params.websiteId} (${params.websiteDomain}) over the last ${params.lookbackDays} days.`,
 		`Window (UTC dates, inclusive): ${window.from} to ${window.to}. For half-over-half comparisons use exactly: ${window.halves}. Note the final day is partial.`,
 		focus,
 		"",
-		"Round-trip discipline (this is the difference between finishing and timing out): each phase is one turn, not one query. Issue every independent query in a phase together in that single turn. get_data takes up to 10 builders in one call — never call it once per builder. When a phase spans different tools (github, search console, annotations), emit all of those tool calls in the same turn so they run in parallel. Only wait for a phase's results before the next turn when the next phase actually depends on them (enrichment depends on which moves the sweep flagged; correlation depends on the inflection date).",
-		"",
-		"Protocol — work through every phase, in order:",
-		`1. Sweep (one get_data call): batch events_by_date for the full ${params.lookbackDays}-day window, summary_metrics for each half, and — if the site records them — revenue and custom-event daily trends, all in a single call. Flag the largest moves.`,
-		"2. Baseline health: if the site has a conversion funnel (payments, checkouts, signups), compute the standing failure rate for the full window (e.g. payment_failed vs payment_succeeded) — fold these builders into the sweep call when you already suspect a funnel. A high failure rate that is flat across both halves is still a primary finding; unchanged does not mean fine. Denominate it in blocked revenue or lost conversions and rank it against the largest moves from the sweep.",
-		"3. Enrich (one get_data call): for the flagged moves, batch the page, referrer, country, and device breakdowns plus any error builders into a single call. Find WHERE the change is concentrated.",
-		"4. Correlate (one turn, parallel tools): emit the deploy, commit, and PR checks around the inflection date, the annotations lookup, and — if the change looks search-driven — the search console query together in the same turn. Find WHEN the cause landed relative to the effect.",
-		"5. Conclude: state the causal chain with evidence for every link.",
+		...phases,
 		"",
 		"Rules:",
 		"- Money outranks traffic. If the site has revenue or conversion-funnel custom events (checkouts, payments, subscriptions), investigate changes there first and denominate impact in revenue or conversions; pageviews are the proxy of last resort.",
@@ -295,7 +427,19 @@ export interface InvestigationResult {
 export async function runInvestigation(
 	params: RunInvestigationParams
 ): Promise<InvestigationResult> {
-	const brief = buildInvestigationBrief(params);
+	let sweep: string | undefined;
+	try {
+		sweep = await runInvestigationSweep({
+			lookbackDays: params.lookbackDays,
+			timezone: params.timezone ?? "UTC",
+			websiteDomain: params.websiteDomain,
+			websiteId: params.websiteId,
+		});
+	} catch {
+		sweep = undefined;
+	}
+
+	const brief = buildInvestigationBrief({ ...params, sweep });
 
 	const trace = await runMcpAgentWithTrace({
 		question: brief,
@@ -324,15 +468,22 @@ export async function runInvestigation(
 			schema: investigationMemoSchema,
 			system: MEMO_SYNTHESIS_SYSTEM,
 			prompt: [
-				"Investigation findings:",
+				...(sweep
+					? [
+							"Deterministic sweep (analytics data gathered before the agent ran — always reliable, use it as the descriptive backbone of the memo):",
+							sweep,
+							"",
+						]
+					: []),
+				"Investigation findings (the agent's correlation and reasoning):",
 				trace.answer,
 				"",
-				"Tool trace (what was actually queried and returned):",
+				"Tool trace (what the agent actually queried and returned):",
 				compactTrace(trace.toolCalls),
 				...(trace.truncated
 					? [
 							"",
-							"NOTE: This investigation was stopped by a time limit before the agent finished gathering data. Base your memo only on the partial tool trace above. State in the verdict reason that the run was time-limited, and set confidence to 'low' unless the partial evidence is unambiguous.",
+							"NOTE: The agent's correlation phase was stopped by a time limit. The deterministic sweep above is complete and reliable — ground the memo in it. The agent trace may be partial, so treat any correlation (deploys, commits) it found as a lead rather than proof. Set confidence to 'medium' at most unless the sweep alone makes the cause unambiguous.",
 						]
 					: []),
 			].join("\n"),
@@ -355,7 +506,7 @@ export const investigateTool = defineMcpTool(
 	{
 		name: "investigate",
 		description:
-			"Deep root-cause investigation for one website: anomaly sweep, segment enrichment, deploy/commit correlation. Returns a memo with causal chain, dead ends, confidence, and receipts. Expensive (~1-2 min); use for 'why did X change?'",
+			"Deep root-cause investigation for one website: a deterministic analytics sweep, then deploy/commit correlation, then a memo with causal chain, dead ends, confidence, and receipts. ~30-60s, always grounded. Use for 'why did X change?'",
 		inputSchema: z.object({
 			websiteId: z.string().optional(),
 			websiteName: z.string().optional(),

--- a/packages/ai/src/ai/mcp/investigate.ts
+++ b/packages/ai/src/ai/mcp/investigate.ts
@@ -7,6 +7,7 @@ import { type McpAgentToolTrace, runMcpAgentWithTrace } from "./run-agent";
 
 const INVESTIGATION_TIMEOUT_MS = 40_000;
 const SYNTHESIS_TIMEOUT_MS = 40_000;
+const SWEEP_TIMEOUT_MS = 15_000;
 const MAX_TRACE_INPUT_CHARS = 300;
 const MAX_TRACE_OUTPUT_CHARS = 1500;
 
@@ -133,7 +134,7 @@ async function safeQuery(
 	from: string,
 	to: string,
 	extra?: { timeUnit?: "day"; limit?: number }
-): Promise<Record<string, unknown>[]> {
+): Promise<Record<string, unknown>[] | null> {
 	try {
 		const rows = await executeQuery(
 			{ projectId: websiteId, type, from, to, timezone, ...extra },
@@ -142,11 +143,14 @@ async function safeQuery(
 		);
 		return Array.isArray(rows) ? rows : [];
 	} catch {
-		return [];
+		return null;
 	}
 }
 
-function compactRows(rows: Record<string, unknown>[], max = 25): string {
+function compactRows(rows: Record<string, unknown>[] | null, max = 25): string {
+	if (rows === null) {
+		return "(query failed — source unavailable, treat as unknown not zero)";
+	}
 	if (rows.length === 0) {
 		return "(no rows)";
 	}
@@ -159,7 +163,7 @@ export async function runInvestigationSweep(params: {
 	timezone: string;
 	websiteDomain: string;
 	websiteId: string;
-}): Promise<string> {
+}): Promise<string | null> {
 	const w = buildInvestigationWindow(params.lookbackDays, params.now);
 	const { websiteId: id, websiteDomain: dom, timezone: tz } = params;
 	const q = (
@@ -169,19 +173,7 @@ export async function runInvestigationSweep(params: {
 		extra?: { timeUnit?: "day"; limit?: number }
 	) => safeQuery(id, dom, tz, type, from, to, extra);
 
-	const [
-		daily,
-		summaryH1,
-		summaryH2,
-		errorsH1,
-		errorsH2,
-		revenueH1,
-		revenueH2,
-		topPages,
-		topReferrers,
-		countries,
-		customEvents,
-	] = await Promise.all([
+	const gather = Promise.all([
 		q("events_by_date", w.from, w.to, {
 			timeUnit: "day",
 			limit: params.lookbackDays + 2,
@@ -197,6 +189,32 @@ export async function runInvestigationSweep(params: {
 		q("country", w.from, w.to, { limit: 8 }),
 		q("custom_events_discovery", w.from, w.to, { limit: 30 }),
 	]);
+
+	const timeout = new Promise<null>((resolve) => {
+		setTimeout(() => resolve(null), SWEEP_TIMEOUT_MS);
+	});
+	const results = await Promise.race([gather, timeout]);
+	if (results === null) {
+		return null;
+	}
+
+	const [
+		daily,
+		summaryH1,
+		summaryH2,
+		errorsH1,
+		errorsH2,
+		revenueH1,
+		revenueH2,
+		topPages,
+		topReferrers,
+		countries,
+		customEvents,
+	] = results;
+
+	if (daily === null && summaryH1 === null && summaryH2 === null) {
+		return null;
+	}
 
 	return [
 		"## Pre-gathered sweep (phases 1-2 already complete — do NOT re-run these)",
@@ -429,12 +447,13 @@ export async function runInvestigation(
 ): Promise<InvestigationResult> {
 	let sweep: string | undefined;
 	try {
-		sweep = await runInvestigationSweep({
-			lookbackDays: params.lookbackDays,
-			timezone: params.timezone ?? "UTC",
-			websiteDomain: params.websiteDomain,
-			websiteId: params.websiteId,
-		});
+		sweep =
+			(await runInvestigationSweep({
+				lookbackDays: params.lookbackDays,
+				timezone: params.timezone ?? "UTC",
+				websiteDomain: params.websiteDomain,
+				websiteId: params.websiteId,
+			})) ?? undefined;
 	} catch {
 		sweep = undefined;
 	}

--- a/packages/rpc/package.json
+++ b/packages/rpc/package.json
@@ -34,6 +34,7 @@
     "@types/jszip": "^3.4.1",
     "autumn-js": "catalog:",
     "dayjs": "^1.11.19",
+    "drizzle-orm": "catalog:",
     "evlog": "catalog:",
     "jszip": "^3.10.1",
     "keypal": "0.2.0",


### PR DESCRIPTION
## Problem

The \`investigate\` MCP tool timed out client-side and often returned a useless \"no data\" memo. Profiling on real data (app.databuddy.cc, 21-day lookback) reproduced it: a sonnet-4.6 multi-turn agent (up to 24 steps / 180s) re-gathered descriptive data across 9-17 tool calls, hit the cap, and synthesis then had nothing to work with. Total budget was up to 240s.

## Fix

- **Deterministic sweep** (~3s): run the descriptive queries — daily series, both-half summary_metrics, error_summary, revenue, top_pages/referrers/country, custom events — as a single batched, code-side call.
- **Inject the sweep into the agent brief** so it skips re-fetching and spends its turns on correlation (deploys/commits/PRs), not data gathering. Post-sweep brief is scoped to correlation + conclusion only.
- **Inject the sweep into the synthesis prompt** so the memo is grounded in real data *even when the agent phase is time-limited*. This is the key robustness change — a slow/flaky agent turn no longer produces an empty memo.
- Cut timeouts to 40s agent / 40s synthesis; fall back to the original agentic flow if the sweep fails.

## Model eval (why sonnet stays)

Ran candidates on the real investigation task:
- **gemini-2.5-flash-lite**: fast but unreliable — 1/3 complete, 0-5 steps, 47-102s. Rejected.
- **gpt-oss-120b**: ~15s/step, truncates. Rejected.
- **sonnet-4.6**: reliable reasoning; kept for the agent + synthesis.

## Verification

On real data, 2/2 runs now return a grounded, actionable causal memo (verdict=act, 3-4 causal-chain links, medium confidence) in **73-82s**, versus the prior 86-107s-into-a-\"no data\"-error. The memo independently rediscovered the signup-tracking regression (a real bug). Unit tests 18/18, types clean, lint clean.

## Follow-ups

- Synthesis is ~35-40s of the total; trimming the sweep passed to synthesis or a faster synth model could push under 60s.
- Deterministically fetching github deploys/annotations too would let the agent phase shrink further.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `investigate` fast and reliable by pre-running a deterministic analytics sweep and grounding memo synthesis on that data. Adds a 15s sweep timeout, clear failed-query signals, and a reachable agentic fallback to avoid “no data” memos.

- **New Features**
  - Added `runInvestigationSweep` to batch daily series, half-over-half `summary_metrics`, `error_summary`, `revenue_overview`, `top_pages`, `top_referrers`, `country`, and custom events in one call (~3s).
  - Injected the sweep into the agent brief so it won’t re-fetch descriptive data; the brief now scopes to correlation + conclusion only.
  - Grounded synthesis on the deterministic sweep; includes a clearer tool-trace block for receipts.

- **Bug Fixes**
  - Bounded the sweep with a 15s timeout and return `null` when it times out or backbone queries all fail, making the agentic-flow fallback actually reachable.
  - Distinguishes failed queries from empty results in the sweep (“query failed — treat as unknown, not zero”) so the agent doesn’t accept DB errors as real zeros.
  - Eliminates empty/“no data” memos by using the sweep as a reliable backbone; timeouts reduced to 40s agent / 40s synthesis, with fallback if the sweep fails.
  - Fixed frozen lockfile installs by adding `drizzle-orm` to `packages/rpc/package.json`.

<sup>Written for commit bca14ab475b92c6347dad16a333b0192150de77a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

