### PR TITLE
fix(observability): stop local dev from polluting prod Axiom datasets

### DIFF
--- a/apps/api/src/lib/evlog-api.ts
+++ b/apps/api/src/lib/evlog-api.ts
@@ -30,6 +30,8 @@ const devFsLogsDir = join(
 const useLocalEvlogFiles =
 	process.env.NODE_ENV === "development" || readBooleanEnv("API_EVLOG_FS");
 
+const drainToAxiom = process.env.NODE_ENV !== "development";
+
 const devFsDrain = useLocalEvlogFiles
 	? createFsDrain({ dir: devFsLogsDir, pretty: false })
 	: null;
@@ -93,7 +95,9 @@ export async function apiLoggerDrain(ctx: DrainContext): Promise<void> {
 	if (devFsDrain) {
 		await devFsDrain(ctx);
 	}
-	batchedAxiomDrain(ctx);
+	if (drainToAxiom) {
+		batchedAxiomDrain(ctx);
+	}
 	batchedSuperlogDrain?.(ctx);
 }
 

--- a/apps/basket/src/lib/evlog-basket.ts
+++ b/apps/basket/src/lib/evlog-basket.ts
@@ -30,6 +30,8 @@ const devFsLogsDir = join(
 const useLocalEvlogFiles =
 	process.env.NODE_ENV === "development" || readBooleanEnv("BASKET_EVLOG_FS");
 
+const drainToAxiom = process.env.NODE_ENV !== "development";
+
 const devFsDrain = useLocalEvlogFiles
 	? createFsDrain({ dir: devFsLogsDir, pretty: false })
 	: null;
@@ -86,7 +88,9 @@ export async function basketLoggerDrain(ctx: DrainContext): Promise<void> {
 	if (devFsDrain) {
 		await devFsDrain(ctx);
 	}
-	batchedAxiomDrain(ctx);
+	if (drainToAxiom) {
+		batchedAxiomDrain(ctx);
+	}
 	batchedSuperlogDrain?.(ctx);
 }
 

--- a/apps/insights/src/lib/evlog-insights.ts
+++ b/apps/insights/src/lib/evlog-insights.ts
@@ -24,15 +24,16 @@ const pipeline = createDrainPipeline<DrainContext>({
 	maxBufferSize: 2000,
 });
 
-const batchedAxiomDrain = axiomApiKey
-	? pipeline(
-			createAxiomDrain({
-				apiKey: axiomApiKey,
-				dataset: env.INSIGHTS_AXIOM_DATASET,
-				...(env.AXIOM_ORG_ID ? { orgId: env.AXIOM_ORG_ID } : {}),
-			})
-		)
-	: null;
+const batchedAxiomDrain =
+	axiomApiKey && env.NODE_ENV !== "development"
+		? pipeline(
+				createAxiomDrain({
+					apiKey: axiomApiKey,
+					dataset: env.INSIGHTS_AXIOM_DATASET,
+					...(env.AXIOM_ORG_ID ? { orgId: env.AXIOM_ORG_ID } : {}),
+				})
+			)
+		: null;
 
 const batchedSuperlogDrain = createBatchedSuperlogDrain();
 

--- a/apps/slack/src/lib/evlog-slack.ts
+++ b/apps/slack/src/lib/evlog-slack.ts
@@ -17,18 +17,19 @@ const activeSlackLog = new AsyncLocalStorage<RequestLogger>();
 
 const axiomApiKey = env.AXIOM_API_KEY ?? env.AXIOM_TOKEN;
 
-const batchedAxiomDrain = axiomApiKey
-	? createDrainPipeline<DrainContext>({
-			batch: { size: 50, intervalMs: 5000 },
-			maxBufferSize: 2000,
-		})(
-			createAxiomDrain({
-				apiKey: axiomApiKey,
-				dataset: env.SLACK_AXIOM_DATASET,
-				...(env.AXIOM_ORG_ID ? { orgId: env.AXIOM_ORG_ID } : {}),
-			})
-		)
-	: null;
+const batchedAxiomDrain =
+	axiomApiKey && env.NODE_ENV !== "development"
+		? createDrainPipeline<DrainContext>({
+				batch: { size: 50, intervalMs: 5000 },
+				maxBufferSize: 2000,
+			})(
+				createAxiomDrain({
+					apiKey: axiomApiKey,
+					dataset: env.SLACK_AXIOM_DATASET,
+					...(env.AXIOM_ORG_ID ? { orgId: env.AXIOM_ORG_ID } : {}),
+				})
+			)
+		: null;
 
 const batchedSuperlogDrain = createBatchedSuperlogDrain();
 

--- a/apps/uptime/src/lib/evlog-uptime.ts
+++ b/apps/uptime/src/lib/evlog-uptime.ts
@@ -30,6 +30,8 @@ const devFsLogsDir = join(
 const useLocalEvlogFiles =
 	process.env.NODE_ENV === "development" || readBooleanEnv("UPTIME_EVLOG_FS");
 
+const drainToAxiom = process.env.NODE_ENV !== "development";
+
 const devFsDrain = useLocalEvlogFiles
 	? createFsDrain({ dir: devFsLogsDir, pretty: false })
 	: null;
@@ -82,7 +84,9 @@ export async function uptimeLoggerDrain(ctx: DrainContext): Promise<void> {
 	if (devFsDrain) {
 		await devFsDrain(ctx);
 	}
-	batchedAxiomDrain(ctx);
+	if (drainToAxiom) {
+		batchedAxiomDrain(ctx);
+	}
 	batchedSuperlogDrain?.(ctx);
 }
 


### PR DESCRIPTION
## Problem
Every service's evlog→Axiom drain ran in development too, so local dev shipped wide events to the **production** Axiom datasets:
- `api`, `basket`, `uptime`: called `batchedAxiomDrain(ctx)` unconditionally.
- `insights`, `slack`: gated only on the Axiom key being present — which a local `.env` usually has.

**Impact, observed:** the Jul 3–4 "5,856 api server errors on deploy day" was 100% `environment: "development"` — local Bun `Cannot find module '@databuddy/services/...'` failures from unbuilt workspace packages. Production errors stayed flat (785→498→200→single digits). Dev noise outweighed real prod errors >4:1 in the shared dataset, so error-rate views (and any alert built on them) misread it as a production incident.

## Fix
Gate the Axiom drain on `NODE_ENV !== "development"` in all five services. Dev still writes to local FS logs (`.evlog/logs`); prod behavior is unchanged.

## Verification
`check-types` green for all five apps; lint clean. Behavioral: in dev the drain is now a no-op/null; prod path untouched.

## Follow-up (separate)
Consider centralizing this in a shared `createAxiomDrain` wrapper so new services can't reintroduce the leak.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop local development from draining telemetry to the production Axiom datasets. This removes dev noise from prod metrics and alerts; production behavior is unchanged.

- **Bug Fixes**
  - Gate the Axiom drain on `NODE_ENV !== "development"` across `api`, `basket`, `insights`, `slack`, and `uptime`.
  - In development, logs write to local `.evlog` files only; in production, the Axiom drain runs as before.

<sup>Written for commit 7fab18d89de1e4af28b11fd5f6b3682d7a4cbce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

