### PR TITLE
fix(slack): restore the crash-looping slack service (resvg needs libgcc in distroless)

### DIFF
--- a/slack.Dockerfile
+++ b/slack.Dockerfile
@@ -39,6 +39,11 @@ WORKDIR /app
 
 COPY --from=builder /app/server server
 
+# @databuddy/charts loads @resvg/resvg-js (a Rust native addon) at startup for
+# server-side chart PNGs; its .node binary dlopens libgcc_s.so.1, which the
+# distroless runtime omits. Bring it over from the Debian-based builder stage.
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgcc_s.so.1 /usr/lib/x86_64-linux-gnu/libgcc_s.so.1
+
 ENV NODE_ENV=production
 
 EXPOSE 3010


### PR DESCRIPTION
## Prod down since ~Jul 4
The slack service crashes at **startup** and has emitted nothing to its Axiom `slack` dataset since Jul 4 (last event 2026-07-04). Root cause from the Railway crash log:

```
error: libgcc_s.so.1: cannot open shared object file: No such file or directory
 code: "ERR_DLOPEN_FAILED"
   at packages/ai/src/agent/index.ts:27  (re-exports charts)
   at @resvg/resvg-js
   at packages/charts/src/index.ts:4
```

`@databuddy/charts` (only slack depends on it) imports `@resvg/resvg-js`, a Rust native addon for server-side chart PNGs. Its `.node` binary `dlopen`s `libgcc_s.so.1` at load. The runtime stage in `slack.Dockerfile` is `oven/bun:1.3.14-distroless`, which strips system shared libs — so the lib is missing and the whole module graph fails to load, crash-looping before any request. Timing matches the chart-PNG feature shipping ~Jul 4.

## Fix
Copy `libgcc_s.so.1` from the Debian-based builder stage into the distroless runtime. Preserves the distroless image; adds only the one missing lib the crash names.

## Verification / caveat
Root cause is confirmed from the live crash log. I **can't deploy-test from here** — final proof is a Railway deploy that boots and starts logging to the `slack` dataset again. resvg (a Rust cdylib) needs `libgcc_s` for unwinding and otherwise relies on glibc (present in distroless), so this one lib should suffice. If a further lib turns up missing, the fallback is switching the runtime stage to `oven/bun:1.3.14-slim`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Slack service crash-loop by adding `libgcc_s.so.1` to the distroless runtime so `@resvg/resvg-js` loads at startup. Restores server-side chart PNGs and lets Slack boot and log again.

- **Bug Fixes**
  - Copy `libgcc_s.so.1` from the Debian-based builder into `/usr/lib/x86_64-linux-gnu/` in the runtime via `slack.Dockerfile`.
  - Keep `oven/bun:1.3.14-distroless`; no other changes.

<sup>Written for commit b3fb08d4e29cca71b4fa5d0b58d492b11e710d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/547?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

