### PR TITLE
feat(docs): add Founding Engineer and SDR openings to careers

### DIFF
--- a/apps/docs/app/(home)/careers/careers-hero.tsx
+++ b/apps/docs/app/(home)/careers/careers-hero.tsx
@@ -50,9 +50,9 @@ export default function CareersHero() {
 						</span>
 					</h1>
 					<p className="mx-auto max-w-3xl text-balance font-medium text-muted-foreground text-sm leading-relaxed tracking-tight sm:text-base lg:text-lg">
-						We're a small, remote team building Databuddy in the open. We don't
-						have a recruiting pipeline and we hire rarely, but we always want to
-						hear from sharp builders who care about the same things we do.
+						We're a small, remote team building Databuddy in the open. We're
+						hiring a Founding Engineer and an SDR — and we still want to hear
+						from sharp builders who care about privacy-first analytics.
 					</p>
 				</div>
 

--- a/apps/docs/app/(home)/careers/careers-openings-data.ts
+++ b/apps/docs/app/(home)/careers/careers-openings-data.ts
@@ -1,15 +1,15 @@
-export type CareerOpening = {
-	id: string;
-	title: string;
-	type: string;
-	location: string;
-	summary: string;
-	responsibilities: string[];
-	requirements: string[];
-	niceToHaves: string[];
+export interface CareerOpening {
 	applyHref: string;
 	applyLabel: string;
-};
+	id: string;
+	location: string;
+	niceToHaves: string[];
+	requirements: string[];
+	responsibilities: string[];
+	summary: string;
+	title: string;
+	type: string;
+}
 
 export const careerOpenings: CareerOpening[] = [
 	{

--- a/apps/docs/app/(home)/careers/careers-openings-data.ts
+++ b/apps/docs/app/(home)/careers/careers-openings-data.ts
@@ -1,0 +1,76 @@
+export type CareerOpening = {
+	id: string;
+	title: string;
+	type: string;
+	location: string;
+	summary: string;
+	responsibilities: string[];
+	requirements: string[];
+	niceToHaves: string[];
+	applyHref: string;
+	applyLabel: string;
+};
+
+export const careerOpenings: CareerOpening[] = [
+	{
+		id: "founding-engineer",
+		title: "Founding Engineer",
+		type: "Full-time",
+		location: "Remote",
+		summary:
+			"Help own the core product with the founders. You'll ship across the TypeScript monorepo — dashboard, API, ingestion, and analytics warehouse — and make real architecture calls while the company is still small.",
+		responsibilities: [
+			"Ship end-to-end features across Next.js, Elysia, Drizzle, ClickHouse, and Redis",
+			"Own problems from product question to production: schema, API, UI, and observability",
+			"Tighten ingestion, query performance, and reliability as volume grows",
+			"Review PRs hard, keep the codebase simple, and raise the bar for everyone else",
+			"Talk directly with users when something breaks or a design decision needs a sharp edge",
+		],
+		requirements: [
+			"Strong TypeScript and comfort across full-stack web systems",
+			"Experience shipping production SaaS, developer tools, or data products",
+			"Solid judgment on SQL, APIs, and performance — not just framework familiarity",
+			"Bias toward small PRs, clear writing, and deleting complexity",
+			"Happy working async and remote with a tiny team",
+		],
+		niceToHaves: [
+			"ClickHouse, analytics pipelines, or high-volume event ingestion",
+			"Open-source contributions or public technical writing",
+			"Prior founding / early-stage engineer experience",
+			"Interest in privacy, GDPR, or cookieless analytics",
+		],
+		applyHref:
+			"mailto:support@databuddy.cc?subject=Founding%20Engineer%20Application%20%E2%80%94%20Databuddy",
+		applyLabel: "Apply for Founding Engineer",
+	},
+	{
+		id: "sdr",
+		title: "Sales Development Representative",
+		type: "Full-time",
+		location: "Remote",
+		summary:
+			"Own outbound and inbound qualification for Databuddy. You'll find teams that care about privacy-first analytics, start the conversation, and book qualified demos for the founders.",
+		responsibilities: [
+			"Run outbound sequences across email, LinkedIn, and warm intros",
+			"Qualify inbound interest and book demos with decision-makers",
+			"Keep a clean pipeline in our CRM and report weekly on activity and conversion",
+			"Learn the product well enough to speak clearly about privacy, performance, and pricing",
+			"Feed product and marketing with real objections, competitor notes, and win/loss signal",
+		],
+		requirements: [
+			"1+ years in SDR, BDR, or similar outbound sales at a B2B SaaS company",
+			"Comfortable writing concise cold outreach that sounds human",
+			"Organized enough to run high volume without dropping follow-ups",
+			"Clear written and spoken English",
+			"Excited about developer tools, analytics, or privacy tech",
+		],
+		niceToHaves: [
+			"Experience selling to founders, growth, or engineering buyers",
+			"Familiarity with privacy, GDPR, or cookieless analytics",
+			"Prior work at an early-stage startup where you wore more than one hat",
+		],
+		applyHref:
+			"mailto:support@databuddy.cc?subject=SDR%20Application%20%E2%80%94%20Databuddy",
+		applyLabel: "Apply for SDR",
+	},
+];

--- a/apps/docs/app/(home)/careers/careers-openings.tsx
+++ b/apps/docs/app/(home)/careers/careers-openings.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+type IconWeight = "regular" | "bold" | "fill" | "duotone";
+
+import { CodeIcon, TargetIcon } from "@databuddy/ui/icons";
+import { SciFiButton } from "@/components/landing/scifi-btn";
+import { SciFiCard } from "@/components/scifi-card";
+import {
+	type CareerOpening,
+	careerOpenings,
+} from "./careers-openings-data";
+
+const openingIcons: Record<
+	string,
+	React.ComponentType<{ className?: string; weight?: IconWeight }>
+> = {
+	"founding-engineer": CodeIcon,
+	sdr: TargetIcon,
+};
+
+function BulletList({ items, title }: { items: string[]; title: string }) {
+	return (
+		<div>
+			<h4 className="mb-2 font-semibold text-foreground text-sm">{title}</h4>
+			<ul className="space-y-2">
+				{items.map((item) => (
+					<li
+						className="flex gap-2 text-pretty text-muted-foreground text-sm leading-relaxed"
+						key={item}
+					>
+						<span
+							aria-hidden
+							className="mt-2 size-1 shrink-0 rounded bg-foreground/40"
+						/>
+						<span>{item}</span>
+					</li>
+				))}
+			</ul>
+		</div>
+	);
+}
+
+function OpeningCard({ opening }: { opening: CareerOpening }) {
+	const Icon = openingIcons[opening.id] ?? CodeIcon;
+
+	return (
+		<SciFiCard variant="primary">
+			<article className="relative rounded border border-primary/50 bg-primary/5 p-6 backdrop-blur-sm transition-all duration-300 hover:border-border/80 hover:bg-card/70 sm:p-8">
+				<div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
+					<div className="flex items-start gap-3">
+						<Icon
+							className="mt-0.5 size-8 shrink-0 text-primary"
+							weight="duotone"
+						/>
+						<div>
+							<h3 className="text-balance font-semibold text-foreground text-xl sm:text-2xl">
+								{opening.title}
+							</h3>
+							<p className="mt-1 text-muted-foreground text-sm tabular-nums">
+								{opening.type} · {opening.location}
+							</p>
+						</div>
+					</div>
+					<SciFiButton asChild>
+						<a href={opening.applyHref}>{opening.applyLabel}</a>
+					</SciFiButton>
+				</div>
+
+				<p className="mb-8 max-w-3xl text-pretty text-muted-foreground text-sm leading-relaxed sm:text-base">
+					{opening.summary}
+				</p>
+
+				<div className="grid grid-cols-1 gap-8 lg:grid-cols-3">
+					<BulletList items={opening.responsibilities} title="What you'll do" />
+					<BulletList
+						items={opening.requirements}
+						title="What we're looking for"
+					/>
+					<BulletList items={opening.niceToHaves} title="Nice to have" />
+				</div>
+			</article>
+		</SciFiCard>
+	);
+}
+
+export default function CareersOpenings() {
+	return (
+		<div>
+			<div className="mb-12 text-center">
+				<h2 className="mb-4 text-balance font-semibold text-2xl sm:text-3xl lg:text-4xl">
+					Open roles
+				</h2>
+				<p className="mx-auto max-w-2xl text-pretty text-muted-foreground text-sm sm:text-base lg:text-lg">
+					{careerOpenings.length === 1
+						? "One opening right now. If it fits, apply directly."
+						: "Current openings. If one fits, apply directly."}
+				</p>
+			</div>
+
+			<div className="space-y-6">
+				{careerOpenings.map((opening) => (
+					<OpeningCard key={opening.id} opening={opening} />
+				))}
+			</div>
+		</div>
+	);
+}

--- a/apps/docs/app/(home)/careers/careers-openings.tsx
+++ b/apps/docs/app/(home)/careers/careers-openings.tsx
@@ -5,10 +5,7 @@ type IconWeight = "regular" | "bold" | "fill" | "duotone";
 import { CodeIcon, TargetIcon } from "@databuddy/ui/icons";
 import { SciFiButton } from "@/components/landing/scifi-btn";
 import { SciFiCard } from "@/components/scifi-card";
-import {
-	type CareerOpening,
-	careerOpenings,
-} from "./careers-openings-data";
+import { type CareerOpening, careerOpenings } from "./careers-openings-data";
 
 const openingIcons: Record<
 	string,

--- a/apps/docs/app/(home)/careers/careers-paths.tsx
+++ b/apps/docs/app/(home)/careers/careers-paths.tsx
@@ -45,9 +45,9 @@ const paths: Path[] = [
 	{
 		icon: EnvelopeSimpleIcon,
 		title: "Pitch us directly",
-		tagline: "For senior / specialist roles",
+		tagline: "For roles we haven't posted",
 		description:
-			"No formal openings right now, but if you'd genuinely move the needle (analytics, distributed systems, developer tooling, design, DevRel) send a short note and links to things you've built.",
+			"If you'd genuinely move the needle outside the open roles (analytics, distributed systems, developer tooling, design, DevRel) send a short note and links to things you've built.",
 		cta: { label: "support@databuddy.cc", href: "mailto:support@databuddy.cc" },
 	},
 ];
@@ -116,8 +116,8 @@ export default function CareersPaths() {
 					Three ways to work with us
 				</h2>
 				<p className="mx-auto max-w-2xl text-pretty text-muted-foreground text-sm sm:text-base lg:text-lg">
-					We don't have a careers portal. We have a codebase, a community, and
-					an inbox. Pick the door that fits.
+					Not the open role above? You can still contribute, join the ambassador
+					program, or pitch us directly.
 				</p>
 			</div>
 

--- a/apps/docs/app/(home)/careers/page.tsx
+++ b/apps/docs/app/(home)/careers/page.tsx
@@ -4,12 +4,13 @@ import Section from "@/components/landing/section";
 
 import { StructuredData } from "@/components/structured-data";
 import CareersHero from "./careers-hero";
+import CareersOpenings from "./careers-openings";
 import CareersPaths from "./careers-paths";
 import CareersPrinciples from "./careers-principles";
 
 const title = "Careers | Databuddy";
 const description =
-	"We're a small, remote team building privacy-first analytics in the open. No formal openings most of the time, but we always want to hear from sharp builders.";
+	"We're hiring a Founding Engineer and an SDR to help build and grow privacy-first analytics. Small remote team, open source, real ownership.";
 const url = "https://www.databuddy.cc/careers";
 
 export const metadata: Metadata = {
@@ -42,6 +43,15 @@ export default function CareersPage() {
 
 			<Section
 				className="border-border border-t bg-background/30"
+				id="careers-openings"
+			>
+				<div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
+					<CareersOpenings />
+				</div>
+			</Section>
+
+			<Section
+				className="border-border border-t bg-background/50"
 				id="careers-paths"
 			>
 				<div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -50,7 +60,7 @@ export default function CareersPage() {
 			</Section>
 
 			<Section
-				className="border-border border-t border-b bg-background/50"
+				className="border-border border-t border-b bg-background/30"
 				id="careers-principles"
 			>
 				<div className="mx-auto w-full max-w-7xl px-4 sm:px-6 lg:px-8">

--- a/apps/docs/components/footer.tsx
+++ b/apps/docs/components/footer.tsx
@@ -33,6 +33,7 @@ const footerSections = [
 			{ href: "/blog", label: "Blog", navItem: "blog" },
 			{ href: "/about", label: "About", navItem: "about" },
 			{ href: "/manifesto", label: "Manifesto", navItem: "manifesto" },
+			{ href: "/careers", label: "Careers", navItem: "careers" },
 			{ href: "/contact", label: "Contact", navItem: "contact" },
 			{
 				external: true,


### PR DESCRIPTION
## Summary
- Add an Open roles section on `/careers` with Founding Engineer and SDR job posts
- Update hero, meta, and paths copy to reflect active hiring
- Link Careers in the footer Company nav

## Test plan
- [ ] Open `/careers` locally and confirm both openings render
- [ ] Confirm Apply mailto links open with the correct subjects
- [ ] Confirm footer Careers link reaches `/careers`
- [ ] Confirm empty-state copy no longer says there are no openings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an Open roles section on `/careers` with Founding Engineer and SDR listings, and update copy/navigation so candidates can find and apply fast.

- **New Features**
  - Added openings data and card UI on `/careers`, with apply `mailto:` links and prefilled subjects.
  - Wired the section into the page via `#careers-openings` and refreshed hero, page meta, and paths copy to reflect active hiring.
  - Added "Careers" to the footer Company nav and fixed careers lint warnings.

<sup>Written for commit 63d06ebd08cde3061b372f77f317723e25764667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

