### PR TITLE
fix(db): restore elastic postgres pool

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,10 +1,13 @@
 /** biome-ignore-all lint/performance/noNamespaceImport: "Required" */
 
 import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
-import { Client } from "pg";
+import { Pool } from "pg";
 import { relations } from "./drizzle/schema/relations";
 
 type DB = NodePgDatabase<typeof relations>;
+
+const DEFAULT_POOL_MAX = 20;
+const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
 
 let _pgErrorFn: ((error: Error) => void) | null = null;
 
@@ -18,20 +21,23 @@ export function setPgTimingFn(fn: (durationMs: number) => void) {
 	_pgTimingFn = fn;
 }
 
-function timeClientQueries(client: Client, ready: () => Promise<void>): void {
-	const originalQuery = client.query.bind(client) as (
+function timePoolQueries(pool: Pool): void {
+	const originalQuery = pool.query.bind(pool) as (
 		...args: unknown[]
 	) => unknown;
-	client.query = ((...args: unknown[]) => {
+	pool.query = ((...args: unknown[]) => {
 		const timingFn = _pgTimingFn;
+		if (!timingFn) {
+			return originalQuery(...args);
+		}
 		const startedAt = performance.now();
-		const result = ready().then(() => originalQuery(...args));
-		if (timingFn) {
+		const result = originalQuery(...args);
+		if (result instanceof Promise) {
 			const record = () => timingFn(performance.now() - startedAt);
 			result.then(record, record);
 		}
 		return result;
-	}) as Client["query"];
+	}) as Pool["query"];
 }
 
 function connectionStringForNodePg(connectionString: string): string {
@@ -46,21 +52,16 @@ function connectionStringForNodePg(connectionString: string): string {
 	}
 }
 
-let _db: DB | null = null;
-let _client: Client | null = null;
-let _connection: Promise<void> | null = null;
-
-function connectClient(client: Client): Promise<void> {
-	if (_connection) {
-		return _connection;
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+	const parsed = Number.parseInt(value ?? "", 10);
+	if (Number.isFinite(parsed) && parsed > 0) {
+		return parsed;
 	}
-	const connection = client.connect().then(() => undefined);
-	_connection = connection.catch((error: unknown) => {
-		_connection = null;
-		throw error;
-	});
-	return _connection;
+	return fallback;
 }
+
+let _db: DB | null = null;
+let _pool: Pool | null = null;
 
 function getDb(): DB {
 	if (!_db) {
@@ -69,42 +70,44 @@ function getDb(): DB {
 			throw new Error("DATABASE_URL is not set");
 		}
 
-		const client = new Client({
+		_pool = new Pool({
 			connectionString: connectionStringForNodePg(databaseUrl),
+			max: parsePositiveInt(process.env.DB_POOL_MAX, DEFAULT_POOL_MAX),
+			idleTimeoutMillis: 30_000,
+			connectionTimeoutMillis: DEFAULT_CONNECTION_TIMEOUT_MS,
 			application_name: process.env.SERVICE_NAME || "databuddy",
 		});
-		_client = client;
-		timeClientQueries(client, () => connectClient(client));
-		client.on("error", (error) => {
+		timePoolQueries(_pool);
+		_pool.on("error", (error) => {
 			if (_pgErrorFn) {
 				_pgErrorFn(error);
 				return;
 			}
-			console.error("[db] postgres client error", error);
+			console.error("[db] postgres pool error", error);
 		});
 
-		_db = drizzle({ client, relations, jit: true });
+		_db = drizzle({ client: _pool, relations, jit: true });
 	}
 	return _db;
 }
 
 export async function warmPostgres(): Promise<void> {
 	getDb();
-	if (!_client) {
+	if (!_pool) {
 		return;
 	}
-	await connectClient(_client);
+	const client = await _pool.connect();
+	client.release();
 }
 
 export async function shutdownPostgres(): Promise<void> {
-	const client = _client;
+	const pool = _pool;
 	_db = null;
-	_client = null;
-	_connection = null;
-	if (!client) {
+	_pool = null;
+	if (!pool) {
 		return;
 	}
-	await client.end();
+	await pool.end();
 }
 
 export const db = new Proxy({} as DB, {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -6,7 +6,7 @@ import { relations } from "./drizzle/schema/relations";
 
 type DB = NodePgDatabase<typeof relations>;
 
-const DEFAULT_POOL_MAX = 20;
+const DEFAULT_POOL_MAX = 50;
 const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
 
 let _pgErrorFn: ((error: Error) => void) | null = null;


### PR DESCRIPTION
## Summary

- Restore the elastic `pg.Pool` in the shared PostgreSQL client.
- Keep the pool lazy/dynamic (`min` remains 0), cap each replica at 50 connections, close idle clients after 30 seconds, and bound acquisition at 10 seconds.
- Preserve PgBouncer-compatible URL normalization, query timing, error handling, warmup, and graceful shutdown.

## Production evidence

- PostgreSQL/PgBouncer itself is not saturated: PgBouncer was 23/400, direct PostgreSQL 10/50, and database CPU was 8%.
- The current production runtime emits `Calling client.query() when the client is already executing a query`, proving concurrent requests are sharing one `pg.Client`.
- A 39-request `/links/create` burst from one API key produced p95 6.49s latency and 28 cache-command timeouts; every slow request had one PostgreSQL query and 0 HTTP 5xx.
- Staging already runs this exact pool implementation with clean health checks and no PostgreSQL acquisition errors.

## Validation

- `bun run lint`
- `bun run check-types` (34/34 tasks)
- `bun run test` (25/25 tasks; 3,905 AI-package tests passed, 0 failed)
- Pre-push test hook passed
- Independent focused review requested before merge

## Rollout and rollback

- After merge, verify production health plus Axiom error rate, PostgreSQL timing, and `/links/create` p95 under the next real burst.
- Rollback is limited to reverting these two commits if pool acquisition or connection counts regress.

## Issue

Emergency maintainer production-incident hotfix; no public issue contains the operational details.

## AI disclosure

OpenAI Codex assisted with incident investigation, the minimal cherry-pick, validation, and PR preparation. The implementation was already exercised in staging and was verified with the full local suite.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore an elastic `pg.Pool` for the shared PostgreSQL client to fix concurrent query contention and reduce timeouts. The pool is lazy (min 0), defaults to 50 max connections per replica, closes idle after 30s, and bounds acquisition to 10s.

- **Bug Fixes**
  - Replaced `pg.Client` with `pg.Pool` and moved query timing to the pool.
  - Preserved PgBouncer-compatible URL normalization, warmup, error reporting, and graceful shutdown.
  - Added `DB_POOL_MAX` env support to override the pool ceiling.

<sup>Written for commit 6d65b6fefc512d0a9caad012c0608429e66ccbf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

