### PR TITLE
fix(shared): tag unkey deployment context

### DIFF
--- a/apps/links/src/routes/redirect.route.test.ts
+++ b/apps/links/src/routes/redirect.route.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { Elysia } from "elysia";
+import * as actualLinkVisitDelivery from "../lib/link-visit-delivery";
 
 const dbSelect = mock(() => ({
 	from: () => ({
@@ -12,6 +13,7 @@ const getCachedLink = mock();
 const ratelimit = mock();
 const resolveDeepLink = mock();
 const enqueueLinkVisit = mock();
+const linkVisitDeliveryModule = { ...actualLinkVisitDelivery };
 
 mock.module("@databuddy/env/app", () => ({
 	config: { urls: { dashboard: "https://dashboard.test" } },
@@ -78,6 +80,7 @@ mock.module("../lib/logging", () => ({
 }));
 
 mock.module("../lib/link-visit-delivery", () => ({
+	...linkVisitDeliveryModule,
 	enqueueLinkVisit,
 }));
 

--- a/packages/shared/src/evlog-redaction.test.ts
+++ b/packages/shared/src/evlog-redaction.test.ts
@@ -40,6 +40,22 @@ describe("databuddy evlog redaction", () => {
 		expect(resolveEvlogEnvironment({})).toBe("production");
 	});
 
+	it("preserves established platform precedence over Unkey", () => {
+		expect(
+			resolveEvlogEnvironment({
+				RAILWAY_ENVIRONMENT_NAME: "staging",
+				UNKEY_ENVIRONMENT_SLUG: "unkey-preview",
+				VERCEL_ENV: "preview",
+			})
+		).toBe("staging");
+		expect(
+			resolveEvlogEnvironment({
+				UNKEY_ENVIRONMENT_SLUG: "unkey-preview",
+				VERCEL_ENV: "preview",
+			})
+		).toBe("preview");
+	});
+
 	it("adds deployment metadata to every service environment", () => {
 		expect(
 			createDatabuddyEvlogEnv("api", {

--- a/packages/shared/src/evlog-redaction.test.ts
+++ b/packages/shared/src/evlog-redaction.test.ts
@@ -55,6 +55,22 @@ describe("databuddy evlog redaction", () => {
 		});
 	});
 
+	it("uses Unkey deployment context outside Railway", () => {
+		expect(
+			createDatabuddyEvlogEnv("links", {
+				NODE_ENV: "production",
+				UNKEY_ENVIRONMENT_SLUG: "preview",
+				UNKEY_GIT_COMMIT_SHA: "def456",
+				UNKEY_REGION: "aws::eu-central-1",
+			})
+		).toEqual({
+			service: "links",
+			environment: "preview",
+			region: "aws::eu-central-1",
+			commitHash: "def456",
+		});
+	});
+
 	it("covers sensitive field names used across services", () => {
 		expect(databuddyEvlogRedactConfig.paths).toContain("headers.authorization");
 		expect(databuddyEvlogRedactConfig.paths).toContain("headers.cookie");

--- a/packages/shared/src/evlog-redaction.ts
+++ b/packages/shared/src/evlog-redaction.ts
@@ -58,9 +58,9 @@ export function resolveEvlogEnvironment(
 ): string {
 	return (
 		env.APP_ENV?.trim() ||
-		env.UNKEY_ENVIRONMENT_SLUG?.trim() ||
 		env.RAILWAY_ENVIRONMENT_NAME?.trim() ||
 		env.VERCEL_ENV?.trim() ||
+		env.UNKEY_ENVIRONMENT_SLUG?.trim() ||
 		(env.NODE_ENV === "development" || env.NODE_ENV === "test"
 			? env.NODE_ENV
 			: "production")

--- a/packages/shared/src/evlog-redaction.ts
+++ b/packages/shared/src/evlog-redaction.ts
@@ -47,6 +47,9 @@ interface EvlogRuntimeEnv {
 	RAILWAY_ENVIRONMENT_NAME?: string;
 	RAILWAY_GIT_COMMIT_SHA?: string;
 	RAILWAY_REPLICA_REGION?: string;
+	UNKEY_ENVIRONMENT_SLUG?: string;
+	UNKEY_GIT_COMMIT_SHA?: string;
+	UNKEY_REGION?: string;
 	VERCEL_ENV?: string;
 }
 
@@ -55,6 +58,7 @@ export function resolveEvlogEnvironment(
 ): string {
 	return (
 		env.APP_ENV?.trim() ||
+		env.UNKEY_ENVIRONMENT_SLUG?.trim() ||
 		env.RAILWAY_ENVIRONMENT_NAME?.trim() ||
 		env.VERCEL_ENV?.trim() ||
 		(env.NODE_ENV === "development" || env.NODE_ENV === "test"
@@ -70,8 +74,8 @@ export function createDatabuddyEvlogEnv(
 	return {
 		service,
 		environment: resolveEvlogEnvironment(env),
-		region: env.RAILWAY_REPLICA_REGION,
-		commitHash: env.RAILWAY_GIT_COMMIT_SHA,
+		region: env.RAILWAY_REPLICA_REGION ?? env.UNKEY_REGION,
+		commitHash: env.RAILWAY_GIT_COMMIT_SHA ?? env.UNKEY_GIT_COMMIT_SHA,
 	};
 }
 


### PR DESCRIPTION
## Summary

- Add Unkey runtime fallbacks for environment, commit SHA, and region in shared evlog context.
- Keep existing Railway, Vercel, and AWS metadata precedence unchanged.
- Add coverage for the Unkey-specific environment variables.

## Why

Links deployments run on Unkey, whose runtime metadata variable names differ from the existing service platforms. Without these fallbacks, Axiom cannot reliably distinguish preview versus production deployments or correlate logs to an Unkey commit and region.

This change only improves telemetry attribution; it does not alter request or deployment behavior.

## Validation

- Targeted shared logging tests passed.
- Shared package typecheck and lint passed.
- Full pre-push suite passed: 25/25 tasks, including 3,924 AI-package tests with 0 failures.

## AI disclosure

OpenAI Codex assisted with incident investigation, implementation, tests, and PR preparation. The change was validated locally through the repository hooks and full test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tag Unkey deployments in `packages/shared` evlog by reading `UNKEY_ENVIRONMENT_SLUG`, `UNKEY_GIT_COMMIT_SHA`, and `UNKEY_REGION`, so logs show the correct environment, commit, and region. Keep platform precedence as Railway > Vercel > Unkey; this only changes telemetry tags.

- **Bug Fixes**
  - Preserve `link-visit-delivery` exports in `apps/links` tests when mocking.

<sup>Written for commit a5702a5db7e2ebffa6a531e1f179fe740bfc94a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/584?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

