### PR TITLE
fix(basket): correct geo resolution telemetry + drop redis geoip cache

### DIFF
--- a/apps/basket/src/utils/ip-geo.ts
+++ b/apps/basket/src/utils/ip-geo.ts
@@ -1,5 +1,4 @@
 import { createHash } from "node:crypto";
-import { cacheable } from "@databuddy/redis/cacheable";
 import { captureError, mergeWideEvent, record } from "@lib/tracing";
 import type { City } from "@maxmind/geoip2-node";
 import {
@@ -169,30 +168,6 @@ function lookupGeoLocation(ip: string): Promise<{
 	});
 }
 
-function coarsenIpForCache(ip: string): string {
-	if (ip.includes(":")) {
-		const groups = ip.split(":");
-		const head = groups.slice(0, 4).join(":");
-		return `${head}::`;
-	}
-	const octets = ip.split(".");
-	if (octets.length === 4) {
-		return `${octets[0]}.${octets[1]}.${octets[2]}.0`;
-	}
-	return ip;
-}
-
-const getCachedGeoLocation = cacheable(lookupGeoLocation, {
-	expireInSec: 86_400 * 7,
-	prefix: "geoip_location",
-	staleWhileRevalidate: true,
-	staleTime: 86_400,
-});
-
-function getGeoLocation(ip: string) {
-	return getCachedGeoLocation(coarsenIpForCache(ip));
-}
-
 export function anonymizeIp(ip: string): string {
 	if (!ip) {
 		return "";
@@ -218,7 +193,7 @@ export function getGeo(ip: string, request?: Request) {
 			};
 		}
 
-		const geo = await getGeoLocation(ip);
+		const geo = await lookupGeoLocation(ip);
 
 		if (!geo.country && request?.headers) {
 			const cfCountry = getCloudflareCountry(request.headers);

--- a/apps/basket/src/utils/ip-geo.ts
+++ b/apps/basket/src/utils/ip-geo.ts
@@ -238,6 +238,17 @@ export function getGeo(ip: string, request?: Request) {
 			}
 		}
 
+		mergeWideEvent({
+			geo: geo.country
+				? {
+						source: "maxmind",
+						country: geo.country,
+						region: geo.region,
+						city: geo.city,
+					}
+				: { source: "unresolved" },
+		});
+
 		return {
 			anonymizedIP: anonymizeIp(ip),
 			country: geo.country,


### PR DESCRIPTION
## What
Two slices fixing the basket IP-geo pipeline.

### 1. Geo resolution telemetry blind spot (`fix`)
The Axiom geo dashboard showed **0.4% resolution / 17.1M "failed to locate"** — a measurement artifact, not an outage. `getGeo()` only merged a `geo.*` wide-event field on the Cloudflare-fallback and skipped-IP paths. On the **MaxMind success path** (~99.5% of traffic) it returned the country but never logged it, so Axiom recorded `geo.country = null` and the dashboard read those as failures.

Evidence (7d, `basket` dataset): `geo.source=cloudflare_header` = 76,957 = *exactly* the "resolved" count; zero GeoIP load errors; MaxMind lookups run on all 17.18M events at 0.26ms p50; flat 30-day trend with no cliff.

Fix: every request now emits a `geo.source` — `maxmind` / `cloudflare_header` / `unresolved` / `skipped`.

### 2. Drop the Redis GeoIP cache (`perf`)
`timing.getGeo` p50 was **142ms** while the in-memory MaxMind lookup is **0.26ms** — the `cacheable` Redis wrapper was ~500x slower than the value it cached. Removed the cache and the `/24` `coarsenIpForCache` helper; lookups now hit the in-process reader on the full IP, restoring city/region precision the coarsening discarded.

## Test
`bun test src/utils/ip-geo.test.ts` -> 20 pass; `check-types` green across all packages.

## Follow-up (dashboard owner)
Update the Axiom panels to compute resolution from `geo.source` (`maxmind` + `cloudflare_header` = resolved) instead of `isnull(geo.country)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes geo resolution telemetry by always emitting `geo.source`, and removes the Redis GeoIP cache to use the in-process MaxMind lookup. This corrects false “failed to locate” readings in Axiom and cuts lookup p50 from ~142ms to ~0.26ms while restoring city/region precision.

- **Migration**
  - Update Axiom dashboards to compute resolution from `geo.source` (`maxmind` + `cloudflare_header` = resolved) instead of `isnull(geo.country)`.

<sup>Written for commit 1aa2b3223ec96dc2d1e1b535694b0123b0dfbb87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

