### PR TITLE
fix(basket): stop logging expected conditions as errors in Axiom

### DIFF
--- a/apps/basket/src/lib/evlog-basket.test.ts
+++ b/apps/basket/src/lib/evlog-basket.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest";
+import { normalizeWideEventForAxiom } from "./evlog-basket";
+
+describe("normalizeWideEventForAxiom", () => {
+	test("downgrades a catalog client error to warn", () => {
+		const event: Record<string, unknown> = {
+			level: "error",
+			error_message: "Event quota exceeded",
+		};
+		normalizeWideEventForAxiom(event);
+		expect(event.level).toBe("warn");
+		expect(event.client_http_error).toBe(true);
+	});
+
+	test("downgrades based on a 4xx http_status", () => {
+		const event: Record<string, unknown> = {
+			level: "error",
+			http_status: 429,
+		};
+		normalizeWideEventForAxiom(event);
+		expect(event.level).toBe("warn");
+		expect(event.client_http_error).toBe(true);
+	});
+
+	test("keeps a 5xx catalog error at error level", () => {
+		const event: Record<string, unknown> = {
+			level: "error",
+			error_message: "Website lookup temporarily unavailable",
+		};
+		normalizeWideEventForAxiom(event);
+		expect(event.level).toBe("error");
+		expect(event.client_http_error).toBeUndefined();
+	});
+
+	test("keeps an unknown error at error level", () => {
+		const event: Record<string, unknown> = {
+			level: "error",
+			error_message: "Failed to get website by ID V2",
+		};
+		normalizeWideEventForAxiom(event);
+		expect(event.level).toBe("error");
+	});
+
+	test("flattens a string error onto error_message", () => {
+		const event: Record<string, unknown> = {
+			level: "error",
+			error: "Event quota exceeded",
+		};
+		normalizeWideEventForAxiom(event);
+		expect(event.error).toBeUndefined();
+		expect(event.error_message).toBe("Event quota exceeded");
+		expect(event.level).toBe("warn");
+	});
+});

--- a/apps/basket/src/lib/evlog-basket.ts
+++ b/apps/basket/src/lib/evlog-basket.ts
@@ -2,6 +2,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBooleanEnv } from "@databuddy/env/boolean";
 import { createBatchedSuperlogDrain } from "@databuddy/shared/evlog-superlog";
+import { CLIENT_ERROR_MESSAGES } from "@lib/structured-errors";
 import type { DrainContext, EnrichContext } from "evlog";
 import { createAxiomDrain } from "evlog/axiom";
 import {
@@ -39,23 +40,24 @@ const devFsDrain = useLocalEvlogFiles
 
 const DURATION_MS_REGEX = /^([\d.]+)(ms|s)$/;
 
-function normalizeWideEventForAxiom(event: Record<string, unknown>): void {
+function isClientHttpError(event: Record<string, unknown>): boolean {
+	const status = event.http_status;
+	if (typeof status === "number" && status >= 400 && status < 500) {
+		return true;
+	}
+	const message = event.error_message;
+	return typeof message === "string" && CLIENT_ERROR_MESSAGES.has(message);
+}
+
+export function normalizeWideEventForAxiom(
+	event: Record<string, unknown>
+): void {
 	if (typeof event.error === "string") {
 		event.error_message = event.error;
 		event.error = undefined;
 	}
 
-	if (event.level !== "error") {
-		return;
-	}
-
-	const err = event.error;
-	if (!err || typeof err !== "object" || Array.isArray(err)) {
-		return;
-	}
-
-	const status = (err as { status?: number }).status;
-	if (typeof status === "number" && status >= 400 && status < 500) {
+	if (event.level === "error" && isClientHttpError(event)) {
 		event.level = "warn";
 		event.client_http_error = true;
 	}

--- a/apps/basket/src/lib/evlog-basket.ts
+++ b/apps/basket/src/lib/evlog-basket.ts
@@ -1,22 +1,18 @@
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readBooleanEnv } from "@databuddy/env/boolean";
+import {
+	createBatchedAxiomDrain,
+	downgradeClientHttpError,
+	enrichHttpWideEvent,
+	normalizeWideEventForAxiom as normalizeSharedWideEventForAxiom,
+} from "@databuddy/shared/evlog-axiom";
 import { createBatchedSuperlogDrain } from "@databuddy/shared/evlog-superlog";
 import { CLIENT_ERROR_MESSAGES } from "@lib/structured-errors";
 import type { DrainContext, EnrichContext } from "evlog";
-import { createAxiomDrain } from "evlog/axiom";
-import {
-	createRequestSizeEnricher,
-	createTraceContextEnricher,
-	createUserAgentEnricher,
-} from "evlog/enrichers";
 import { createFsDrain } from "evlog/fs";
-import { createDrainPipeline } from "evlog/pipeline";
 
-const batchedAxiomDrain = createDrainPipeline<DrainContext>({
-	batch: { size: 50, intervalMs: 5000 },
-	maxBufferSize: 2000,
-})(createAxiomDrain({ apiKey: process.env.AXIOM_TOKEN }));
+const batchedAxiomDrain = createBatchedAxiomDrain(process.env.AXIOM_TOKEN);
 
 const batchedSuperlogDrain = createBatchedSuperlogDrain();
 
@@ -38,9 +34,7 @@ const devFsDrain = useLocalEvlogFiles
 	? createFsDrain({ dir: devFsLogsDir, pretty: false })
 	: null;
 
-const DURATION_MS_REGEX = /^([\d.]+)(ms|s)$/;
-
-function isClientHttpError(event: Record<string, unknown>): boolean {
+function isBasketClientHttpError(event: Record<string, unknown>): boolean {
 	const status = event.http_status;
 	if (typeof status === "number" && status >= 400 && status < 500) {
 		return true;
@@ -52,28 +46,10 @@ function isClientHttpError(event: Record<string, unknown>): boolean {
 export function normalizeWideEventForAxiom(
 	event: Record<string, unknown>
 ): void {
-	if (typeof event.error === "string") {
-		event.error_message = event.error;
-		event.error = undefined;
+	normalizeSharedWideEventForAxiom(event);
+	if (isBasketClientHttpError(event)) {
+		downgradeClientHttpError(event);
 	}
-
-	if (event.level === "error" && isClientHttpError(event)) {
-		event.level = "warn";
-		event.client_http_error = true;
-	}
-}
-
-function parseDurationMs(duration: unknown): number | undefined {
-	if (typeof duration !== "string") {
-		return;
-	}
-	const match = duration.match(DURATION_MS_REGEX);
-	if (!match?.[1]) {
-		return;
-	}
-	return match[2] === "s"
-		? Math.round(Number.parseFloat(match[1]) * 1000)
-		: Math.round(Number.parseFloat(match[1]));
 }
 
 export async function basketLoggerDrain(ctx: DrainContext): Promise<void> {
@@ -82,11 +58,6 @@ export async function basketLoggerDrain(ctx: DrainContext): Promise<void> {
 	}
 
 	normalizeWideEventForAxiom(ctx.event as Record<string, unknown>);
-
-	const durationMs = parseDurationMs(ctx.event.duration);
-	if (durationMs !== undefined) {
-		ctx.event.duration_ms = durationMs;
-	}
 
 	if (devFsDrain) {
 		await devFsDrain(ctx);
@@ -97,16 +68,8 @@ export async function basketLoggerDrain(ctx: DrainContext): Promise<void> {
 	batchedSuperlogDrain?.(ctx);
 }
 
-const enrichers = [
-	createUserAgentEnricher(),
-	createRequestSizeEnricher(),
-	createTraceContextEnricher(),
-] as const;
-
 export function enrichBasketWideEvent(ctx: EnrichContext): void {
-	for (const enricher of enrichers) {
-		enricher(ctx);
-	}
+	enrichHttpWideEvent(ctx);
 }
 
 export async function flushBatchedAxiomDrain(): Promise<void> {

--- a/apps/basket/src/lib/producer.delivery.test.ts
+++ b/apps/basket/src/lib/producer.delivery.test.ts
@@ -4,9 +4,15 @@ import type { Admin, Producer } from "kafkajs";
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import type { ProducerConfig } from "./producer";
 
-const { mockCaptureError } = vi.hoisted(() => ({
+const { mockCaptureError, mockLogWarn } = vi.hoisted(() => ({
 	mockCaptureError: vi.fn(),
+	mockLogWarn: vi.fn(),
 }));
+
+vi.mock("evlog", async () => {
+	const actual = await vi.importActual<typeof import("evlog")>("evlog");
+	return { ...actual, log: { ...actual.log, warn: mockLogWarn } };
+});
 
 vi.mock("@databuddy/db/clickhouse", () => ({
 	clickHouse: {},
@@ -73,6 +79,7 @@ async function makeEffects(
 describe("producer delivery guarantees", () => {
 	beforeEach(() => {
 		mockCaptureError.mockClear();
+		mockLogWarn.mockClear();
 	});
 
 	test("resolves a core send only after direct ClickHouse fallback succeeds", async () => {
@@ -745,7 +752,7 @@ describe("producer delivery guarantees", () => {
 		await Promise.all(deliveries);
 
 		expect(insert).toHaveBeenCalledTimes(50);
-		expect(mockCaptureError).toHaveBeenCalledTimes(1);
+		expect(mockLogWarn).toHaveBeenCalledTimes(1);
 		expect(await Effect.runPromise(effects.stats)).toMatchObject({
 			connected: false,
 			connecting: false,

--- a/apps/basket/src/lib/producer.ts
+++ b/apps/basket/src/lib/producer.ts
@@ -5,7 +5,7 @@ import { readBooleanEnv } from "@databuddy/env/boolean";
 import { captureError, record } from "@lib/tracing";
 import { PRODUCER_DRAIN_TIMEOUT_MS } from "@lib/shutdown-budget";
 import { Data, Deferred, Effect, Layer, ManagedRuntime, Ref } from "effect";
-import { createError } from "evlog";
+import { createError, log } from "evlog";
 import { type Admin, CompressionTypes, Kafka, type Producer } from "kafkajs";
 
 function stringifyEvent(event: unknown): string {
@@ -569,9 +569,13 @@ function makeProducerEffects(
 				})).pipe(
 					Effect.tap(() =>
 						Effect.sync(() =>
-							captureError(err.cause, {
+							log.warn({
 								message:
 									"Redpanda connection failed, using ClickHouse fallback",
+								error_message:
+									err.cause instanceof Error
+										? err.cause.message
+										: String(err.cause),
 							})
 						)
 					),

--- a/apps/basket/src/lib/structured-errors.ts
+++ b/apps/basket/src/lib/structured-errors.ts
@@ -1,7 +1,7 @@
 import { createError, defineErrorCatalog, EvlogError, parseError } from "evlog";
 import type { z } from "zod";
 
-export const basketErrorCatalog = defineErrorCatalog("basket", {
+const BASKET_ERROR_SPEC = {
 	TRACK_PAYLOAD_TOO_LARGE: {
 		message: "Payload too large",
 		status: 413,
@@ -176,7 +176,15 @@ export const basketErrorCatalog = defineErrorCatalog("basket", {
 		why: "The JSON did not match the expected event shape.",
 		fix: "Correct the fields listed in errors and retry.",
 	},
-});
+} as const;
+
+export const basketErrorCatalog = defineErrorCatalog("basket", BASKET_ERROR_SPEC);
+
+export const CLIENT_ERROR_MESSAGES: ReadonlySet<string> = new Set(
+	Object.values(BASKET_ERROR_SPEC)
+		.filter((entry) => entry.status >= 400 && entry.status < 500)
+		.map((entry) => entry.message)
+);
 
 declare module "evlog" {
 	interface RegisteredErrorCatalogs {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -31,6 +31,7 @@
     "./stripe-webhooks": "./src/stripe-webhooks.ts",
     "./audit": "./src/audit.ts",
     "./evlog-fields": "./src/evlog-fields.ts",
+    "./evlog-axiom": "./src/evlog-axiom.ts",
     "./evlog-redaction": "./src/evlog-redaction.ts",
     "./evlog-superlog": "./src/evlog-superlog.ts"
   },

--- a/packages/shared/src/evlog-axiom.test.ts
+++ b/packages/shared/src/evlog-axiom.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+	normalizeHttpWideEventForAxiom,
+	normalizeWideEventForAxiom,
+} from "./evlog-axiom";
+
+describe("normalizeWideEventForAxiom", () => {
+	test("moves string errors and adds a numeric duration", () => {
+		const event: Record<string, unknown> = {
+			error: "request failed",
+			duration: "1.25s",
+			level: "error",
+		};
+
+		normalizeWideEventForAxiom(event);
+
+		expect(event.error).toBeUndefined();
+		expect(event.error_message).toBe("request failed");
+		expect(event.duration_ms).toBe(1250);
+	});
+
+	test("downgrades structured 4xx errors", () => {
+		const event: Record<string, unknown> = {
+			error: { status: 429 },
+			level: "error",
+		};
+
+		normalizeHttpWideEventForAxiom(event);
+
+		expect(event.level).toBe("warn");
+		expect(event.client_http_error).toBe(true);
+	});
+
+	test("keeps structured server errors at error level", () => {
+		const event: Record<string, unknown> = {
+			error: { status: 503 },
+			level: "error",
+		};
+
+		normalizeHttpWideEventForAxiom(event);
+
+		expect(event.level).toBe("error");
+		expect(event.client_http_error).toBeUndefined();
+	});
+});

--- a/packages/shared/src/evlog-axiom.ts
+++ b/packages/shared/src/evlog-axiom.ts
@@ -1,0 +1,103 @@
+import type { DrainContext, EnrichContext } from "evlog";
+import { createAxiomDrain } from "evlog/axiom";
+import {
+	createRequestSizeEnricher,
+	createTraceContextEnricher,
+	createUserAgentEnricher,
+} from "evlog/enrichers";
+import { createDrainPipeline } from "evlog/pipeline";
+
+const createAxiomPipeline = createDrainPipeline<DrainContext>({
+	batch: { size: 50, intervalMs: 5000 },
+	maxBufferSize: 2000,
+});
+
+const durationPattern = /^([\d.]+)(ms|s)$/;
+
+const httpEnrichers = [
+	createUserAgentEnricher(),
+	createRequestSizeEnricher(),
+	createTraceContextEnricher(),
+] as const;
+
+export function createBatchedAxiomDrain(
+	apiKey: string | undefined,
+	dataset?: string
+) {
+	return createAxiomPipeline(
+		createAxiomDrain({
+			apiKey,
+			...(dataset ? { dataset } : {}),
+		})
+	);
+}
+
+export function normalizeWideEventForAxiom(
+	event: Record<string, unknown>
+): void {
+	if (typeof event.error === "string") {
+		event.error_message = event.error;
+		event.error = undefined;
+	}
+
+	const durationMs = parseDurationMs(event.duration);
+	if (durationMs !== undefined) {
+		event.duration_ms = durationMs;
+	}
+}
+
+export function normalizeHttpWideEventForAxiom(
+	event: Record<string, unknown>
+): void {
+	normalizeWideEventForAxiom(event);
+	if (hasClientHttpError(event)) {
+		downgradeClientHttpError(event);
+	}
+}
+
+export function downgradeClientHttpError(event: Record<string, unknown>): void {
+	if (event.level !== "error") {
+		return;
+	}
+
+	event.level = "warn";
+	event.client_http_error = true;
+}
+
+export function enrichHttpWideEvent(ctx: EnrichContext): void {
+	for (const enrich of httpEnrichers) {
+		enrich(ctx);
+	}
+}
+
+function hasClientHttpError(event: Record<string, unknown>): boolean {
+	if (event.level !== "error") {
+		return false;
+	}
+
+	const error = event.error;
+	if (!isRecord(error)) {
+		return false;
+	}
+
+	const status = error.status;
+	return typeof status === "number" && status >= 400 && status < 500;
+}
+
+function parseDurationMs(duration: unknown): number | undefined {
+	if (typeof duration !== "string") {
+		return;
+	}
+
+	const match = duration.match(durationPattern);
+	if (!match?.[1]) {
+		return;
+	}
+
+	const durationMs = Number.parseFloat(match[1]);
+	return Math.round(match[2] === "s" ? durationMs * 1000 : durationMs);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}


### PR DESCRIPTION
## What
Follow-up to #589. Basket's Axiom error signal is ~100% noise: of 3.18M weekly `level=error` events, **3,169,529 (99.7%) are `Event quota exceeded`** — a normal billing state (customer hit their plan limit). Rate limits, invalid client IDs, unauthorized origins, and a handled Redpanda→ClickHouse fallback are also logged as errors. Real errors (e.g. `Failed to get website by ID`, 135/wk) are drowned ~20,000:1, making error-rate alerting meaningless.

## Root cause
The `evlog` Elysia plugin logs **every** thrown error via `state.logger.error(err)` and drops the error's status. Basket's `onError` marks 4xx as `isExpectedClientError` but doesn't downgrade the already-set level, and the drain's old 4xx→warn check keyed off `error.status`, which is gone by drain time (only `error_message` survives).

## Fix
1. **Client errors → warn.** Make the raw error spec the single source of truth in `structured-errors.ts` and derive `CLIENT_ERROR_MESSAGES` (messages with 4xx status) from it. The Axiom drain downgrades `error → warn` (+`client_http_error`) when `http_status` is 4xx **or** `error_message` is a known catalog client error. Ordering-independent — keys only off fields that survive to the drain.
2. **Handled Redpanda fallback → warn.** The connection failure recovers via direct ClickHouse insert, so it's `log.warn`, not `captureError`.

## Test
New `evlog-basket.test.ts` covers the downgrade matrix (catalog 4xx → warn, `http_status` 4xx → warn, 5xx catalog stays error, unknown stays error, string-error flattening). Full basket suite: **606 pass** (`vitest run`); `check-types` green.

## Follow-up
Once deployed, basket's error-rate panels/alerts will reflect real failures instead of quota noise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Downgraded expected client HTTP errors to warn in Axiom and reclassified the Redpanda→ClickHouse fallback as warn, so Basket’s error signal reflects real failures instead of quota noise. Extracted Axiom drain helpers to `@databuddy/shared/evlog-axiom` and adopted them in Basket.

- **Bug Fixes**
  - Downgrade events to `warn` (+`client_http_error`) in the Axiom drain when `http_status` is 4xx or `error_message` matches client errors derived from the catalog.
  - Flatten string `error` into `error_message` before classification for consistent handling.
  - Use `log.warn` for the handled Redpanda connection failure that falls back to direct ClickHouse insert.

- **Refactors**
  - Moved the batched Axiom drain and HTTP enrichers to `@databuddy/shared/evlog-axiom` and switched Basket to use them.
  - Basket keeps catalog-driven client-error detection and calls the shared `downgradeClientHttpError` after normalization.

<sup>Written for commit 021e11eacf2d135a619f8634fc450c13747a937b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

