### PR TITLE
style(basket): fix structured-errors formatting to unblock release lint

### DIFF
--- a/apps/basket/src/lib/structured-errors.ts
+++ b/apps/basket/src/lib/structured-errors.ts
@@ -178,7 +178,10 @@ const BASKET_ERROR_SPEC = {
 	},
 } as const;
 
-export const basketErrorCatalog = defineErrorCatalog("basket", BASKET_ERROR_SPEC);
+export const basketErrorCatalog = defineErrorCatalog(
+	"basket",
+	BASKET_ERROR_SPEC
+);
 
 export const CLIENT_ERROR_MESSAGES: ReadonlySet<string> = new Set(
 	Object.values(BASKET_ERROR_SPEC)


### PR DESCRIPTION
The `defineErrorCatalog("basket", BASKET_ERROR_SPEC)` call from #590 was a single line; ultracite wants it wrapped multi-line. This failed the `Lint` check on staging and is blocking the staging→main release (#587). Verified: `bunx ultracite check` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wrap the `defineErrorCatalog("basket", BASKET_ERROR_SPEC)` call over multiple lines to satisfy `ultracite` formatting and fix the failing Lint check on staging. This unblocks the staging→main release.

<sup>Written for commit 4078a65b4b1bb008c5e4e2df65cf5cc93ddb522a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

