### PR TITLE
chore(repo): catch formatting in pre-commit before CI

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,6 +44,11 @@ pre-commit:
         - "apps/uptime/**/*.{ts,tsx}"
         - "scripts/lint-policy.ts"
       run: bun scripts/lint-policy.ts --staged
+    format:
+      glob:
+        - "**/*.{ts,tsx,js,jsx,mjs,cjs,json,jsonc,css}"
+      run: bunx ultracite check {staged_files}
+      fail_text: "Formatting/lint issues found. Run: bun run format"
     lockfile-check:
       glob:
         - "**/package.json"


### PR DESCRIPTION
The pre-commit hook ran check-types and policy-lint but never `ultracite check`, so formatting issues (like the #590 one-liner that failed the release lint on #587) only surfaced in CI. Adds a staged-file `ultracite check` step to lefthook's pre-commit, mirroring CI's `Lint` job.

Verified: staged a misformatted file and ran `bunx lefthook run pre-commit` — the new `format` command fails with `Run: bun run format`; clean files pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ultracite` formatting checks to `lefthook` pre-commit so formatting issues are caught locally instead of failing in CI. The hook runs `bunx ultracite check {staged_files}` across JS/TS/JSON/CSS and fails with “Run: bun run format” to guide fixes.

<sup>Written for commit 33836f3a8a31b3772883ff80b8c444166f7601c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

