### PR TITLE
feat(slack): App Home quick-start tab

### DIFF
--- a/apps/slack/slack-app-manifest.json
+++ b/apps/slack/slack-app-manifest.json
@@ -74,6 +74,7 @@
   "settings": {
     "event_subscriptions": {
       "bot_events": [
+        "app_home_opened",
         "app_mention",
         "assistant_thread_context_changed",
         "assistant_thread_started",

--- a/apps/slack/src/slack/app-home.test.ts
+++ b/apps/slack/src/slack/app-home.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { buildAppHomeView } from "@/slack/app-home";
+import { SLACK_SUGGESTED_PROMPTS } from "@/slack/messages";
+
+describe("buildAppHomeView", () => {
+	it("builds a home view with a header and blocks", () => {
+		const view = buildAppHomeView();
+		expect(view.type).toBe("home");
+		const blocks = view.blocks as Array<Record<string, unknown>>;
+		expect(blocks[0]).toMatchObject({ type: "header" });
+		expect((blocks[0].text as { text: string }).text).toBe("Databuddy");
+		expect(blocks.length).toBeGreaterThan(3);
+	});
+
+	it("lists the suggested prompts", () => {
+		const view = buildAppHomeView();
+		const text = JSON.stringify(view);
+		for (const prompt of SLACK_SUGGESTED_PROMPTS) {
+			expect(text).toContain(prompt.message);
+		}
+	});
+});

--- a/apps/slack/src/slack/app-home.ts
+++ b/apps/slack/src/slack/app-home.ts
@@ -1,0 +1,43 @@
+import { SLACK_SUGGESTED_PROMPTS } from "@/slack/messages";
+
+export function buildAppHomeView(): Record<string, unknown> {
+	const prompts = SLACK_SUGGESTED_PROMPTS.map(
+		(prompt) => `• ${prompt.message}`
+	).join("\n");
+
+	return {
+		type: "home",
+		blocks: [
+			{
+				type: "header",
+				text: { type: "plain_text", text: "Databuddy" },
+			},
+			{
+				type: "section",
+				text: {
+					type: "mrkdwn",
+					text: "Ask about your analytics right here in Slack — traffic, pages, conversions, campaigns, errors, and product usage. Mention *@Databuddy*, send a direct message, or use the assistant.",
+				},
+			},
+			{ type: "divider" },
+			{
+				type: "section",
+				text: { type: "mrkdwn", text: "*Try asking*" },
+			},
+			{
+				type: "section",
+				text: { type: "mrkdwn", text: prompts },
+			},
+			{ type: "divider" },
+			{
+				type: "context",
+				elements: [
+					{
+						type: "mrkdwn",
+						text: "Commands: `/databuddy-status`   `/databuddy-help`   `/databuddy-bind`",
+					},
+				],
+			},
+		],
+	};
+}

--- a/apps/slack/src/slack/listeners.ts
+++ b/apps/slack/src/slack/listeners.ts
@@ -8,6 +8,7 @@ import {
 import { createRPCContext } from "@databuddy/rpc";
 import { appendInvestigationReply } from "@databuddy/rpc/insights";
 import type { DatabuddyAgentClient, SlackAgentRun } from "@/agent/agent-client";
+import { buildAppHomeView } from "@/slack/app-home";
 import { createSlackEventLog } from "@/lib/evlog-slack";
 import { abortSlackActiveRun } from "@/slack/active-runs";
 import { getSlackChannelMentionPolicy } from "@/slack/channel-policy";
@@ -155,6 +156,22 @@ export function registerSlackListeners(
 	const dedupe = createRecentDedupe();
 
 	app.assistant(createDatabuddyAssistant({ agent, dedupe, threadQueue }));
+
+	app.event("app_home_opened", async ({ client, event, logger }) => {
+		if (event.tab !== "home") {
+			return;
+		}
+		try {
+			await client.views.publish({
+				user_id: event.user,
+				view: buildAppHomeView() as unknown as Parameters<
+					typeof client.views.publish
+				>[0]["view"],
+			});
+		} catch (error) {
+			logger.warn("Failed to publish Slack App Home", error);
+		}
+	});
 
 	app.event(
 		"app_mention",

--- a/apps/slack/src/slack/types.ts
+++ b/apps/slack/src/slack/types.ts
@@ -25,6 +25,7 @@ export interface SlackAgentClient {
 		"history" | "info" | "replies"
 	>;
 	reactions: Pick<WebClient["reactions"], "add">;
+	views: Pick<WebClient["views"], "publish">;
 }
 
 export type SlackSay = (


### PR DESCRIPTION
Publishes a Home tab (the app's dashboard page in Slack) with a quick-start guide: what Databuddy can do, example questions, and the slash commands. Enabled via `app_home_opened` + `views.publish`.

Stacked on #595 (drill-downs) — will auto-retarget to staging when that merges.

## Testing
- apps/slack suite: 73/73 pass (new app-home.test.ts). Typecheck + ultracite clean.
- View uses only Block Kit primitives already verified to render live in #594 (header/section/divider/context). Not live-published to avoid writing to a real user's Home tab unprompted.

## Follow-up
v1 is static guidance. Next: enrich with live data (open investigations count, connected sites) and quick-action buttons.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a Slack App Home tab with a quick-start guide to help users get started in Slack. The Home tab renders on open via `app_home_opened` and publishes the view with `views.publish`.

- **New Features**
  - Subscribes to `app_home_opened` in the manifest and registers a listener to publish the Home view.
  - Adds `buildAppHomeView` using Block Kit (header, sections, dividers, context) with suggested prompts and slash commands.
  - Extends Slack client types to include `views.publish`.

<sup>Written for commit 11f8c73d6988f41741e73f06856b770d7d01680f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

