### PR TITLE
fix(slack): raise agent timeout, clarify empty-result message

### DIFF
--- a/apps/slack/src/agent/agent-client.ts
+++ b/apps/slack/src/agent/agent-client.ts
@@ -40,6 +40,11 @@ export interface SlackAgentStreamOptions {
 	abortSignal?: AbortSignal;
 }
 
+// Slack streams keep the "thinking" indicator open, and Slack imposes no stream
+// duration limit, so allow multi-site/complex analytics runs well past the 45s
+// default before the outer 5-minute run timeout in run-handler steps in.
+const SLACK_AGENT_TIMEOUT_MS = 120_000;
+
 export interface SlackAgentRunner {
 	stream(
 		run: SlackAgentRun,
@@ -100,6 +105,7 @@ class SharedDatabuddyAgentRunner implements SlackAgentRunner {
 			memoryUserId: createSlackMemoryUserId(run),
 			slackContext: run.slackContext,
 			source: "slack",
+			timeoutMs: SLACK_AGENT_TIMEOUT_MS,
 			timezone: "UTC",
 		});
 	}

--- a/apps/slack/src/slack/messages.ts
+++ b/apps/slack/src/slack/messages.ts
@@ -57,7 +57,7 @@ export const SLACK_COPY = {
 	missingSlackScopes:
 		"I'm missing a Slack permission in this workspace. Reconnect Slack from Databuddy settings so the new scopes are granted, then try again.",
 	noAnswer:
-		"I didn't get a usable result. Try again, or ask something specific like `traffic for the last 7 days`.",
+		"That took too long or came back empty. Try a narrower question — one site, or a shorter range like `traffic for the last 7 days`.",
 	processingReaction: "rabbit",
 	responseInterrupted:
 		"Response interrupted. The information above may be incomplete. Try again before acting on it.",


### PR DESCRIPTION
## Incident
Live P1: `@Databuddy what's my traffic today` → `both` returned **"I didn't get a usable result"** with no data.

## Root cause (from Axiom + Railway logs)
- The agent has a **45s internal timeout** (`DEFAULT_MCP_AGENT_TIMEOUT_MS`), and the Slack path passed **no `timeoutMs`** override → used 45s.
- The two-site query exceeded 45s (2× ClickHouse + `gpt-5.6-terra` reasoning latency) → `controller.abort()` fired → the in-flight ClickHouse query was aborted (`The user aborted a request` at `run-agent.ts:223`).
- Agent yielded **0 chunks** (wide event: `slack_stream_chunks=0, slack_answer_chars=0`) → `respond.ts` success path with empty text → misleading `noAnswer` copy.

**Not** the Block Kit / drill-down / App Home work — those act on streamed text, and nothing was streamed (0 chunks). Rejected via the wide-event counts.

## Fix
1. Slack passes `timeoutMs: 120_000` to `streamDatabuddyAgent` — well under the 5-min outer run timeout. Slack docs specify no stream-duration limit, so holding the 'thinking' stream open longer is safe.
2. Empty-result copy is now honest + actionable: 'That took too long or came back empty. Try a narrower question — one site, or a shorter range.'

## Testing
- apps/slack suite: **74/74 pass**, typecheck + ultracite clean.
- The timeout param is verified by code + typecheck (streamDatabuddyAgent accepts it); real-world confirmation needs the next multi-site query in prod — I'll watch the wide events after deploy.

## Follow-up (not in this PR)
If multi-site queries still approach 120s, the real fix is model/query latency, not the timeout. And a dynamic per-tool status ('Querying both sites…') would beat the static 'Thinking…' during long runs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised the Slack agent stream timeout to 120s and clarified the empty-result message. This prevents premature aborts on multi-site queries and gives users clearer next steps.

- **Bug Fixes**
  - Pass `timeoutMs: 120_000` to the Slack agent stream to avoid 45s aborts on longer queries.
  - Update empty-result copy to note timeouts and suggest narrowing scope (one site or shorter range).

<sup>Written for commit f99d511260100f92f949558ad369b721eb647723. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

