### PR TITLE
fix(ai): force data-table component for tables in Slack

### DIFF
--- a/packages/ai/src/ai/prompts/analytics.ts
+++ b/packages/ai/src/ai/prompts/analytics.ts
@@ -193,7 +193,7 @@ Output discipline:
 - Use only values from this turn's tool results. Render a Slack delivery's channelId as \`<#CHANNELID>\`.
 - Skip preamble. Lead with the receipt itself. NEVER start with "Sure", "Got it", "Done.", "Done!", "Great", "Perfect", "Here's", "Thinking", "I've routed", "I've set up", "I've configured", "Let me", "I'll", or any acknowledgement of the user's message.
 - Default reply: 1-2 short sentences for receipts, up to 3-6 short sentences for metric summaries. No headings/report formatting unless asked. No invented numbers. No marketing or re-pitch.
-- Slack renders component JSON natively: prefer a data-table over a long markdown table, and use chart/list components for trends and rankings. After a substantive analytics answer you may append one suggested-actions component with tailored drill-down follow-ups.
+- Slack cannot render markdown/ASCII tables — they show as broken stacked text. For ANY tabular data (even two rows), emit a data-table component as JSON on its own line, never a markdown table. Use chart/list components for trends and rankings. After a substantive analytics answer you may append one suggested-actions component with tailored drill-down follow-ups.
 - Rewrite/exact-copy tasks => output only the final copy. No labels, options, explanation, or preamble.
 
 - After delivering concrete metrics, you may offer weekly investigations in this channel once. If accepted, call configure_investigations action=configure, channelAction=add, channelId=slack_channel_id, frequency=weekly, confirmed=false, then confirmed=true after approval.


### PR DESCRIPTION
## The 'wrong table in Slack'
The bot's traffic tables render as a broken stack of values in Slack. Cause: the agent emits **markdown tables**, but Slack's `markdown_text` streaming format **can't render markdown/ASCII tables** — so they collapse into stacked text. Confirmed via wide events: every answer has `slack_component_count = 0, slack_block_count = 0` — the native `data_table` rendering we built is never triggered.

The base MCP prompt says 'Markdown tables for data', and my earlier Slack nudge was too soft ('prefer a data-table over a *long* markdown table') — a 2-row table isn't 'long', so the model used markdown.

## Fix
Hard rule in the Slack-only prompt section: **Slack cannot render markdown tables; emit a data-table component for ANY tabular data (even two rows), never a markdown table.** Only affects Slack output (dashboard still uses markdown tables).

## Verify
One-line prompt change; no tests assert the text. Real confirmation is the next Slack table rendering as a native `data_table` block (`slack_block_count > 0`) — I'll check the wide event after deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `data-table` for any tabular data in Slack to fix broken markdown tables and restore native table rendering. Only affects Slack output; dashboard remains unchanged.

- **Bug Fixes**
  - Updated Slack-only prompt in `packages/ai/src/ai/prompts/analytics.ts` to always emit a `data-table` JSON block for any table (even two rows), never markdown/ASCII tables.

<sup>Written for commit 0da5e8c8eaaead06a14d3c27eef990f2bda1990d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

