### PR TITLE
fix(db): cap ClickHouse queries at 25s (no more 120s hangs)

### DIFF
--- a/packages/db/src/clickhouse/client.ts
+++ b/packages/db/src/clickhouse/client.ts
@@ -198,6 +198,8 @@ async function readJsonResponse<T>(
 	}
 }
 
+const CH_QUERY_MAX_MS = 25_000;
+
 async function chQueryWithMeta<T>(
 	query: string,
 	params?: Record<string, unknown>,
@@ -213,19 +215,21 @@ async function chQueryWithMeta<T>(
 			}
 		: { ...(options?.clickhouse_settings ?? {}), ...finalSettings };
 	assertCacheCompatibleSettings(settings);
+	const timeoutSignal = AbortSignal.timeout(CH_QUERY_MAX_MS);
+	const abortSignal = options?.abort_signal
+		? AbortSignal.any([options.abort_signal, timeoutSignal])
+		: timeoutSignal;
 	const json = await readJsonResponse<T>(
 		() =>
 			clickHouse.query({
 				query: logical.query,
 				query_params: params,
-				...(options?.abort_signal && {
-					abort_signal: options.abort_signal,
-				}),
+				abort_signal: abortSignal,
 				...(Object.keys(settings).length > 0 && {
 					clickhouse_settings: settings,
 				}),
 			}),
-		options?.abort_signal
+		abortSignal
 	);
 
 	const intColumns = new Set(


### PR DESCRIPTION
## The reliability root cause
When a ClickHouse connection hangs (dead keep-alive socket / network blip), the query used to stall the **full caller budget** — 120s for the Slack agent — then return nothing. That's the '`get_data` hung 2 minutes' incident.

Why the client's own `request_timeout: 30s` didn't save us: **passing an `abort_signal` to @clickhouse/client supersedes `request_timeout`**. The agent passes its 120s signal, so a hung connection rode the full 120s.

## Fix
Every query now runs under `AbortSignal.any([callerSignal, AbortSignal.timeout(25s)])` — so a hung connection fails fast at 25s regardless of the caller's budget, while caller-initiated aborts still work exactly as before.

This is the clean version of the earlier ping-guard idea: no per-query ping (that broke the abort tests by pinging in the hot path), just a hard cap the caller can't bypass.

## Scope + testing
- Shared path (`chQueryWithMeta`) — caps agent **and** dashboard queries. No analytics query should take 25s, so it's a pure safety net; a pathological query now errors fast instead of hanging.
- **102 ClickHouse tests pass** (incl. the abort + timeout-propagation tests, untouched), typecheck + ultracite clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap all ClickHouse queries at 25s to fail fast on hung connections and avoid 120s stalls. Caller-triggered aborts still work the same.

- **Bug Fixes**
  - Enforce a hard 25s cap via `AbortSignal.any([callerSignal, AbortSignal.timeout(25_000)])` in `chQueryWithMeta`.
  - Corrects behavior where passing a caller `abort_signal` to `@clickhouse/client` overrode `request_timeout`, leading to long hangs.
  - Applies to both agent and dashboard queries; valid queries are unaffected.

<sup>Written for commit a028474654de93447d8a5383c2432b71b1042831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

