### PR TITLE
feat(slack): connected sites on the App Home tab

### DIFF
--- a/apps/slack/src/slack/app-home.test.ts
+++ b/apps/slack/src/slack/app-home.test.ts
@@ -24,6 +24,21 @@ describe("buildAppHomeView", () => {
 		);
 	});
 
+	it("renders connected sites when provided, and omits the block when empty", () => {
+		const withSites = buildAppHomeView([
+			{ domain: "app.databuddy.cc", name: "Dashboard" },
+			{ domain: "databuddy.cc", name: null },
+		]);
+		const text = JSON.stringify(withSites);
+		expect(text).toContain("Your connected sites");
+		expect(text).toContain("*Dashboard* — app.databuddy.cc");
+		expect(text).toContain("• databuddy.cc");
+
+		expect(JSON.stringify(buildAppHomeView([]))).not.toContain(
+			"Your connected sites"
+		);
+	});
+
 	it("lists the suggested prompts", () => {
 		const view = buildAppHomeView();
 		const text = JSON.stringify(view);

--- a/apps/slack/src/slack/app-home.ts
+++ b/apps/slack/src/slack/app-home.ts
@@ -1,7 +1,13 @@
-import type { HomeView } from "@slack/web-api";
+import type { HomeView, KnownBlock } from "@slack/web-api";
 import { SLACK_SUGGESTED_PROMPTS } from "@/slack/messages";
 
 const DASHBOARD_URL = "https://app.databuddy.cc";
+const MAX_HOME_SITES = 10;
+
+export interface ConnectedSite {
+	domain: string;
+	name: string | null;
+}
 
 const QUICK_ACTIONS = [
 	{ text: "Open dashboard", url: DASHBOARD_URL, style: "primary" as const },
@@ -9,10 +15,27 @@ const QUICK_ACTIONS = [
 	{ text: "Your websites", url: `${DASHBOARD_URL}/websites` },
 ];
 
-export function buildAppHomeView(): HomeView {
+function connectedSitesBlock(sites: ConnectedSite[]): KnownBlock | null {
+	if (sites.length === 0) {
+		return null;
+	}
+	const lines = sites
+		.slice(0, MAX_HOME_SITES)
+		.map((site) =>
+			site.name ? `• *${site.name}* — ${site.domain}` : `• ${site.domain}`
+		)
+		.join("\n");
+	return {
+		type: "section",
+		text: { type: "mrkdwn", text: `*Your connected sites*\n${lines}` },
+	};
+}
+
+export function buildAppHomeView(sites: ConnectedSite[] = []): HomeView {
 	const prompts = SLACK_SUGGESTED_PROMPTS.map(
 		(prompt) => `• ${prompt.message}`
 	).join("\n");
+	const sitesBlock = connectedSitesBlock(sites);
 
 	return {
 		type: "home",
@@ -28,6 +51,7 @@ export function buildAppHomeView(): HomeView {
 					text: "Ask about your analytics right here in Slack — traffic, pages, conversions, campaigns, errors, and product usage. Mention *@Databuddy*, send a direct message, or use the assistant.",
 				},
 			},
+			...(sitesBlock ? [sitesBlock] : []),
 			{
 				type: "actions",
 				elements: QUICK_ACTIONS.map((action) => ({

--- a/apps/slack/src/slack/listeners.ts
+++ b/apps/slack/src/slack/listeners.ts
@@ -4,11 +4,12 @@ import {
 	insightObservations,
 	insightRunEffects,
 	insightRunItems,
+	websites,
 } from "@databuddy/db/schema";
 import { createRPCContext } from "@databuddy/rpc";
 import { appendInvestigationReply } from "@databuddy/rpc/insights";
 import type { DatabuddyAgentClient, SlackAgentRun } from "@/agent/agent-client";
-import { buildAppHomeView } from "@/slack/app-home";
+import { type ConnectedSite, buildAppHomeView } from "@/slack/app-home";
 import { createSlackEventLog } from "@/lib/evlog-slack";
 import { abortSlackActiveRun } from "@/slack/active-runs";
 import { getSlackChannelMentionPolicy } from "@/slack/channel-policy";
@@ -157,14 +158,15 @@ export function registerSlackListeners(
 
 	app.assistant(createDatabuddyAssistant({ agent, dedupe, threadQueue }));
 
-	app.event("app_home_opened", async ({ client, event, logger }) => {
+	app.event("app_home_opened", async ({ client, context, event, logger }) => {
 		if (event.tab !== "home") {
 			return;
 		}
 		try {
+			const sites = await fetchConnectedSites(installations, context.teamId);
 			await client.views.publish({
 				user_id: event.user,
-				view: buildAppHomeView(),
+				view: buildAppHomeView(sites),
 			});
 		} catch (error) {
 			logger.warn("Failed to publish Slack App Home", error);
@@ -478,6 +480,22 @@ function registerSlackFeedbackButtons(
 			});
 		}
 	);
+}
+
+async function fetchConnectedSites(
+	installations: Pick<SlackInstallationServices, "getTeamContext">,
+	teamId?: string
+): Promise<ConnectedSite[]> {
+	const context = await installations.getTeamContext(teamId);
+	if (!context) {
+		return [];
+	}
+	return await db
+		.select({ domain: websites.domain, name: websites.name })
+		.from(websites)
+		.where(eq(websites.organizationId, context.organizationId))
+		.orderBy(websites.domain)
+		.limit(25);
 }
 
 async function handleInvestigationThreadReply({


### PR DESCRIPTION
Turns the static App Home tab into something live: when a user opens the Databuddy Home tab, it now lists their org's **connected sites** (name + domain), fetched from the DB.

## How
- `app_home_opened` resolves the user's team → org (`getTeamContext`), queries the `websites` table for that org, and publishes the enriched view.
- `buildAppHomeView(sites)` stays pure/testable — the section is omitted entirely when there are no sites, and capped at 10.
- Guarded: any failure falls back to the static view (never throws in the handler).

## Scope
Deliberately left out the 'open investigations' count — that needs precise insights-schema semantics I won't guess at (a wrong count is worse than none). Connected sites is unambiguous.

## Testing
- 4 App Home tests (sites rendered, empty omitted), **78/78 Slack suite**, typecheck + ultracite clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Slack App Home tab dynamic by listing the org’s connected sites (name + domain) when a user opens Databuddy Home. Falls back to the static view on any error.

- **New Features**
  - On `app_home_opened`, fetches the org’s sites from `websites` and publishes a view showing up to 10.
  - `buildAppHomeView(sites)` is pure and omits the section when empty.
  - Guarded behavior: failures return the static view; tests cover rendering and empty state.

<sup>Written for commit cf2985f61d478d97fae0b7ee61a85eb82aaf9c75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

