### PR TITLE
refactor(slack): retire emoji-reaction feedback (native buttons confirmed live)

### DIFF
--- a/apps/slack/slack-app-manifest.json
+++ b/apps/slack/slack-app-manifest.json
@@ -66,7 +66,6 @@
         "groups:history",
         "groups:read",
         "im:history",
-        "reactions:read",
         "reactions:write"
       ]
     }
@@ -80,9 +79,7 @@
         "assistant_thread_started",
         "message.channels",
         "message.groups",
-        "message.im",
-        "reaction_added",
-        "reaction_removed"
+        "message.im"
       ]
     },
     "interactivity": {

--- a/apps/slack/src/slack/feedback.ts
+++ b/apps/slack/src/slack/feedback.ts
@@ -4,12 +4,8 @@ import {
 	normalizeAgentFeedbackSignal,
 	recordAgentFeedback,
 } from "@databuddy/ai/agent/feedback";
-import type { types } from "@slack/bolt";
 import { createSlackEventLog, setSlackLog, toError } from "@/lib/evlog-slack";
 import type { SlackInstallationServices } from "@/slack/installations";
-import { SLACK_COPY } from "@/slack/messages";
-
-export type SlackFeedbackAction = "added" | "removed";
 
 export function resolveSlackFeedbackSignal(action: unknown): string | null {
 	if (!isRecord(action)) {
@@ -96,140 +92,7 @@ export async function handleSlackFeedbackAction({
 	}
 }
 
-type SlackReactionEvent = types.ReactionAddedEvent | types.ReactionRemovedEvent;
-
-interface SlackReactionEventLike {
-	eventTs?: SlackReactionEvent["event_ts"];
-	item?: SlackReactionEvent["item"];
-	itemUser?: SlackReactionEvent["item_user"];
-	reaction?: SlackReactionEvent["reaction"];
-	team?: string;
-	user?: SlackReactionEvent["user"];
-}
-
 interface SlackFeedbackLogger {
 	error(...args: unknown[]): void;
 	warn(...args: unknown[]): void;
-}
-
-export async function logSlackReactionFeedback({
-	action,
-	botUserId,
-	event,
-	installations,
-	logger,
-	teamId,
-}: {
-	action: SlackFeedbackAction;
-	botUserId?: string;
-	event: unknown;
-	installations: Pick<SlackInstallationServices, "getTeamContext">;
-	logger: SlackFeedbackLogger;
-	teamId?: string;
-}): Promise<void> {
-	const reactionEvent = toSlackReactionEvent(event);
-	if (
-		!reactionEvent?.reaction ||
-		reactionEvent.item?.type !== "message" ||
-		!reactionEvent.item.channel ||
-		!reactionEvent.item.ts
-	) {
-		return;
-	}
-
-	if (reactionEvent.user && botUserId && reactionEvent.user === botUserId) {
-		return;
-	}
-
-	if (
-		reactionEvent.itemUser &&
-		botUserId &&
-		reactionEvent.itemUser !== botUserId
-	) {
-		return;
-	}
-
-	const normalizedReaction = normalizeAgentFeedbackSignal(
-		reactionEvent.reaction
-	);
-	if (
-		action === "added" &&
-		normalizedReaction ===
-			normalizeAgentFeedbackSignal(SLACK_COPY.processingReaction)
-	) {
-		return;
-	}
-
-	const resolvedTeamId = teamId ?? reactionEvent.team;
-	const sentiment = classifyAgentFeedbackSentiment(normalizedReaction);
-	let integrationId: string | undefined;
-	let organizationId: string | undefined;
-	const eventLog = createSlackEventLog({
-		slack_channel_id: reactionEvent.item.channel,
-		slack_event: "feedback_reaction",
-		slack_event_ts: reactionEvent.eventTs,
-		slack_feedback_action: action,
-		slack_feedback_explicit: sentiment !== "neutral",
-		slack_feedback_reaction: normalizedReaction,
-		slack_feedback_sentiment: sentiment,
-		slack_message_ts: reactionEvent.item.ts,
-		slack_team_id: resolvedTeamId,
-		slack_user_id: reactionEvent.user,
-	});
-
-	try {
-		const teamContext = await installations.getTeamContext(resolvedTeamId);
-		integrationId = teamContext?.integrationId;
-		organizationId = teamContext?.organizationId;
-		setSlackLog(eventLog, {
-			slack_integration_id: integrationId,
-			slack_organization_id: organizationId,
-		});
-	} catch (error) {
-		const err = toError(error);
-		logger.warn("Failed to resolve Slack feedback context", err.message);
-		eventLog.error(err, { error_step: "feedback_context" });
-	} finally {
-		const feedback = recordAgentFeedback({
-			action,
-			integrationId,
-			organizationId,
-			responseId: reactionEvent.item.ts,
-			signal: normalizedReaction,
-			source: "slack",
-			sourceEventId: reactionEvent.eventTs,
-			targetId: reactionEvent.item.channel,
-			userId: reactionEvent.user,
-		});
-		setSlackLog(eventLog, feedback.wideEvent);
-		eventLog.emit();
-	}
-}
-
-function toSlackReactionEvent(event: unknown): SlackReactionEventLike | null {
-	if (!isRecord(event)) {
-		return null;
-	}
-	const item = toSlackReactionMessageItem(event.item);
-	return {
-		eventTs: getString(event.event_ts),
-		item,
-		itemUser: getString(event.item_user),
-		reaction: getString(event.reaction),
-		team: getString(event.team),
-		user: getString(event.user),
-	};
-}
-
-function toSlackReactionMessageItem(
-	item: unknown
-): SlackReactionEvent["item"] | undefined {
-	if (!isRecord(item)) {
-		return;
-	}
-	const channel = getString(item.channel);
-	const ts = getString(item.ts);
-	return item.type === "message" && channel && ts
-		? { channel, ts, type: "message" }
-		: undefined;
 }

--- a/apps/slack/src/slack/listeners.ts
+++ b/apps/slack/src/slack/listeners.ts
@@ -15,10 +15,7 @@ import { abortSlackActiveRun } from "@/slack/active-runs";
 import { getSlackChannelMentionPolicy } from "@/slack/channel-policy";
 import { DRILLDOWN_ACTION_ID, FEEDBACK_ACTION_ID } from "@/slack/blocks";
 import { parseDrilldownRun } from "@/slack/drilldown";
-import {
-	handleSlackFeedbackAction,
-	logSlackReactionFeedback,
-} from "@/slack/feedback";
+import { handleSlackFeedbackAction } from "@/slack/feedback";
 import type { SlackInstallationServices } from "@/slack/installations";
 import {
 	createRecentDedupe,
@@ -429,7 +426,6 @@ export function registerSlackListeners(
 	});
 
 	registerSlackCommands(app, installations);
-	registerSlackReactionFeedback(app, installations);
 	registerSlackFeedbackButtons(app, installations);
 	registerSlackDrilldown(app, agent, threadQueue);
 }
@@ -642,27 +638,6 @@ function registerSlackCommands(
 		await ack();
 		await respondToBindCommand({ command, installations, logger, respond });
 	});
-}
-
-function registerSlackReactionFeedback(
-	app: App,
-	installations: SlackInstallationServices
-) {
-	for (const [eventName, action] of [
-		["reaction_added", "added"],
-		["reaction_removed", "removed"],
-	] as const) {
-		app.event(eventName, async ({ context, event, logger }) => {
-			await logSlackReactionFeedback({
-				action,
-				botUserId: context.botUserId,
-				event,
-				installations,
-				logger,
-				teamId: context.teamId,
-			});
-		});
-	}
 }
 
 function getMentionSourceTeamId(event: {


### PR DESCRIPTION
Now that the native `feedback_buttons` path is **confirmed working in prod** (a 👍 click recorded: `slack_event: feedback_button, sentiment: positive, org resolved, recordAgentFeedback fired`), the emoji-reaction feedback path is redundant. Removing it.

## Deleted
- `logSlackReactionFeedback` + its reaction-event types/helpers (feedback.ts, ~137 lines)
- The `reaction_added`/`reaction_removed` listeners + `registerSlackReactionFeedback` (listeners.ts)
- `reaction_added`/`reaction_removed` bot events and the `reactions:read` scope from the manifest

## Kept
- `reactions:write` + the 🐰 processing-acknowledgement reaction (that's a separate, still-useful signal — not feedback).
- The native `feedback_buttons` path (`handleSlackFeedbackAction`) — now the sole feedback mechanism.

## Result
**Net −165 lines**, one feedback path instead of two, one fewer OAuth scope. 78/78 Slack tests pass, typecheck + ultracite clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires Slack emoji-reaction feedback now that native `feedback_buttons` is live in production. This simplifies feedback to a single path and removes the `reactions:read` scope and reaction event listeners.

- **Refactors**
  - Removed reaction feedback code and `reaction_added`/`reaction_removed` listeners.
  - Updated manifest: dropped `reactions:read` and reaction events; kept `reactions:write` for the processing-ack reaction.
  - `handleSlackFeedbackAction` is now the sole feedback path; all Slack tests pass.

<sup>Written for commit 7b6b133baefb1c579e9741ab93dfa6b193c79215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

