### PR TITLE
fix(links): recover Redis cache connections

### DIFF
--- a/apps/links/src/lib/logging.ts
+++ b/apps/links/src/lib/logging.ts
@@ -149,3 +149,22 @@ export function captureError(
 		});
 	}
 }
+
+/** Log a recovered dependency failure without turning the request into an incident. */
+export function captureWarning(error: Error, attributes?: LogFields): void {
+	try {
+		const requestLog = getRequestLogger();
+		if (attributes) {
+			requestLog.warn(error.message, attributes);
+		} else {
+			requestLog.warn(error.message);
+		}
+	} catch {
+		log.warn({
+			service: "links",
+			error_message: error.message,
+			...(error.stack ? { error_stack: error.stack } : {}),
+			...(attributes ?? {}),
+		});
+	}
+}

--- a/apps/links/src/routes/redirect.route.test.ts
+++ b/apps/links/src/routes/redirect.route.test.ts
@@ -13,6 +13,8 @@ const getCachedLink = mock();
 const ratelimit = mock();
 const resolveDeepLink = mock();
 const enqueueLinkVisit = mock();
+const captureError = mock(() => {});
+const captureWarning = mock(() => {});
 const linkVisitDeliveryModule = { ...actualLinkVisitDelivery };
 
 mock.module("@databuddy/env/app", () => ({
@@ -73,7 +75,8 @@ mock.module("@databuddy/shared/constants/deep-link-apps", () => ({
 }));
 
 mock.module("../lib/logging", () => ({
-	captureError: mock(() => {}),
+	captureError,
+	captureWarning,
 	mergeWideEvent: mock(() => {}),
 	record: async <T>(_name: string, run: () => Promise<T> | T) => run(),
 	setAttributes: mock(() => {}),
@@ -112,6 +115,8 @@ beforeEach(() => {
 	ratelimit.mockClear();
 	resolveDeepLink.mockClear();
 	enqueueLinkVisit.mockClear();
+	captureError.mockClear();
+	captureWarning.mockClear();
 	getCachedLink.mockResolvedValue({ state: "miss" });
 	ratelimit.mockResolvedValue({
 		limit: 60,
@@ -124,6 +129,22 @@ beforeEach(() => {
 });
 
 describe("redirect route", () => {
+	test("warns and falls through to Postgres when the cache is unavailable", async () => {
+		const cacheError = new Error("Redis unavailable");
+		getCachedLink.mockRejectedValueOnce(cacheError);
+
+		const response = await app.handle(
+			new Request("http://links.test/cache-fallback")
+		);
+
+		expect(response.status).toBe(302);
+		expect(dbSelect).toHaveBeenCalledTimes(1);
+		expect(captureWarning).toHaveBeenCalledWith(cacheError, {
+			error_step: "cache_get",
+		});
+		expect(captureError).not.toHaveBeenCalled();
+	});
+
 	test("uses a negative cache hit without querying Postgres", async () => {
 		getCachedLink.mockResolvedValue({ state: "not_found" });
 

--- a/apps/links/src/routes/redirect.ts
+++ b/apps/links/src/routes/redirect.ts
@@ -19,7 +19,12 @@ import { Elysia, redirect, t } from "elysia";
 import { LRUCache } from "lru-cache";
 import { createHash, randomUUID } from "node:crypto";
 import { UAParser } from "ua-parser-js";
-import { captureError, mergeWideEvent, record } from "../lib/logging";
+import {
+	captureError,
+	captureWarning,
+	mergeWideEvent,
+	record,
+} from "../lib/logging";
 import { createDeepLinkFallbackResponse } from "../lib/deep-link-fallback";
 import { enqueueLinkVisit } from "../lib/link-visit-delivery";
 import type { LinkVisitEvent } from "../lib/producer";
@@ -154,7 +159,9 @@ async function lookupLink(slug: string, ipHash: string) {
 	const t0 = performance.now();
 	const cached = await record("link.cache.get", () =>
 		getCachedLink(slug).catch((err) => {
-			captureError(err, { error_step: "cache_get" });
+			captureWarning(err instanceof Error ? err : new Error(String(err)), {
+				error_step: "cache_get",
+			});
 			return { state: "miss" as const };
 		})
 	);
@@ -230,9 +237,11 @@ async function lookupLink(slug: string, ipHash: string) {
 
 	if (!row) {
 		await record("link.cache.set_not_found", () =>
-			setCachedLinkNotFoundIfAbsent(slug).catch((err) =>
-				captureError(err, { error_step: "cache_set_not_found" })
-			)
+			setCachedLinkNotFoundIfAbsent(slug).catch((err) => {
+				captureWarning(err instanceof Error ? err : new Error(String(err)), {
+					error_step: "cache_set_not_found",
+				});
+			})
 		);
 		return {
 			link: null,
@@ -259,9 +268,11 @@ async function lookupLink(slug: string, ipHash: string) {
 	};
 
 	await record("link.cache.set", () =>
-		setCachedLinkIfAbsent(slug, link).catch((err) =>
-			captureError(err, { error_step: "cache_backfill" })
-		)
+		setCachedLinkIfAbsent(slug, link).catch((err) => {
+			captureWarning(err instanceof Error ? err : new Error(String(err)), {
+				error_step: "cache_backfill",
+			});
+		})
 	);
 	return {
 		link,

--- a/packages/redis/000-redis.test.ts
+++ b/packages/redis/000-redis.test.ts
@@ -40,10 +40,12 @@ describe("redis", () => {
 			expect(options.maxRetriesPerRequest).toBe(1);
 		});
 
-		it("does not queue commands or reconnect after failure", () => {
+		it("does not queue commands and reconnects with capped backoff", () => {
 			expect(options.enableOfflineQueue).toBe(false);
 			expect(options.lazyConnect).toBe(true);
-			expect(options.retryStrategy(1)).toBeNull();
+			expect(options.retryStrategy(1)).toBe(100);
+			expect(options.retryStrategy(30)).toBe(3000);
+			expect(options.retryStrategy(1000)).toBe(3000);
 		});
 	});
 
@@ -59,11 +61,13 @@ describe("redis", () => {
 			expect(options.commandTimeout).toBe(1000);
 		});
 
-		it("does not queue commands or reconnect after failure", () => {
+		it("does not queue commands and reconnects with capped backoff", () => {
 			expect(options.enableOfflineQueue).toBe(false);
 			expect(options.lazyConnect).toBe(true);
 			expect(options.maxRetriesPerRequest).toBe(1);
-			expect(options.retryStrategy(1)).toBeNull();
+			expect(options.retryStrategy(1)).toBe(100);
+			expect(options.retryStrategy(30)).toBe(3000);
+			expect(options.retryStrategy(1000)).toBe(3000);
 		});
 	});
 

--- a/packages/redis/redis-options.ts
+++ b/packages/redis/redis-options.ts
@@ -39,7 +39,9 @@ export function createLinkCacheRedisConnectionOptions(): LinkCacheRedisConnectio
 		enableOfflineQueue: false,
 		lazyConnect: true,
 		maxRetriesPerRequest: 1,
-		retryStrategy: () => null,
+		// Keep the client recovering after a Redis restart, while offline commands
+		// still reject immediately instead of queuing behind that recovery.
+		retryStrategy: (times) => Math.min(times * 100, 3000),
 	};
 }
 


### PR DESCRIPTION
## What changed

- keep link-cache and rate-limit Redis clients reconnecting with a capped 100 ms–3 s backoff
- keep `enableOfflineQueue: false`, so operations still fail immediately during recovery
- log recovered Redis cache read/write failures as warnings instead of Axiom errors

## Root cause

The latency-sensitive Redis clients returned `null` from `retryStrategy`, which permanently stopped reconnecting after a disconnect. Each recovered redirect fallback then emitted error-level telemetry despite successfully reading from Postgres.

## Validation

- `bun run lint`
- `bun run check-types`
- `bun test` in `packages/redis`
- `bun run test` in `apps/links`
- full pre-push monorepo test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore auto-reconnect for link-cache and rate-limit Redis clients with a capped 100 ms–3 s backoff to avoid permanent disconnects. During recovery, cache failures are logged as warnings, and requests fall back to Postgres without queuing.

- **Bug Fixes**
  - Redis: set `retryStrategy` to `Math.min(times * 100, 3000)`; keep `enableOfflineQueue: false`, `lazyConnect: true`, `maxRetriesPerRequest: 1`.
  - Logging: add `captureWarning` in `apps/links` and use it for `cache_get`, `cache_set_not_found`, and `cache_backfill` failures to reduce error noise.
  - Redirects: on cache errors, warn and fall through to Postgres; cache backfills remain best-effort.
  - Tests: update `packages/redis` and `apps/links` to cover backoff capping (100–3000 ms) and warning behavior, including a route test for cache-unavailable fallback.

<sup>Written for commit 289b412a60acb28598ff0824f9e044ee350efe6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

