### PR TITLE
test(slack): validate quick-action URL origins

### DIFF
--- a/apps/slack/src/slack/app-home.test.ts
+++ b/apps/slack/src/slack/app-home.test.ts
@@ -19,9 +19,10 @@ describe("buildAppHomeView", () => {
 		expect(actions).toBeDefined();
 		const buttons = actions?.elements as Array<{ url: string }>;
 		expect(buttons.length).toBeGreaterThan(0);
-		expect(buttons.every((b) => b.url.startsWith("https://app.databuddy.cc"))).toBe(
-			true
-		);
+			const dashboardOrigin = new URL("https://app.databuddy.cc").origin;
+			expect(buttons.every((button) => new URL(button.url).origin === dashboardOrigin)).toBe(
+				true
+			);
 	});
 
 	it("renders connected sites when provided, and omits the block when empty", () => {


### PR DESCRIPTION
## Summary
- compare Slack quick-action URLs by parsed origin
- remove the substring-validation pattern that triggered CodeQL

## Validation
- `bun test src/slack/app-home.test.ts`
- `bun run check-types`
- `bun run lint`
- full pre-push test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Slack App Home tests to validate quick-action URLs by parsing and comparing `URL.origin` instead of using a `startsWith` substring check. This removes the pattern flagged by CodeQL and more accurately enforces the allowed dashboard origin.

<sup>Written for commit b6ec83fd3cea0c000e8cbe1a0b9fd575c089bc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

