### PR TITLE
chore(ci): preserve staging during promotions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ For picker controls, use the component that matches the interaction:
 - **Keep integration linear**: Rebase a slice onto current `origin/staging` before it is ready for review; do not merge `staging` into the slice merely to refresh it. Request fresh review when a rebase changes reviewed code.
 - **Isolate parallel work**: Use one worktree per active branch. Never let two agents or contributors mutate the same branch or reuse a task branch for a different concern.
 - **Retire completed work**: Merged PR source branches are automatically deleted. Delete closed PR branches manually, remove clean finished worktrees, and create a new branch from current `staging` for any follow-up—never revive or repurpose an old PR branch.
+- **Promote safely**: Never open a `main` PR directly from `staging`, because GitHub can delete the merged PR head. Use `bun run release:prepare --create` to cut a disposable `release/staging-to-main-*` branch at the exact `origin/staging` commit, then open the promotion PR from that branch.
 
 ## CI and Review Lessons
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build --filter=@databuddy/devtools --filter=@databuddy/sdk && changeset publish",
+    "release:prepare": "bun scripts/prepare-staging-release.ts",
     "clean": "find . -type d \\( -name node_modules -o -name .next -o -name .turbo -o -name turbo \\) -prune -print -exec rm -rf {} +"
   },
   "type": "module",

--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+
+const RELEASE_BRANCH_PREFIX = "release/staging-to-main-";
+const ISO_MILLISECONDS = /\.\d{3}Z$/u;
+const ISO_SEPARATORS = /[-:]/gu;
+const create = process.argv.includes("--create");
+
+function run(command: string[]): string {
+	const result = spawnSync(command[0], command.slice(1), {
+		encoding: "utf8",
+	});
+	const stdout = result.stdout?.trim() ?? "";
+	const stderr = result.stderr?.trim() ?? "";
+
+	if (result.error || result.status !== 0) {
+		throw new Error(
+			`Command failed: ${command.join(" ")}\n${stderr || stdout || result.error?.message}`
+		);
+	}
+
+	return stdout;
+}
+
+function releaseBranchName() {
+	return `${RELEASE_BRANCH_PREFIX}${new Date()
+		.toISOString()
+		.replaceAll(ISO_SEPARATORS, "")
+		.replace(ISO_MILLISECONDS, "Z")}`;
+}
+
+interface PullRequest {
+	headRefName: string;
+	number: number;
+	url: string;
+}
+
+run(["git", "fetch", "origin", "main", "staging"]);
+
+const repository = run([
+	"gh",
+	"repo",
+	"view",
+	"--json",
+	"nameWithOwner",
+	"--jq",
+	".nameWithOwner",
+]);
+const mainSha = run(["git", "rev-parse", "origin/main"]);
+const stagingSha = run(["git", "rev-parse", "origin/staging"]);
+
+if (mainSha === stagingSha) {
+	console.log("staging already matches main; no release PR is needed.");
+	process.exit(0);
+}
+
+run(["git", "merge-base", "--is-ancestor", "origin/main", "origin/staging"]);
+
+const openPullRequests = JSON.parse(
+	run([
+		"gh",
+		"pr",
+		"list",
+		"--repo",
+		repository,
+		"--base",
+		"main",
+		"--state",
+		"open",
+		"--json",
+		"headRefName,number,url",
+	])
+) as PullRequest[];
+const existingRelease = openPullRequests.find(
+	(pullRequest) =>
+		pullRequest.headRefName === "staging" ||
+		pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+);
+
+if (existingRelease) {
+	throw new Error(
+		`An open staging promotion already exists: ${existingRelease.url}. Merge or close it before preparing another release.`
+	);
+}
+
+const branch = releaseBranchName();
+
+if (!create) {
+	console.log(`Release source: ${stagingSha}`);
+	console.log(`Release branch: ${branch}`);
+	console.log(
+		"Dry run only. Re-run with --create to push the disposable release branch and open the main PR."
+	);
+	process.exit(0);
+}
+
+run(["git", "push", "origin", `${stagingSha}:refs/heads/${branch}`]);
+
+const pullRequestBody = [
+	`Promotes staging commit ${stagingSha} through a disposable release branch`,
+	"so GitHub may delete the merged PR head without deleting staging.",
+].join(" ");
+const pullRequestUrl = run([
+	"gh",
+	"pr",
+	"create",
+	"--repo",
+	repository,
+	"--base",
+	"main",
+	"--head",
+	branch,
+	"--title",
+	"release: promote staging to main",
+	"--body",
+	pullRequestBody,
+]);
+
+console.log(`Release PR created: ${pullRequestUrl}`);


### PR DESCRIPTION
## Summary
- add `bun run release:prepare` to create a disposable release branch from `origin/staging`
- require `--create` before it pushes or opens the `main` promotion PR
- document that `staging` must never be the head of a main-release PR

## Validation
- `bun run lint`
- `bun run check-types`
- `bun run release:prepare`
- `bun run release:prepare --create` with synchronized refs
- full pre-push test suite

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Safely promotes `staging` to `main` by using a disposable release branch instead of `staging` as the PR head. Adds `bun run release:prepare` with a dry run by default and `--create` to push and open the PR.

- New Features
  - Adds `scripts/prepare-staging-release.ts` and `release:prepare` to cut `release/staging-to-main-*` from `origin/staging`; dry run prints the source and branch; `--create` pushes and opens a `main` PR.
  - Safety checks: no-op when `staging` equals `main`, ensures `main` is an ancestor of `staging`, and blocks if a promotion PR from `staging` or a `release/staging-to-main-*` branch is already open. Docs now state to never open a `main` PR from `staging`.

- Migration
  - Preview: `bun run release:prepare`
  - Create PR: `bun run release:prepare --create`

<sup>Written for commit f4f2488cd22ad06b9d2b0aec0a90ac8c6fba7339. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

