### PR TITLE
release: promote staging to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ For picker controls, use the component that matches the interaction:
 - **Keep integration linear**: Rebase a slice onto current `origin/staging` before it is ready for review; do not merge `staging` into the slice merely to refresh it. Request fresh review when a rebase changes reviewed code.
 - **Isolate parallel work**: Use one worktree per active branch. Never let two agents or contributors mutate the same branch or reuse a task branch for a different concern.
 - **Retire completed work**: Merged PR source branches are automatically deleted. Delete closed PR branches manually, remove clean finished worktrees, and create a new branch from current `staging` for any follow-up—never revive or repurpose an old PR branch.
+- **Promote safely**: Never open a `main` PR directly from `staging`, because GitHub can delete the merged PR head. Use `bun run release:prepare --create` to cut a disposable `release/staging-to-main-*` branch at the exact `origin/staging` commit, then open the promotion PR from that branch.
 
 ## CI and Review Lessons
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build --filter=@databuddy/devtools --filter=@databuddy/sdk && changeset publish",
+    "release:prepare": "bun scripts/prepare-staging-release.ts",
     "clean": "find . -type d \\( -name node_modules -o -name .next -o -name .turbo -o -name turbo \\) -prune -print -exec rm -rf {} +"
   },
   "type": "module",

--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+
+const RELEASE_BRANCH_PREFIX = "release/staging-to-main-";
+const ISO_MILLISECONDS = /\.\d{3}Z$/u;
+const ISO_SEPARATORS = /[-:]/gu;
+const create = process.argv.includes("--create");
+
+function run(command: string[]): string {
+	const result = spawnSync(command[0], command.slice(1), {
+		encoding: "utf8",
+	});
+	const stdout = result.stdout?.trim() ?? "";
+	const stderr = result.stderr?.trim() ?? "";
+
+	if (result.error || result.status !== 0) {
+		throw new Error(
+			`Command failed: ${command.join(" ")}\n${stderr || stdout || result.error?.message}`
+		);
+	}
+
+	return stdout;
+}
+
+function releaseBranchName() {
+	return `${RELEASE_BRANCH_PREFIX}${new Date()
+		.toISOString()
+		.replaceAll(ISO_SEPARATORS, "")
+		.replace(ISO_MILLISECONDS, "Z")}`;
+}
+
+interface PullRequest {
+	headRefName: string;
+	number: number;
+	url: string;
+}
+
+run(["git", "fetch", "origin", "main", "staging"]);
+
+const repository = run([
+	"gh",
+	"repo",
+	"view",
+	"--json",
+	"nameWithOwner",
+	"--jq",
+	".nameWithOwner",
+]);
+const mainSha = run(["git", "rev-parse", "origin/main"]);
+const stagingSha = run(["git", "rev-parse", "origin/staging"]);
+
+if (mainSha === stagingSha) {
+	console.log("staging already matches main; no release PR is needed.");
+	process.exit(0);
+}
+
+run(["git", "merge-base", "--is-ancestor", "origin/main", "origin/staging"]);
+
+const openPullRequests = JSON.parse(
+	run([
+		"gh",
+		"pr",
+		"list",
+		"--repo",
+		repository,
+		"--base",
+		"main",
+		"--state",
+		"open",
+		"--json",
+		"headRefName,number,url",
+	])
+) as PullRequest[];
+const existingRelease = openPullRequests.find(
+	(pullRequest) =>
+		pullRequest.headRefName === "staging" ||
+		pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+);
+
+if (existingRelease) {
+	throw new Error(
+		`An open staging promotion already exists: ${existingRelease.url}. Merge or close it before preparing another release.`
+	);
+}
+
+const branch = releaseBranchName();
+
+if (!create) {
+	console.log(`Release source: ${stagingSha}`);
+	console.log(`Release branch: ${branch}`);
+	console.log(
+		"Dry run only. Re-run with --create to push the disposable release branch and open the main PR."
+	);
+	process.exit(0);
+}
+
+run(["git", "push", "origin", `${stagingSha}:refs/heads/${branch}`]);
+
+const pullRequestBody = [
+	`Promotes staging commit ${stagingSha} through a disposable release branch`,
+	"so GitHub may delete the merged PR head without deleting staging.",
+].join(" ");
+const pullRequestUrl = run([
+	"gh",
+	"pr",
+	"create",
+	"--repo",
+	repository,
+	"--base",
+	"main",
+	"--head",
+	branch,
+	"--title",
+	"release: promote staging to main",
+	"--body",
+	pullRequestBody,
+]);
+
+console.log(`Release PR created: ${pullRequestUrl}`);


### PR DESCRIPTION
Promotes staging commit fa88e4d722920589876801c2e63e78296221da8a through a disposable release branch so GitHub may delete the merged PR head without deleting staging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes `staging` to `main` through a disposable `release/staging-to-main-*` branch and adds a `release:prepare` script to automate future promotions and protect `staging` from deletion.

- **New Features**
  - Added `release:prepare` (`bun scripts/prepare-staging-release.ts`) and wired it in `package.json`.
  - Dry run by default; use `--create` to push the branch and open the PR via `gh`. Validates `staging` is ahead and blocks duplicate promotion PRs.
  - Documented the safe promotion rule in AGENTS.md.

- **Migration**
  - To promote, run: `bun run release:prepare --create`.

<sup>Written for commit fa88e4d722920589876801c2e63e78296221da8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/607?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

