### PR TITLE
fix(ci): harden release promotion helper

### DIFF
--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -1,31 +1,67 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync } from "bun";
 
 const RELEASE_BRANCH_PREFIX = "release/staging-to-main-";
-const ISO_MILLISECONDS = /\.\d{3}Z$/u;
-const ISO_SEPARATORS = /[-:]/gu;
+const RELEASE_BRANCH_SHA_LENGTH = 12;
+const GIT_SUFFIX = /\.git$/u;
+const GITHUB_ORIGIN =
+	/^(?:https:\/\/github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)(?<repository>[^/]+\/[^/]+)$/u;
 const create = process.argv.includes("--create");
 
-function run(command: string[]): string {
-	const result = spawnSync(command[0], command.slice(1), {
-		encoding: "utf8",
-	});
-	const stdout = result.stdout?.trim() ?? "";
-	const stderr = result.stderr?.trim() ?? "";
+interface CommandResult {
+	stderr: string;
+	stdout: string;
+	success: boolean;
+}
 
-	if (result.error || result.status !== 0) {
+const decoder = new TextDecoder();
+
+function execute(command: string[]): CommandResult {
+	const result = spawnSync(command, {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	return {
+		stderr: decoder.decode(result.stderr).trim(),
+		stdout: decoder.decode(result.stdout).trim(),
+		success: result.success,
+	};
+}
+
+function run(command: string[]): string {
+	const result = execute(command);
+
+	if (!result.success) {
 		throw new Error(
-			`Command failed: ${command.join(" ")}\n${stderr || stdout || result.error?.message}`
+			`Command failed: ${command.join(" ")}\n${result.stderr || result.stdout}`
 		);
 	}
 
-	return stdout;
+	return result.stdout;
 }
 
-function releaseBranchName() {
-	return `${RELEASE_BRANCH_PREFIX}${new Date()
-		.toISOString()
-		.replaceAll(ISO_SEPARATORS, "")
-		.replace(ISO_MILLISECONDS, "Z")}`;
+function output(message: string) {
+	process.stdout.write(`${message}\n`);
+}
+
+function originRepository() {
+	const origin = run(["git", "remote", "get-url", "origin"]).replace(
+		GIT_SUFFIX,
+		""
+	);
+	const repository = origin.match(GITHUB_ORIGIN)?.groups?.repository;
+
+	if (!repository) {
+		throw new Error(
+			`origin must be a github.com repository URL; received ${origin}`
+		);
+	}
+
+	return repository;
+}
+
+function releaseBranchName(stagingSha: string) {
+	return `${RELEASE_BRANCH_PREFIX}${stagingSha.slice(0, RELEASE_BRANCH_SHA_LENGTH)}`;
 }
 
 interface PullRequest {
@@ -34,60 +70,65 @@ interface PullRequest {
 	url: string;
 }
 
+function openReleasePullRequest(repository: string, branch: string) {
+	const openPullRequests = JSON.parse(
+		run([
+			"gh",
+			"pr",
+			"list",
+			"--repo",
+			repository,
+			"--base",
+			"main",
+			"--state",
+			"open",
+			"--json",
+			"headRefName,number,url",
+		])
+	) as PullRequest[];
+
+	const existingPromotion = openPullRequests.find(
+		(pullRequest) =>
+			pullRequest.headRefName === "staging" ||
+			pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+	);
+
+	if (existingPromotion && existingPromotion.headRefName !== branch) {
+		throw new Error(
+			`An open staging promotion already exists: ${existingPromotion.url}. Merge or close it before preparing another release.`
+		);
+	}
+
+	return existingPromotion;
+}
+
 run(["git", "fetch", "origin", "main", "staging"]);
 
-const repository = run([
-	"gh",
-	"repo",
-	"view",
-	"--json",
-	"nameWithOwner",
-	"--jq",
-	".nameWithOwner",
-]);
+const repository = originRepository();
 const mainSha = run(["git", "rev-parse", "origin/main"]);
 const stagingSha = run(["git", "rev-parse", "origin/staging"]);
 
 if (mainSha === stagingSha) {
-	console.log("staging already matches main; no release PR is needed.");
+	output("staging already matches main; no release PR is needed.");
 	process.exit(0);
 }
 
 run(["git", "merge-base", "--is-ancestor", "origin/main", "origin/staging"]);
 
-const openPullRequests = JSON.parse(
-	run([
-		"gh",
-		"pr",
-		"list",
-		"--repo",
-		repository,
-		"--base",
-		"main",
-		"--state",
-		"open",
-		"--json",
-		"headRefName,number,url",
-	])
-) as PullRequest[];
-const existingRelease = openPullRequests.find(
-	(pullRequest) =>
-		pullRequest.headRefName === "staging" ||
-		pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
-);
+const branch = releaseBranchName(stagingSha);
+const existingRelease = openReleasePullRequest(repository, branch);
 
 if (existingRelease) {
-	throw new Error(
-		`An open staging promotion already exists: ${existingRelease.url}. Merge or close it before preparing another release.`
+	output(
+		`A promotion for this staging commit is already open: ${existingRelease.url}`
 	);
+	process.exit(0);
 }
 
-const branch = releaseBranchName();
-
 if (!create) {
-	console.log(`Release source: ${stagingSha}`);
-	console.log(`Release branch: ${branch}`);
-	console.log(
+	output(`Release source: ${stagingSha}`);
+	output(`Release branch: ${branch}`);
+	output(
 		"Dry run only. Re-run with --create to push the disposable release branch and open the main PR."
 	);
 	process.exit(0);
@@ -99,7 +140,7 @@ const pullRequestBody = [
 	`Promotes staging commit ${stagingSha} through a disposable release branch`,
 	"so GitHub may delete the merged PR head without deleting staging.",
 ].join(" ");
-const pullRequestUrl = run([
+const createPullRequest = execute([
 	"gh",
 	"pr",
 	"create",
@@ -115,4 +156,20 @@ const pullRequestUrl = run([
 	pullRequestBody,
 ]);
 
-console.log(`Release PR created: ${pullRequestUrl}`);
+if (createPullRequest.success) {
+	output(`Release PR created: ${createPullRequest.stdout}`);
+	process.exit(0);
+}
+
+const concurrentRelease = openReleasePullRequest(repository, branch);
+
+if (concurrentRelease) {
+	output(
+		`A concurrent promotion already created this release PR: ${concurrentRelease.url}`
+	);
+	process.exit(0);
+}
+
+throw new Error(
+	`Unable to create a release PR. The deterministic branch ${branch} remains reusable on retry.\n${createPullRequest.stderr || createPullRequest.stdout}`
+);


### PR DESCRIPTION
Addresses all Greptile findings from #607.

- derives the GitHub PR target from `origin`, matching fetch and push
- uses a deterministic source-SHA release branch, so concurrent invocations converge on one PR and failed creation retries reuse the branch
- uses Bun process APIs and repository-compliant output/date conventions

Validation:
- `bun run lint`
- `bun run check-types`
- `bun run test` (pre-push: 3,924 passing, 28 skipped)
- `git diff --check`
- `bun run release:prepare` (correctly rejected the existing #607 promotion)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the staging→main release promotion script for deterministic behavior and safe concurrency. Prevents duplicate promotions and makes failures retriable.

- **Refactors**
  - Derives the GitHub repository from `origin` and scopes `gh pr` calls to it; rejects non-GitHub remotes.
  - Names release branches as `release/staging-to-main-<12-char-staging-sha>` from `origin/staging` for idempotent retries.
  - Detects existing or concurrent promotions and reports/reuses the PR instead of failing; clearer dry-run output.
  - Switches to Bun process APIs with structured stdout/stderr handling for more reliable command execution.

<sup>Written for commit 73c9472b2eaa4c37fbcb5ed88c79bb677423d65a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

