### PR TITLE
fix(ci): paginate release promotion checks

### DIFF
--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -65,37 +65,34 @@ function releaseBranchName(stagingSha: string) {
 }
 
 interface PullRequest {
-	headRefName: string;
+	head: {
+		ref: string;
+	};
+	html_url: string;
 	number: number;
-	url: string;
 }
 
 function openReleasePullRequest(repository: string, branch: string) {
-	const openPullRequests = JSON.parse(
+	const pullRequestPages = JSON.parse(
 		run([
 			"gh",
-			"pr",
-			"list",
-			"--repo",
-			repository,
-			"--base",
-			"main",
-			"--state",
-			"open",
-			"--json",
-			"headRefName,number,url",
+			"api",
+			"--paginate",
+			"--slurp",
+			`repos/${repository}/pulls?state=open&base=main&per_page=100`,
 		])
-	) as PullRequest[];
+	) as PullRequest[][];
+	const openPullRequests = pullRequestPages.flat();
 
 	const existingPromotion = openPullRequests.find(
 		(pullRequest) =>
-			pullRequest.headRefName === "staging" ||
-			pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+			pullRequest.head.ref === "staging" ||
+			pullRequest.head.ref.startsWith(RELEASE_BRANCH_PREFIX)
 	);
 
-	if (existingPromotion && existingPromotion.headRefName !== branch) {
+	if (existingPromotion && existingPromotion.head.ref !== branch) {
 		throw new Error(
-			`An open staging promotion already exists: ${existingPromotion.url}. Merge or close it before preparing another release.`
+			`An open staging promotion already exists: ${existingPromotion.html_url}. Merge or close it before preparing another release.`
 		);
 	}
 
@@ -120,7 +117,7 @@ const existingRelease = openReleasePullRequest(repository, branch);
 
 if (existingRelease) {
 	output(
-		`A promotion for this staging commit is already open: ${existingRelease.url}`
+		`A promotion for this staging commit is already open: ${existingRelease.html_url}`
 	);
 	process.exit(0);
 }
@@ -165,7 +162,7 @@ const concurrentRelease = openReleasePullRequest(repository, branch);
 
 if (concurrentRelease) {
 	output(
-		`A concurrent promotion already created this release PR: ${concurrentRelease.url}`
+		`A concurrent promotion already created this release PR: ${concurrentRelease.html_url}`
 	);
 	process.exit(0);
 }


### PR DESCRIPTION
Addresses the remaining Greptile P2 on #609.

Uses GitHub REST pagination for the complete set of open PRs targeting `main`, so an existing promotion cannot be hidden beyond the CLI default page size.

Validation:
- `bun run lint`
- `bun run check-types`
- `bun run test` (pre-push: 3,924 passing, 28 skipped)
- `git diff --check`
- `bun run release:prepare` (found the open #609 promotion)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the release promotion script checks all open PRs to `main` using GitHub REST pagination, so existing promotions aren’t missed and duplicates aren’t created. Switches from `gh pr list` to `gh api --paginate`.

- **Bug Fixes**
  - Fetch all pages of open PRs via `gh api --paginate --slurp repos/{repo}/pulls?state=open&base=main&per_page=100`.
  - Match promotions by `head.ref` (`staging` or release branch prefix) and use `html_url` in messages.
  - Prevent false negatives when existing promotion PRs are beyond the default page size.

<sup>Written for commit 7f845ce9f7c025c727a31e4761e636d03c3f0916. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

