### PR TITLE
release: promote staging to main

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,6 +162,7 @@ For picker controls, use the component that matches the interaction:
 - **Keep integration linear**: Rebase a slice onto current `origin/staging` before it is ready for review; do not merge `staging` into the slice merely to refresh it. Request fresh review when a rebase changes reviewed code.
 - **Isolate parallel work**: Use one worktree per active branch. Never let two agents or contributors mutate the same branch or reuse a task branch for a different concern.
 - **Retire completed work**: Merged PR source branches are automatically deleted. Delete closed PR branches manually, remove clean finished worktrees, and create a new branch from current `staging` for any follow-up—never revive or repurpose an old PR branch.
+- **Promote safely**: Never open a `main` PR directly from `staging`, because GitHub can delete the merged PR head. Use `bun run release:prepare --create` to cut a disposable `release/staging-to-main-*` branch at the exact `origin/staging` commit, then open the promotion PR from that branch.
 
 ## CI and Review Lessons
 

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "turbo run build --filter=@databuddy/devtools --filter=@databuddy/sdk && changeset publish",
+    "release:prepare": "bun scripts/prepare-staging-release.ts",
     "clean": "find . -type d \\( -name node_modules -o -name .next -o -name .turbo -o -name turbo \\) -prune -print -exec rm -rf {} +"
   },
   "type": "module",

--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -1,0 +1,118 @@
+import { spawnSync } from "node:child_process";
+
+const RELEASE_BRANCH_PREFIX = "release/staging-to-main-";
+const ISO_MILLISECONDS = /\.\d{3}Z$/u;
+const ISO_SEPARATORS = /[-:]/gu;
+const create = process.argv.includes("--create");
+
+function run(command: string[]): string {
+	const result = spawnSync(command[0], command.slice(1), {
+		encoding: "utf8",
+	});
+	const stdout = result.stdout?.trim() ?? "";
+	const stderr = result.stderr?.trim() ?? "";
+
+	if (result.error || result.status !== 0) {
+		throw new Error(
+			`Command failed: ${command.join(" ")}\n${stderr || stdout || result.error?.message}`
+		);
+	}
+
+	return stdout;
+}
+
+function releaseBranchName() {
+	return `${RELEASE_BRANCH_PREFIX}${new Date()
+		.toISOString()
+		.replaceAll(ISO_SEPARATORS, "")
+		.replace(ISO_MILLISECONDS, "Z")}`;
+}
+
+interface PullRequest {
+	headRefName: string;
+	number: number;
+	url: string;
+}
+
+run(["git", "fetch", "origin", "main", "staging"]);
+
+const repository = run([
+	"gh",
+	"repo",
+	"view",
+	"--json",
+	"nameWithOwner",
+	"--jq",
+	".nameWithOwner",
+]);
+const mainSha = run(["git", "rev-parse", "origin/main"]);
+const stagingSha = run(["git", "rev-parse", "origin/staging"]);
+
+if (mainSha === stagingSha) {
+	console.log("staging already matches main; no release PR is needed.");
+	process.exit(0);
+}
+
+run(["git", "merge-base", "--is-ancestor", "origin/main", "origin/staging"]);
+
+const openPullRequests = JSON.parse(
+	run([
+		"gh",
+		"pr",
+		"list",
+		"--repo",
+		repository,
+		"--base",
+		"main",
+		"--state",
+		"open",
+		"--json",
+		"headRefName,number,url",
+	])
+) as PullRequest[];
+const existingRelease = openPullRequests.find(
+	(pullRequest) =>
+		pullRequest.headRefName === "staging" ||
+		pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+);
+
+if (existingRelease) {
+	throw new Error(
+		`An open staging promotion already exists: ${existingRelease.url}. Merge or close it before preparing another release.`
+	);
+}
+
+const branch = releaseBranchName();
+
+if (!create) {
+	console.log(`Release source: ${stagingSha}`);
+	console.log(`Release branch: ${branch}`);
+	console.log(
+		"Dry run only. Re-run with --create to push the disposable release branch and open the main PR."
+	);
+	process.exit(0);
+}
+
+run(["git", "push", "origin", `${stagingSha}:refs/heads/${branch}`]);
+
+const pullRequestBody = [
+	`Promotes staging commit ${stagingSha} through a disposable release branch`,
+	"so GitHub may delete the merged PR head without deleting staging.",
+].join(" ");
+const pullRequestUrl = run([
+	"gh",
+	"pr",
+	"create",
+	"--repo",
+	repository,
+	"--base",
+	"main",
+	"--head",
+	branch,
+	"--title",
+	"release: promote staging to main",
+	"--body",
+	pullRequestBody,
+]);
+
+console.log(`Release PR created: ${pullRequestUrl}`);

--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -65,37 +65,34 @@ function releaseBranchName(stagingSha: string) {
 }
 
 interface PullRequest {
-	headRefName: string;
+	head: {
+		ref: string;
+	};
+	html_url: string;
 	number: number;
-	url: string;
 }
 
 function openReleasePullRequest(repository: string, branch: string) {
-	const openPullRequests = JSON.parse(
+	const pullRequestPages = JSON.parse(
 		run([
 			"gh",
-			"pr",
-			"list",
-			"--repo",
-			repository,
-			"--base",
-			"main",
-			"--state",
-			"open",
-			"--json",
-			"headRefName,number,url",
+			"api",
+			"--paginate",
+			"--slurp",
+			`repos/${repository}/pulls?state=open&base=main&per_page=100`,
 		])
-	) as PullRequest[];
+	) as PullRequest[][];
+	const openPullRequests = pullRequestPages.flat();
 
 	const existingPromotion = openPullRequests.find(
 		(pullRequest) =>
-			pullRequest.headRefName === "staging" ||
-			pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+			pullRequest.head.ref === "staging" ||
+			pullRequest.head.ref.startsWith(RELEASE_BRANCH_PREFIX)
 	);
 
-	if (existingPromotion && existingPromotion.headRefName !== branch) {
+	if (existingPromotion && existingPromotion.head.ref !== branch) {
 		throw new Error(
-			`An open staging promotion already exists: ${existingPromotion.url}. Merge or close it before preparing another release.`
+			`An open staging promotion already exists: ${existingPromotion.html_url}. Merge or close it before preparing another release.`
 		);
 	}
 
@@ -120,7 +117,7 @@ const existingRelease = openReleasePullRequest(repository, branch);
 
 if (existingRelease) {
 	output(
-		`A promotion for this staging commit is already open: ${existingRelease.url}`
+		`A promotion for this staging commit is already open: ${existingRelease.html_url}`
 	);
 	process.exit(0);
 }
@@ -165,7 +162,7 @@ const concurrentRelease = openReleasePullRequest(repository, branch);
 
 if (concurrentRelease) {
 	output(
-		`A concurrent promotion already created this release PR: ${concurrentRelease.url}`
+		`A concurrent promotion already created this release PR: ${concurrentRelease.html_url}`
 	);
 	process.exit(0);
 }

--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -1,31 +1,67 @@
-import { spawnSync } from "node:child_process";
+import { spawnSync } from "bun";
 
 const RELEASE_BRANCH_PREFIX = "release/staging-to-main-";
-const ISO_MILLISECONDS = /\.\d{3}Z$/u;
-const ISO_SEPARATORS = /[-:]/gu;
+const RELEASE_BRANCH_SHA_LENGTH = 12;
+const GIT_SUFFIX = /\.git$/u;
+const GITHUB_ORIGIN =
+	/^(?:https:\/\/github\.com\/|git@github\.com:|ssh:\/\/git@github\.com\/)(?<repository>[^/]+\/[^/]+)$/u;
 const create = process.argv.includes("--create");
 
-function run(command: string[]): string {
-	const result = spawnSync(command[0], command.slice(1), {
-		encoding: "utf8",
-	});
-	const stdout = result.stdout?.trim() ?? "";
-	const stderr = result.stderr?.trim() ?? "";
+interface CommandResult {
+	stderr: string;
+	stdout: string;
+	success: boolean;
+}
 
-	if (result.error || result.status !== 0) {
+const decoder = new TextDecoder();
+
+function execute(command: string[]): CommandResult {
+	const result = spawnSync(command, {
+		stderr: "pipe",
+		stdout: "pipe",
+	});
+
+	return {
+		stderr: decoder.decode(result.stderr).trim(),
+		stdout: decoder.decode(result.stdout).trim(),
+		success: result.success,
+	};
+}
+
+function run(command: string[]): string {
+	const result = execute(command);
+
+	if (!result.success) {
 		throw new Error(
-			`Command failed: ${command.join(" ")}\n${stderr || stdout || result.error?.message}`
+			`Command failed: ${command.join(" ")}\n${result.stderr || result.stdout}`
 		);
 	}
 
-	return stdout;
+	return result.stdout;
 }
 
-function releaseBranchName() {
-	return `${RELEASE_BRANCH_PREFIX}${new Date()
-		.toISOString()
-		.replaceAll(ISO_SEPARATORS, "")
-		.replace(ISO_MILLISECONDS, "Z")}`;
+function output(message: string) {
+	process.stdout.write(`${message}\n`);
+}
+
+function originRepository() {
+	const origin = run(["git", "remote", "get-url", "origin"]).replace(
+		GIT_SUFFIX,
+		""
+	);
+	const repository = origin.match(GITHUB_ORIGIN)?.groups?.repository;
+
+	if (!repository) {
+		throw new Error(
+			`origin must be a github.com repository URL; received ${origin}`
+		);
+	}
+
+	return repository;
+}
+
+function releaseBranchName(stagingSha: string) {
+	return `${RELEASE_BRANCH_PREFIX}${stagingSha.slice(0, RELEASE_BRANCH_SHA_LENGTH)}`;
 }
 
 interface PullRequest {
@@ -34,60 +70,65 @@ interface PullRequest {
 	url: string;
 }
 
+function openReleasePullRequest(repository: string, branch: string) {
+	const openPullRequests = JSON.parse(
+		run([
+			"gh",
+			"pr",
+			"list",
+			"--repo",
+			repository,
+			"--base",
+			"main",
+			"--state",
+			"open",
+			"--json",
+			"headRefName,number,url",
+		])
+	) as PullRequest[];
+
+	const existingPromotion = openPullRequests.find(
+		(pullRequest) =>
+			pullRequest.headRefName === "staging" ||
+			pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
+	);
+
+	if (existingPromotion && existingPromotion.headRefName !== branch) {
+		throw new Error(
+			`An open staging promotion already exists: ${existingPromotion.url}. Merge or close it before preparing another release.`
+		);
+	}
+
+	return existingPromotion;
+}
+
 run(["git", "fetch", "origin", "main", "staging"]);
 
-const repository = run([
-	"gh",
-	"repo",
-	"view",
-	"--json",
-	"nameWithOwner",
-	"--jq",
-	".nameWithOwner",
-]);
+const repository = originRepository();
 const mainSha = run(["git", "rev-parse", "origin/main"]);
 const stagingSha = run(["git", "rev-parse", "origin/staging"]);
 
 if (mainSha === stagingSha) {
-	console.log("staging already matches main; no release PR is needed.");
+	output("staging already matches main; no release PR is needed.");
 	process.exit(0);
 }
 
 run(["git", "merge-base", "--is-ancestor", "origin/main", "origin/staging"]);
 
-const openPullRequests = JSON.parse(
-	run([
-		"gh",
-		"pr",
-		"list",
-		"--repo",
-		repository,
-		"--base",
-		"main",
-		"--state",
-		"open",
-		"--json",
-		"headRefName,number,url",
-	])
-) as PullRequest[];
-const existingRelease = openPullRequests.find(
-	(pullRequest) =>
-		pullRequest.headRefName === "staging" ||
-		pullRequest.headRefName.startsWith(RELEASE_BRANCH_PREFIX)
-);
+const branch = releaseBranchName(stagingSha);
+const existingRelease = openReleasePullRequest(repository, branch);
 
 if (existingRelease) {
-	throw new Error(
-		`An open staging promotion already exists: ${existingRelease.url}. Merge or close it before preparing another release.`
+	output(
+		`A promotion for this staging commit is already open: ${existingRelease.url}`
 	);
+	process.exit(0);
 }
 
-const branch = releaseBranchName();
-
 if (!create) {
-	console.log(`Release source: ${stagingSha}`);
-	console.log(`Release branch: ${branch}`);
-	console.log(
+	output(`Release source: ${stagingSha}`);
+	output(`Release branch: ${branch}`);
+	output(
 		"Dry run only. Re-run with --create to push the disposable release branch and open the main PR."
 	);
 	process.exit(0);
@@ -99,7 +140,7 @@ const pullRequestBody = [
 	`Promotes staging commit ${stagingSha} through a disposable release branch`,
 	"so GitHub may delete the merged PR head without deleting staging.",
 ].join(" ");
-const pullRequestUrl = run([
+const createPullRequest = execute([
 	"gh",
 	"pr",
 	"create",
@@ -115,4 +156,20 @@ const pullRequestUrl = run([
 	pullRequestBody,
 ]);
 
-console.log(`Release PR created: ${pullRequestUrl}`);
+if (createPullRequest.success) {
+	output(`Release PR created: ${createPullRequest.stdout}`);
+	process.exit(0);
+}
+
+const concurrentRelease = openReleasePullRequest(repository, branch);
+
+if (concurrentRelease) {
+	output(
+		`A concurrent promotion already created this release PR: ${concurrentRelease.url}`
+	);
+	process.exit(0);
+}
+
+throw new Error(
+	`Unable to create a release PR. The deterministic branch ${branch} remains reusable on retry.\n${createPullRequest.stderr || createPullRequest.stdout}`
+);


### PR DESCRIPTION
Promotes staging commit 97e4ac0c921d09e7f216283c0647d244aaacca20 through a disposable release branch so GitHub may delete the merged PR head without deleting staging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates safe staging-to-main promotions with a disposable release branch using a new `release:prepare` script. Prevents GitHub from deleting `staging` when the promotion PR is merged.

- **New Features**
  - Added `scripts/prepare-staging-release.ts` to create a deterministic `release/staging-to-main-<12sha>` branch at `origin/staging`, push it, and open the main PR via `gh`.
  - Dry run by default; use `--create` to actually push and open the PR. Detects existing promotions (with pagination) and exits early.
  - Validates `origin` is a GitHub repo and that `staging` is ahead of `main`. Adds `release:prepare` in `package.json`. Documents the workflow in AGENTS.md.

- **Migration**
  - Preview: `bun run release:prepare`
  - Promote: `bun run release:prepare --create`
  - Do not open a `main` PR directly from `staging`. Ensure `gh` is installed and authenticated, and `origin` points to GitHub.

<sup>Written for commit 97e4ac0c921d09e7f216283c0647d244aaacca20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

