### PR TITLE
fix(ci): scope release checks to origin

### DIFF
--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -67,6 +67,9 @@ function releaseBranchName(stagingSha: string) {
 interface PullRequest {
 	head: {
 		ref: string;
+		repo: {
+			full_name: string;
+		} | null;
 	};
 	html_url: string;
 	number: number;
@@ -86,8 +89,9 @@ function openReleasePullRequest(repository: string, branch: string) {
 
 	const existingPromotion = openPullRequests.find(
 		(pullRequest) =>
-			pullRequest.head.ref === "staging" ||
-			pullRequest.head.ref.startsWith(RELEASE_BRANCH_PREFIX)
+			pullRequest.head.repo?.full_name === repository &&
+			(pullRequest.head.ref === "staging" ||
+				pullRequest.head.ref.startsWith(RELEASE_BRANCH_PREFIX))
 	);
 
 	if (existingPromotion && existingPromotion.head.ref !== branch) {


### PR DESCRIPTION
Addresses the final Greptile P1 from #611.

Only considers promotion-style PR heads whose source repository equals the `origin` repository, preventing fork branches with matching names from blocking or impersonating a promotion.

Validation:
- `bun run lint`
- `bun run check-types`
- `bun run test` (pre-push: 3,924 passing, 28 skipped)
- `git diff --check`
- `bun run release:prepare` (found the open #611 promotion)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope release promotion checks to PRs whose head repo matches the origin repository. Prevents forks with matching branch names from blocking or impersonating promotions.

<sup>Written for commit 4ff1594a2d02fb3fcc35b085afe592747dbec99e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

