### PR TITLE
fix(ci): guard concurrent release promotions

### DIFF
--- a/scripts/prepare-staging-release.ts
+++ b/scripts/prepare-staging-release.ts
@@ -58,60 +58,36 @@ function releaseBranchName(stagingSha: string) {
 	return `${RELEASE_BRANCH_PREFIX}${stagingSha.slice(0, RELEASE_BRANCH_SHA_LENGTH)}`;
 }
 
-function arrayValues(value: unknown) {
-	return Array.isArray(value) ? (value as unknown[]) : [];
-}
-
-function recordValue(record: object, key: string) {
-	return Object.entries(record).find(([name]) => name === key)?.[1];
-}
-
 function openReleasePullRequest(repository: string) {
-	const pullRequestPages = arrayValues(
-		JSON.parse(
-			run([
-				"gh",
-				"api",
-				"--paginate",
-				"--slurp",
-				`repos/${repository}/pulls?state=open&base=main&per_page=100`,
-			])
-		)
-	);
+	const promotion = run([
+		"gh",
+		"pr",
+		"list",
+		"--repo",
+		repository,
+		"--state",
+		"open",
+		"--base",
+		"main",
+		"--limit",
+		"1000",
+		"--json",
+		"headRefName,headRepository,url",
+		"--jq",
+		`[.[] | select(.headRepository.nameWithOwner? == "${repository}") | select(.headRefName == "staging" or (.headRefName | startswith("${RELEASE_BRANCH_PREFIX}")))][0] | select(.) | [.headRefName, .url] | @tsv`,
+	]);
 
-	for (const pullRequestPage of pullRequestPages) {
-		for (const pullRequest of arrayValues(pullRequestPage)) {
-			if (typeof pullRequest !== "object" || pullRequest === null) {
-				continue;
-			}
-
-			const head = recordValue(pullRequest, "head");
-			const pullRequestUrl = recordValue(pullRequest, "html_url");
-
-			if (typeof head !== "object" || head === null) {
-				continue;
-			}
-
-			const headReference = recordValue(head, "ref");
-			const headRepository = recordValue(head, "repo");
-
-			if (typeof headRepository !== "object" || headRepository === null) {
-				continue;
-			}
-
-			const headRepositoryName = recordValue(headRepository, "full_name");
-
-			if (
-				headRepositoryName === repository &&
-				typeof headReference === "string" &&
-				typeof pullRequestUrl === "string" &&
-				(headReference === "staging" ||
-					headReference.startsWith(RELEASE_BRANCH_PREFIX))
-			) {
-				return { branch: headReference, url: pullRequestUrl };
-			}
-		}
+	if (!promotion) {
+		return;
 	}
+
+	const [promotionBranch, promotionUrl] = promotion.split("\t");
+
+	if (!(promotionBranch && promotionUrl)) {
+		throw new Error("GitHub returned an invalid open release promotion.");
+	}
+
+	return { branch: promotionBranch, url: promotionUrl };
 }
 
 function verifyNoConflictingRelease(repository: string, branch: string) {
@@ -187,11 +163,17 @@ if (createPullRequest.success) {
 
 const concurrentRelease = openReleasePullRequest(repository);
 
-if (concurrentRelease) {
+if (concurrentRelease?.branch === branch) {
 	output(
 		`A concurrent promotion already created this release PR: ${concurrentRelease.url}`
 	);
 	process.exit(0);
+}
+
+if (concurrentRelease) {
+	throw new Error(
+		`Another staging promotion is already open: ${concurrentRelease.url}. The deterministic branch ${branch} remains reusable on retry.`
+	);
 }
 
 throw new Error(


### PR DESCRIPTION
Addresses the final release-promotion review feedback.\n\nOnly the matching release branch can satisfy a concurrent-create retry, and GitHub filters the promotion listing to the fields the helper needs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards concurrent release promotions in CI to stop duplicate PRs and race conditions. Only reuses the deterministic release branch if an open PR matches it; otherwise the run fails with a clear message.

- **Bug Fixes**
  - Accepts a concurrent retry only when the open PR’s branch equals the deterministic release branch; exits early with success.
  - Replaces the paginated `gh api` scan with `gh pr list --json headRefName,headRepository,url` and a `jq` filter to target `staging` and release-prefixed branches from the same repo.

<sup>Written for commit e215825b104b1351c99aa6b460368cec8c07d84e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

