### PR TITLE
fix: harden user identity attribution

### DIFF
--- a/apps/basket/src/lib/request-validation-logic.test.ts
+++ b/apps/basket/src/lib/request-validation-logic.test.ts
@@ -229,6 +229,17 @@ describe("validateRequest", () => {
 		expect(mockCheckAutumnUsage).toHaveBeenCalled();
 	});
 
+	test("can skip event usage checks for non-event ingestion", async () => {
+		const result = await validateRequest(
+			{},
+			{ client_id: "ws_1" },
+			makeReq(),
+			{ checkUsage: false }
+		);
+		expect("clientId" in result).toBe(true);
+		expect(mockCheckAutumnUsage).not.toHaveBeenCalled();
+	});
+
 	test("no ownerId → skips billing check", async () => {
 		mockGetWebsiteByIdV2.mockResolvedValue({
 			id: "ws_1",

--- a/apps/basket/src/lib/request-validation.ts
+++ b/apps/basket/src/lib/request-validation.ts
@@ -25,6 +25,10 @@ export interface ValidatedRequest {
 	userAgent: string;
 }
 
+export interface ValidateRequestOptions {
+	checkUsage?: boolean;
+}
+
 interface WebsiteSecuritySettings {
 	allowedIps?: string[];
 	allowedOrigins?: string[];
@@ -53,7 +57,8 @@ export function getWebsiteSecuritySettings(
 export function validateRequest(
 	body: unknown,
 	query: unknown,
-	request: Request
+	request: Request,
+	options: ValidateRequestOptions = {}
 ): Promise<ValidatedRequest> {
 	return record("validateRequest", async () => {
 		const log = useLogger();
@@ -132,7 +137,7 @@ export function validateRequest(
 
 		log.set({ website: { domain: website.domain, status: website.status } });
 
-		if (website.ownerId) {
+		if (website.ownerId && options.checkUsage !== false) {
 			await checkAutumnUsage(website.ownerId, "events", {
 				website_domain: website.domain,
 				website_id: website.id,

--- a/apps/basket/src/routes/identify.test.ts
+++ b/apps/basket/src/routes/identify.test.ts
@@ -32,13 +32,17 @@ import { VALIDATION_LIMITS as SHARED_LIMITS } from "@databuddy/validation";
 import type { ApiKeyRow } from "@lib/api-key";
 import { hasWebsiteScope } from "@lib/api-key";
 import { VALIDATION_LIMITS } from "@utils/validation";
-import { denyApiKeyIdentify } from "./identify";
+import { denyApiKeyIdentify, normalizeIdentifyProfileId } from "./identify";
 
 describe("validation limit drift", () => {
 	test("profile id cap matches between schema and sanitization", () => {
 		expect(VALIDATION_LIMITS.USER_ID_MAX_LENGTH).toBe(
 			SHARED_LIMITS.USER_ID_MAX_LENGTH
 		);
+	});
+
+	test("normalizes profile ids with the same ingestion sanitizer", () => {
+		expect(normalizeIdentifyProfileId("  profile-1\u0000  ")).toBe("profile-1");
 	});
 });
 

--- a/apps/basket/src/routes/identify.ts
+++ b/apps/basket/src/routes/identify.ts
@@ -18,7 +18,9 @@ import {
 	rethrowOrWrap,
 } from "@lib/structured-errors";
 import { record } from "@lib/tracing";
+import { sanitizeString, VALIDATION_LIMITS } from "@utils/validation";
 import { Elysia } from "elysia";
+import { parseError } from "evlog";
 import { useLogger } from "evlog/elysia";
 
 export type ApiKeyIdentifyDenial =
@@ -70,6 +72,10 @@ type IdentifyTarget =
 	  }
 	| { botResponse: unknown };
 
+export function normalizeIdentifyProfileId(profileId: string): string {
+	return sanitizeString(profileId, VALIDATION_LIMITS.USER_ID_MAX_LENGTH);
+}
+
 async function resolveIdentifyTarget(
 	body: unknown,
 	query: unknown,
@@ -99,13 +105,14 @@ async function resolveIdentifyTarget(
 	const { clientId, userAgent, ip } = await validateRequest(
 		body,
 		query,
-		request
+		request,
+		{ checkUsage: false }
 	);
 	log.set({ clientId });
 
 	const botError = await checkForBot(request, body, query, clientId, userAgent);
 	if (botError) {
-		log.set({ rejected: "bot" });
+		log.set({ identify_outcome: "blocked", http_status: 204, rejected: "bot" });
 		return { botResponse: botError.error };
 	}
 
@@ -146,10 +153,22 @@ export const identifyRoute = new Elysia().post(
 				throw basketErrors.identifyRateLimited();
 			}
 
-			const { profileId, anonymousId, traits } = parseResult.data;
+			const profileId = normalizeIdentifyProfileId(parseResult.data.profileId);
+			if (!profileId) {
+				log.set({ rejected: "profile_id" });
+				throw createIngestSchemaValidationError([
+					{
+						code: "custom",
+						path: ["profileId"],
+						message: "profileId must contain a valid identifier",
+					},
+				]);
+			}
+			const { anonymousId, traits } = parseResult.data;
 			log.set({
 				traitCount: Object.keys(traits ?? {}).length,
 				hasAlias: Boolean(anonymousId),
+				canonicalized_profile_id: profileId !== parseResult.data.profileId,
 			});
 
 			const [update] = await Promise.all([
@@ -166,9 +185,16 @@ export const identifyRoute = new Elysia().post(
 			if (update && update.changes.length > 0) {
 				log.set({ traitChanges: update.changes.length });
 			}
+			log.set({ identify_outcome: "success", http_status: 200 });
 
 			return Response.json({ status: "success", type: "identify" });
 		} catch (error) {
+			const parsed = parseError(error);
+			log.set({
+				identify_outcome: "rejected",
+				http_status: parsed.status,
+				failure_reason: parsed.code,
+			});
 			rethrowOrWrap(error, log);
 		}
 	}

--- a/packages/ai/src/query/builders/profiles.integration.test.ts
+++ b/packages/ai/src/query/builders/profiles.integration.test.ts
@@ -1,0 +1,159 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { randomUUIDv7 } from "bun";
+import { chCommand, chQuery, clickHouse } from "@databuddy/db/clickhouse";
+import { ProfilesBuilders } from "./profiles";
+
+const describeIntegration =
+	process.env.CLICKHOUSE_INTEGRATION_TESTS === "true" ? describe : describe.skip;
+
+const websiteId = `profile-builder-${randomUUIDv7()}`;
+const profileId = "profile-builder-user";
+const anonymousId = "profile-builder-anonymous";
+
+describeIntegration("profile query identity against ClickHouse", () => {
+	beforeAll(async () => {
+		await clickHouse.insert({
+			table: "analytics.events",
+			format: "JSONEachRow",
+			values: [
+				{
+					anonymous_id: anonymousId,
+					client_id: websiteId,
+					created_at: "2026-08-01 12:00:00",
+					event_name: "screen_view",
+					id: randomUUIDv7(),
+					path: "/before-identify",
+					profile_id: "",
+					properties: "{}",
+					session_id: "profile-builder-session-1",
+					time: "2026-08-01 12:00:00",
+					url: "https://example.test/before-identify",
+				},
+				{
+					anonymous_id: anonymousId,
+					client_id: websiteId,
+					created_at: "2026-08-01 12:02:00",
+					event_name: "screen_view",
+					id: randomUUIDv7(),
+					path: "/after-identify",
+					profile_id: profileId,
+					properties: "{}",
+					session_id: "profile-builder-session-1",
+					time: "2026-08-01 12:02:00",
+					url: "https://example.test/after-identify",
+				},
+				{
+					anonymous_id: anonymousId,
+					client_id: websiteId,
+					created_at: "2026-08-01 13:00:00",
+					event_name: "screen_view",
+					id: randomUUIDv7(),
+					path: "/return",
+					profile_id: profileId,
+					properties: "{}",
+					session_id: "profile-builder-session-2",
+					time: "2026-08-01 13:00:00",
+					url: "https://example.test/return",
+				},
+			],
+		});
+
+		await clickHouse.insert({
+			table: "analytics.custom_events",
+			format: "JSONEachRow",
+			values: [
+				{
+					anonymous_id: anonymousId,
+					event_name: "identify",
+					owner_id: websiteId,
+					profile_id: profileId,
+					properties: "{}",
+					session_id: "profile-builder-session-1",
+					timestamp: "2026-08-01 12:01:00",
+					website_id: websiteId,
+				},
+			],
+		});
+	});
+
+	afterAll(async () => {
+		await chCommand(
+			"ALTER TABLE analytics.events DELETE WHERE client_id = {websiteId:String} SETTINGS mutations_sync = 1",
+			{ websiteId }
+		);
+		await chCommand(
+			"ALTER TABLE analytics.custom_events DELETE WHERE owner_id = {websiteId:String} SETTINGS mutations_sync = 1",
+			{ websiteId }
+		);
+	});
+
+	it("stitches pre-identification events and returns one profile row", async () => {
+		const query = ProfilesBuilders.profile_list?.customSql?.({
+			endDate: "2026-08-02",
+			limit: 10,
+			offset: 0,
+			startDate: "2026-08-01",
+			websiteId,
+		});
+		if (!query || typeof query === "string") {
+			throw new Error("Profile list did not compile");
+		}
+
+		const rows = await chQuery<{
+			custom_event_count: number | string;
+			profile_id: string;
+			session_count: number | string;
+			total_events: number | string;
+			visitor_id: string;
+		}>(query.sql, query.params);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]).toMatchObject({
+			profile_id: profileId,
+			visitor_id: profileId,
+		});
+		expect(Number(rows[0]?.total_events)).toBe(3);
+		expect(Number(rows[0]?.session_count)).toBe(2);
+		expect(Number(rows[0]?.custom_event_count)).toBe(1);
+	});
+
+	it("uses the same stitched identity in profile detail and sessions", async () => {
+		const detailQuery = ProfilesBuilders.profile_detail?.customSql?.({
+			endDate: "2026-08-02",
+			filters: [{ field: "anonymous_id", op: "eq", value: profileId }],
+			startDate: "2026-08-01",
+			websiteId,
+		});
+		const sessionsQuery = ProfilesBuilders.profile_sessions?.customSql?.({
+			endDate: "2026-08-02",
+			filters: [{ field: "anonymous_id", op: "eq", value: profileId }],
+			startDate: "2026-08-01",
+			websiteId,
+		});
+		if (
+			!detailQuery ||
+			typeof detailQuery === "string" ||
+			!sessionsQuery ||
+			typeof sessionsQuery === "string"
+		) {
+			throw new Error("Profile detail queries did not compile");
+		}
+
+		const [detailRows, sessionRows] = await Promise.all([
+			chQuery<{ total_pageviews: number | string }>(
+				detailQuery.sql,
+				detailQuery.params
+			),
+			chQuery<{ session_id: string }>(sessionsQuery.sql, sessionsQuery.params),
+		]);
+
+		expect(Number(detailRows[0]?.total_pageviews)).toBe(3);
+		expect(sessionRows).toHaveLength(2);
+		expect(new Set(sessionRows.map((row) => row.session_id))).toEqual(
+			new Set([
+				"profile-builder-session-1",
+				"profile-builder-session-2",
+			])
+		);
+	});
+});

--- a/packages/ai/src/query/builders/profiles.ts
+++ b/packages/ai/src/query/builders/profiles.ts
@@ -1,6 +1,5 @@
 import {
 	CUSTOM_EVENTS_VISITOR_KEY,
-	EVENTS_VISITOR_KEY,
 	revenueLatestCte,
 	visitorMatch,
 } from "@databuddy/db/clickhouse";
@@ -34,6 +33,113 @@ const PROFILE_AGGREGATE_FILTER_OPERATORS = new Set<Filter["op"]>([
 ]);
 
 const VISITOR_MATCH = visitorMatch();
+
+const PROFILE_IDENTITY_CTES = `
+      visitor_identity_rows AS (
+        SELECT
+          profile_id,
+          anonymous_id,
+          session_id,
+          time AS identity_time
+        FROM ${Analytics.events}
+        WHERE
+          client_id = {websiteId:String}
+          AND profile_id != ''
+          AND time >= toDateTime({startDate:String})
+          AND time <= toDateTime({endDate:String})
+
+        UNION ALL
+
+        SELECT
+          profile_id,
+          ifNull(anonymous_id, '') AS anonymous_id,
+          ifNull(session_id, '') AS session_id,
+          timestamp AS identity_time
+        FROM ${Analytics.custom_events}
+        WHERE
+          (owner_id = {websiteId:String} OR website_id = {websiteId:String})
+          AND profile_id != ''
+          AND timestamp >= toDateTime({startDate:String})
+          AND timestamp <= toDateTime({endDate:String})
+      ),
+      visitor_profiles_by_anonymous AS (
+        SELECT
+          anonymous_id,
+          argMin(profile_id, identity_time) AS initial_profile_id
+        FROM visitor_identity_rows
+        WHERE anonymous_id != ''
+        GROUP BY anonymous_id
+      ),
+      visitor_identity_by_session AS (
+        SELECT
+          session_id,
+          argMin(profile_id, identity_time) AS initial_profile_id
+        FROM visitor_identity_rows
+        WHERE session_id != ''
+        GROUP BY session_id
+      )`;
+
+const PROFILE_TARGET_IDENTITY_CTES = `
+      target_identity_rows AS (
+        SELECT
+          profile_id,
+          anonymous_id,
+          session_id,
+          time AS identity_time
+        FROM ${Analytics.events}
+        WHERE
+          client_id = {websiteId:String}
+          AND (profile_id = {visitorId:String} OR anonymous_id = {visitorId:String})
+          AND time >= toDateTime({startDate:String})
+          AND time <= toDateTime({endDate:String})
+
+        UNION ALL
+
+        SELECT
+          profile_id,
+          ifNull(anonymous_id, '') AS anonymous_id,
+          ifNull(session_id, '') AS session_id,
+          timestamp AS identity_time
+        FROM ${Analytics.custom_events}
+        WHERE
+          (owner_id = {websiteId:String} OR website_id = {websiteId:String})
+          AND (profile_id = {visitorId:String} OR anonymous_id = {visitorId:String})
+          AND timestamp >= toDateTime({startDate:String})
+          AND timestamp <= toDateTime({endDate:String})
+      ),
+      target_anonymous_ids AS (
+        SELECT
+          anonymous_id
+        FROM target_identity_rows
+        WHERE anonymous_id != ''
+        GROUP BY anonymous_id
+      ),
+      target_session_ids AS (
+        SELECT
+          session_id
+        FROM target_identity_rows
+        WHERE session_id != ''
+        GROUP BY session_id
+      )`;
+
+const identityJoins = (source: string): string => `
+        LEFT JOIN visitor_profiles_by_anonymous direct_profile
+          ON ifNull(${source}.anonymous_id, '') = direct_profile.anonymous_id
+        LEFT JOIN visitor_identity_by_session session_identity
+          ON ifNull(${source}.session_id, '') = session_identity.session_id
+        `;
+
+const canonicalVisitorExpression = (source: string): string => `coalesce(
+        nullIf(${source}.profile_id, ''),
+        nullIf(session_identity.initial_profile_id, ''),
+        nullIf(direct_profile.initial_profile_id, ''),
+        nullIf(${source}.anonymous_id, ''),
+        ''
+      )`;
+
+// Explicit profile ids always win. Anonymous-only rows use the first profile
+// assignment seen for that anonymous/session key so pre-identification activity
+// is backfilled without moving already-attributed rows after a profile change.
 
 const SUBQUERY_FILTER_FIELDS = new Set(["event_name"]);
 const PROFILE_LIST_ALLOWED_FILTERS = [
@@ -165,18 +271,103 @@ function buildProfileAggregateFilter(
 	};
 }
 
-// error_spans, web_vitals_spans, and outgoing_links carry no profile_id,
-// so an identified visitor's rows there are found via the device set
-// (anonymous_ids) resolved from the events table.
-const PROFILE_ACTIVITY_CTE = `
+function profileActivityCte(
+	identityCtes: string,
+	limitToVisitor = false
+): string {
+	const eventVisitorExpression = limitToVisitor
+		? "{visitorId:String}"
+		: canonicalVisitorExpression("e");
+	const customVisitorExpression = limitToVisitor
+		? "{visitorId:String}"
+		: canonicalVisitorExpression("ce");
+	const eventJoins = limitToVisitor ? "" : identityJoins("e");
+	const customEventJoins = limitToVisitor ? "" : identityJoins("ce");
+	const visitorCondition = limitToVisitor
+		? `AND (
+            e.profile_id = {visitorId:String}
+            OR (
+              ifNull(e.profile_id, '') = ''
+              AND (
+                e.anonymous_id IN (SELECT anonymous_id FROM target_anonymous_ids)
+                OR e.session_id IN (SELECT session_id FROM target_session_ids)
+              )
+            )
+          )`
+		: `AND ${canonicalVisitorExpression("e")} = {visitorId:String}`;
+	const customVisitorCondition = limitToVisitor
+		? `AND (
+            ifNull(ce.profile_id, '') = {visitorId:String}
+            OR (
+              ifNull(ce.profile_id, '') = ''
+              AND (
+                ifNull(ce.anonymous_id, '') IN (SELECT anonymous_id FROM target_anonymous_ids)
+                OR ifNull(ce.session_id, '') IN (SELECT session_id FROM target_session_ids)
+              )
+            )
+          )`
+		: `AND ${canonicalVisitorExpression("ce")} = {visitorId:String}`;
+
+	return `
+      ${identityCtes},
+      profile_events AS (
+        SELECT
+          e.id AS id,
+          e.client_id AS client_id,
+          e.event_name AS event_name,
+          e.anonymous_id AS anonymous_id,
+          e.time AS time,
+          e.session_id AS session_id,
+          e.path AS path,
+          e.properties AS properties,
+          e.profile_id AS profile_id,
+          e.time_on_page AS time_on_page,
+          e.user_agent AS user_agent,
+          e.browser_name AS browser_name,
+          e.os_name AS os_name,
+          e.device_type AS device_type,
+          e.country AS country,
+          e.region AS region,
+          e.referrer AS referrer,
+          ${eventVisitorExpression} AS visitor_id
+        FROM ${Analytics.events} e
+        ${eventJoins}
+        WHERE
+          e.client_id = {websiteId:String}
+          AND e.time >= toDateTime({startDate:String})
+          AND e.time <= toDateTime({endDate:String})
+          ${visitorCondition}
+      ),
+      profile_custom_events AS (
+        SELECT
+          ce.owner_id AS owner_id,
+          ce.website_id AS website_id,
+          ce.timestamp AS timestamp,
+          ce.event_name AS event_name,
+          ce.properties AS properties,
+          ce.anonymous_id AS anonymous_id,
+          ce.session_id AS session_id,
+          ce.profile_id AS profile_id,
+          ce.path AS path,
+          ${customVisitorExpression} AS visitor_id
+        FROM ${Analytics.custom_events} ce
+        ${customEventJoins}
+        WHERE
+          (ce.owner_id = {websiteId:String} OR ce.website_id = {websiteId:String})
+          AND ce.timestamp >= toDateTime({startDate:String})
+          AND ce.timestamp <= toDateTime({endDate:String})
+          ${customVisitorCondition}
+      ),
       visitor_ids AS (
         SELECT DISTINCT anonymous_id
-        FROM ${Analytics.events}
-        WHERE
-          client_id = {websiteId:String}
-          AND ${VISITOR_MATCH}
-          AND time >= toDateTime({startDate:String})
-          AND time <= toDateTime({endDate:String})
+        FROM profile_events
+        WHERE visitor_id = {visitorId:String} AND anonymous_id != ''
+
+        UNION DISTINCT
+
+        SELECT DISTINCT ifNull(anonymous_id, '')
+        FROM profile_custom_events
+        WHERE visitor_id = {visitorId:String} AND ifNull(anonymous_id, '') != ''
 
         UNION DISTINCT
 
@@ -186,24 +377,18 @@ const PROFILE_ACTIVITY_CTE = `
         SELECT
           session_id,
           time
-        FROM ${Analytics.events}
+        FROM profile_events
         WHERE
-          client_id = {websiteId:String}
-          AND ${VISITOR_MATCH}
-          AND time >= toDateTime({startDate:String})
-          AND time <= toDateTime({endDate:String})
+          visitor_id = {visitorId:String}
 
         UNION ALL
 
         SELECT
           ifNull(session_id, '') as session_id,
           timestamp as time
-        FROM ${Analytics.custom_events}
+        FROM profile_custom_events
         WHERE
-          website_id = {websiteId:String}
-          AND ${VISITOR_MATCH}
-          AND timestamp >= toDateTime({startDate:String})
-          AND timestamp <= toDateTime({endDate:String})
+          visitor_id = {visitorId:String}
 
         UNION ALL
 
@@ -241,6 +426,7 @@ const PROFILE_ACTIVITY_CTE = `
           AND timestamp >= toDateTime({startDate:String})
           AND timestamp <= toDateTime({endDate:String})
       )`;
+}
 
 function stripePaymentIntentId(alias = ""): string {
 	const prefix = alias ? `${alias}.` : "";
@@ -348,67 +534,109 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
 				: "";
 
 			const eventSubqueryClause = subqueryConditions.length
-				? `AND ${EVENTS_VISITOR_KEY} IN (
-        SELECT DISTINCT ${CUSTOM_EVENTS_VISITOR_KEY}
-        FROM ${Analytics.custom_events}
-        WHERE (owner_id = {websiteId:String} OR website_id = {websiteId:String})
-          AND ${subqueryConditions.join(" AND ")}
-          AND timestamp >= toDateTime({startDate:String})
-          AND timestamp <= toDateTime({endDate:String})
-          AND (anonymous_id IS NOT NULL OR profile_id != '')
-      )`
+				? `AND visitor_id IN (
+	        SELECT DISTINCT visitor_id
+	        FROM profile_custom_events
+	        WHERE ${subqueryConditions.join(" AND ")}
+	          AND visitor_id != ''
+	      )`
 				: "";
 
 			const profileSort = resolveProfileSort(orderBy);
+			const profileRevenueKeyPredicate = `${CUSTOM_EVENTS_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)`;
 
 			return {
 				sql: `
-    WITH visitor_profiles AS (
+    WITH ${PROFILE_IDENTITY_CTES},
+    profile_events AS (
       SELECT
-        ${EVENTS_VISITOR_KEY} as visitor_id,
-        max(profile_id) as latest_profile_id,
-        MIN(time) as first_visit,
-        MAX(time) as last_visit,
-        uniq(session_id) as session_count,
-        COUNT(*) as total_events,
-        uniqIf(path, event_name = 'screen_view') as unique_pages,
-        any(user_agent) as user_agent,
-        any(country) as country,
-        any(region) as region,
-        any(device_type) as device_type,
-        any(browser_name) as browser_name,
-        any(os_name) as os_name,
-        any(referrer) as referrer
-      FROM ${Analytics.events}
+        e.id AS id,
+        e.client_id AS client_id,
+        e.event_name AS event_name,
+        e.anonymous_id AS anonymous_id,
+        e.time AS time,
+        e.session_id AS session_id,
+        e.path AS path,
+        e.properties AS properties,
+        e.profile_id AS profile_id,
+        e.user_agent AS user_agent,
+        e.browser_name AS browser_name,
+        e.os_name AS os_name,
+        e.device_type AS device_type,
+        e.country AS country,
+        e.region AS region,
+        e.referrer AS referrer,
+        ${canonicalVisitorExpression("e")} AS visitor_id
+      FROM ${Analytics.events} e
+      ${identityJoins("e")}
       WHERE
-        client_id = {websiteId:String}
-        AND time >= toDateTime({startDate:String})
-        AND time <= toDateTime({endDate:String})
+        e.client_id = {websiteId:String}
+        AND e.time >= toDateTime({startDate:String})
+        AND e.time <= toDateTime({endDate:String})
+    ),
+    profile_custom_events AS (
+      SELECT
+        ce.owner_id AS owner_id,
+        ce.website_id AS website_id,
+        ce.timestamp AS timestamp,
+        ce.event_name AS event_name,
+        ce.properties AS properties,
+        ce.anonymous_id AS anonymous_id,
+        ce.session_id AS session_id,
+        ce.profile_id AS profile_id,
+        ce.path AS path,
+        ${canonicalVisitorExpression("ce")} AS visitor_id
+      FROM ${Analytics.custom_events} ce
+      ${identityJoins("ce")}
+      WHERE
+        (ce.owner_id = {websiteId:String} OR ce.website_id = {websiteId:String})
+        AND ce.timestamp >= toDateTime({startDate:String})
+        AND ce.timestamp <= toDateTime({endDate:String})
+    ),
+    all_visitor_profiles AS (
+      SELECT
+        pe.visitor_id AS visitor_id,
+        argMaxIf(pe.profile_id, pe.time, pe.profile_id != '') as latest_profile_id,
+        MIN(pe.time) as first_visit,
+        MAX(pe.time) as last_visit,
+        uniq(pe.session_id) as session_count,
+        COUNT(*) as total_events,
+        uniqIf(pe.path, pe.event_name = 'screen_view') as unique_pages,
+        any(pe.user_agent) as user_agent,
+        any(pe.country) as country,
+        any(pe.region) as region,
+        any(pe.device_type) as device_type,
+        any(pe.browser_name) as browser_name,
+        any(pe.os_name) as os_name,
+        any(pe.referrer) as referrer
+      FROM profile_events pe
+      WHERE
+        pe.visitor_id != ''
 	${combinedWhereClause}
 	${eventSubqueryClause}
       GROUP BY visitor_id
       ${havingClause}
+    ),
+    visitor_profiles AS (
+      SELECT *
+      FROM all_visitor_profiles
       ORDER BY ${profileSort}
       LIMIT {limit:Int32} OFFSET {offset:Int32}
     ),
     visitor_custom_events AS (
       SELECT
-        ${CUSTOM_EVENTS_VISITOR_KEY} as visitor_id,
+        visitor_id,
         COUNT(*) as custom_event_count,
         uniq(event_name) as unique_event_names
-      FROM ${Analytics.custom_events}
+      FROM profile_custom_events
       WHERE (owner_id = {websiteId:String} OR website_id = {websiteId:String})
-        AND timestamp >= toDateTime({startDate:String})
-        AND timestamp <= toDateTime({endDate:String})
-        AND ${CUSTOM_EVENTS_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)
+        AND visitor_id IN (SELECT visitor_id FROM visitor_profiles)
       GROUP BY visitor_id
     ),
-		${stripeProfileContextCtes(
-			`${CUSTOM_EVENTS_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)`
-		)},
+		${stripeProfileContextCtes(profileRevenueKeyPredicate)},
 		${revenueLatestCte({
 			candidateWhere: `(
-				${CUSTOM_EVENTS_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)
+				${profileRevenueKeyPredicate}
 				OR (owner_id, ${stripePaymentIntentId()}) IN (
 					SELECT owner_id, payment_intent_id FROM profile_payment_intents
 				)
@@ -424,46 +652,6 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
 			FROM profile_revenue_attributed
 			WHERE ${ATTRIBUTED_REVENUE_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)
 	      GROUP BY visitor_id
-    ),
-    visitor_sessions AS (
-      SELECT
-        ${EVENTS_VISITOR_KEY} as visitor_id,
-        session_id,
-        MIN(time) as session_start,
-        MAX(time) as session_end,
-        LEAST(dateDiff('second', MIN(time), MAX(time)), 28800) as duration,
-        COUNT(*) as page_views,
-        uniqIf(path, event_name = 'screen_view') as unique_pages,
-        any(user_agent) as user_agent,
-        any(country) as country,
-        any(region) as region,
-        any(device_type) as device_type,
-        any(browser_name) as browser_name,
-        any(os_name) as os_name,
-        any(referrer) as referrer,
-        groupArray(
-          tuple(
-            id,
-            time,
-            event_name,
-            path,
-            CASE
-              WHEN event_name NOT IN ('screen_view', 'page_exit', 'web_vitals', 'link_out')
-                AND properties IS NOT NULL
-                AND properties != '{}'
-              THEN CAST(properties AS String)
-              ELSE NULL
-            END
-          )
-        ) as events
-      FROM ${Analytics.events}
-      WHERE client_id = {websiteId:String}
-        AND time >= toDateTime({startDate:String})
-        AND time <= toDateTime({endDate:String})
-        AND ${EVENTS_VISITOR_KEY} IN (SELECT visitor_id FROM visitor_profiles)
-	${combinedWhereClause}
-      GROUP BY visitor_id, session_id
-      ORDER BY visitor_id, session_start DESC
     )
     SELECT
       vp.visitor_id AS visitor_id,
@@ -482,26 +670,11 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
       vp.referrer AS referrer,
       COALESCE(vce.custom_event_count, 0) as custom_event_count,
       COALESCE(vce.unique_event_names, 0) as unique_event_names,
-      COALESCE(vr.ltv, 0) as ltv,
-      COALESCE(vs.session_id, '') as session_id,
-      COALESCE(vs.session_start, '') as session_start,
-      COALESCE(vs.session_end, '') as session_end,
-      COALESCE(vs.duration, 0) as duration,
-      COALESCE(vs.page_views, 0) as page_views,
-      COALESCE(vs.unique_pages, 0) as session_unique_pages,
-      COALESCE(vs.user_agent, '') as session_user_agent,
-      COALESCE(vs.country, '') as session_country,
-      COALESCE(vs.region, '') as session_region,
-      COALESCE(vs.device_type, '') as session_device_type,
-      COALESCE(vs.browser_name, '') as session_browser_name,
-      COALESCE(vs.os_name, '') as session_os_name,
-      COALESCE(vs.referrer, '') as session_referrer,
-      COALESCE(vs.events, []) as events
+      COALESCE(vr.ltv, 0) as ltv
     FROM visitor_profiles vp
     LEFT JOIN visitor_custom_events vce ON vp.visitor_id = vce.visitor_id
     LEFT JOIN visitor_revenue vr ON vp.visitor_id = vr.visitor_id
-    LEFT JOIN visitor_sessions vs ON vp.visitor_id = vs.visitor_id
-    ORDER BY vp.${profileSort}, vs.session_start DESC
+    ORDER BY vp.${profileSort}
   `,
 				params: {
 					websiteId,
@@ -536,7 +709,7 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
 
 			return {
 				sql: `
-    WITH ${PROFILE_ACTIVITY_CTE},
+	    WITH ${profileActivityCte(PROFILE_TARGET_IDENTITY_CTES, true)},
     activity_stats AS (
       SELECT
         {visitorId:String} as visitor_id,
@@ -546,18 +719,14 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
       FROM profile_activity
       WHERE session_id != ''
     ),
-    event_stats AS (
+	    event_stats AS (
       SELECT
         countIf(event_name = 'screen_view') as total_pageviews,
         SUM(CASE WHEN time_on_page > 0 THEN time_on_page ELSE 0 END) as total_duration,
         formatReadableTimeDelta(SUM(CASE WHEN time_on_page > 0 THEN time_on_page ELSE 0 END)) as total_duration_formatted
-      FROM ${Analytics.events}
-      WHERE
-        client_id = {websiteId:String}
-        AND ${VISITOR_MATCH}
-        AND time >= toDateTime({startDate:String})
-        AND time <= toDateTime({endDate:String})
-    ),
+	      FROM profile_events
+	      WHERE visitor_id = {visitorId:String}
+	    ),
     profile_context AS (
       SELECT
         argMaxIf(profile_id, time, profile_id != '') as latest_profile_id,
@@ -566,12 +735,8 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
         any(os_name) as os,
         any(country) as country,
         any(region) as region
-      FROM ${Analytics.events}
-      WHERE
-        client_id = {websiteId:String}
-        AND ${VISITOR_MATCH}
-        AND time >= toDateTime({startDate:String})
-        AND time <= toDateTime({endDate:String})
+	      FROM profile_events
+	      WHERE visitor_id = {visitorId:String}
     )
     SELECT
       ast.visitor_id,
@@ -716,7 +881,7 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
 
 			return {
 				sql: `
-    WITH ${PROFILE_ACTIVITY_CTE},
+	    WITH ${profileActivityCte(PROFILE_TARGET_IDENTITY_CTES, true)},
     user_sessions AS (
       SELECT
         session_id,
@@ -742,13 +907,9 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
         any(country) as country,
         any(region) as region,
         any(referrer) as referrer
-      FROM ${Analytics.events} e
-      INNER JOIN user_sessions us ON e.session_id = us.session_id
-      WHERE
-        e.client_id = {websiteId:String}
-        AND (e.anonymous_id = {visitorId:String} OR e.profile_id = {visitorId:String})
-        AND e.time >= toDateTime({startDate:String})
-        AND e.time <= toDateTime({endDate:String})
+	      FROM profile_events e
+	      INNER JOIN user_sessions us ON e.session_id = us.session_id
+	      WHERE e.visitor_id = {visitorId:String}
       GROUP BY e.session_id
     ),
     all_events AS (
@@ -769,13 +930,9 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
           WHEN e.event_name NOT IN ('screen_view', 'page_exit', 'web_vitals', 'link_out') THEN 'custom'
           ELSE 'analytics'
         END as source
-      FROM ${Analytics.events} e
-      INNER JOIN user_sessions us ON e.session_id = us.session_id
-      WHERE
-        e.client_id = {websiteId:String}
-        AND (e.anonymous_id = {visitorId:String} OR e.profile_id = {visitorId:String})
-        AND e.time >= toDateTime({startDate:String})
-        AND e.time <= toDateTime({endDate:String})
+	      FROM profile_events e
+	      INNER JOIN user_sessions us ON e.session_id = us.session_id
+	      WHERE e.visitor_id = {visitorId:String}
 
       UNION ALL
 
@@ -795,13 +952,9 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
           ELSE NULL
         END as properties,
         'custom' as source
-      FROM ${Analytics.custom_events} ce
-      INNER JOIN user_sessions us ON ifNull(ce.session_id, '') = us.session_id
-      WHERE
-        ce.website_id = {websiteId:String}
-        AND (ce.anonymous_id = {visitorId:String} OR ce.profile_id = {visitorId:String})
-        AND ce.timestamp >= toDateTime({startDate:String})
-        AND ce.timestamp <= toDateTime({endDate:String})
+	      FROM profile_custom_events ce
+	      INNER JOIN user_sessions us ON ifNull(ce.session_id, '') = us.session_id
+	      WHERE ce.visitor_id = {visitorId:String}
 
       UNION ALL
 
@@ -888,7 +1041,7 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
       GROUP BY session_id
     )
     SELECT
-      us.session_id,
+      us.session_id AS session_id,
       us.session_name,
       us.first_visit,
       us.last_visit,

--- a/packages/ai/src/query/simple-builder.test.ts
+++ b/packages/ai/src/query/simple-builder.test.ts
@@ -538,13 +538,13 @@ describe("SimpleQueryBuilder.compile", () => {
 		).compile();
 
 		expect(sql).toContain(
-			"AND if(profile_id != '', profile_id, anonymous_id) IN ("
+			"AND visitor_id IN ("
 		);
 		expect(sql).toContain(
-			"SELECT DISTINCT coalesce(nullIf(profile_id, ''), nullIf(anonymous_id, ''))"
+			"SELECT DISTINCT visitor_id"
 		);
 		expect(sql).toContain("FROM analytics.custom_events");
-		expect(sql).toContain("AND event_name = {f0:String}");
+		expect(sql).toContain("event_name = {f0:String}");
 		expect(sql).not.toContain("eventNameFilter");
 		expect(params.f0).toBe("signup");
 	});
@@ -584,7 +584,7 @@ describe("SimpleQueryBuilder.compile", () => {
 			})
 		).compile();
 
-		expect(sql).toContain("AND event_name LIKE {f0:String}");
+		expect(sql).toContain("event_name LIKE {f0:String}");
 		expect(params.f0).toBe("%signup%");
 	});
 
@@ -663,7 +663,7 @@ describe("SimpleQueryBuilder.compile", () => {
 		);
 
 		const { params, sql } = builder.compile();
-		expect(sql).toContain("anonymous_id = {visitorId:String}");
+		expect(sql).toContain("visitor_id = {visitorId:String}");
 		expect(params.visitorId).toBe("visitor-1");
 	});
 
@@ -696,7 +696,7 @@ describe("SimpleQueryBuilder.compile", () => {
 		);
 
 		const { params, sql } = builder.compile();
-		expect(sql).toContain("anonymous_id = {visitorId:String}");
+		expect(sql).toContain("visitor_id = {visitorId:String}");
 		expect(params.visitorId).toBe("visitor-1");
 	});
 


### PR DESCRIPTION
## Summary

- Prevent identify requests from being rejected by event-usage quota checks.
- Canonicalize identify profile IDs consistently with event ingestion and add structured identify outcomes for Axiom.
- Stitch pre-identification activity into identified profiles and make profile-list pagination one-row-per-visitor.
- Remove redundant identity joins from profile-list queries after measuring the improvement.

## Verification

- Full suite: 3,940 passed, 32 skipped, 0 failed.
- ClickHouse identity fixture: 2 passed.
- Typecheck: 35/35 packages passed.
- Lint and policy checks passed.
- Production build passed; docs generation logged an existing local API connection warning but completed successfully.
- Hosted read-only profile-list benchmark improved from 409/406/414/404/439ms to 343/352/321/332/347ms on the same workload.

No tracker script or database schema changes are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened identity ingestion and attribution across `apps/basket` and `packages/ai`. Identify calls no longer fail on event-usage quotas, profile IDs are canonicalized, and profile queries stitch pre-identification activity and return one row per visitor.

- Identify route (`apps/basket`):
  - Skips event-usage quota checks for identify requests (old: subject to “events” quota; new: bypasses it).
  - Canonicalizes `profileId` with the same sanitizer as event ingestion; rejects empty/invalid IDs.
  - Adds structured logs: `identify_outcome`, `http_status`, `failure_reason`, and a `canonicalized_profile_id` flag; bot blocks log outcome “blocked”.
- Profiles queries (`packages/ai`):
  - Introduces identity CTEs that derive a canonical `visitor_id` from `profile_id`/`anonymous_id`/`session_id` and backfill pre-identification activity.
  - Changes `profile_list` to return exactly one row per visitor; removes session columns and redundant joins; event filtering uses `visitor_id`.
  - Aligns `profile_detail` and `profile_sessions` with the same stitched identity logic; adds a ClickHouse integration test.
  - Hosted read-only profile-list benchmark improved from ~400ms to ~340ms.

**Migration**
- Stop reading session fields from `profile_list`. Use `profile_sessions` for per-session data.
- Ensure clients send a valid, non-empty `profileId`; it may be normalized before storage.

<sup>Written for commit 4448f97c89756428d13f75208f557b8d1a6b9333. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

