### PR TITLE
fix(ai): prevent profile identity cross-attribution

### DIFF
--- a/packages/ai/src/query/builders/profiles.integration.test.ts
+++ b/packages/ai/src/query/builders/profiles.integration.test.ts
@@ -14,6 +14,14 @@ const collisionWebsiteId = `profile-builder-collision-${randomUUIDv7()}`;
 const collisionProfileA = "profile-builder-collision-a";
 const collisionProfileB = "profile-builder-collision-b";
 const collisionSessionId = "profile-builder-collision-session";
+type ProfileSessionEvent = [
+	string,
+	string,
+	string,
+	string,
+	string | null,
+	string?,
+];
 
 function collisionEvent(
 	anonymous_id: string,
@@ -258,7 +266,10 @@ describeIntegration("profile query identity against ClickHouse", () => {
 					if (!query || typeof query === "string") {
 						throw new Error("Session query did not compile");
 					}
-					return chQuery<{ events: unknown[]; session_id: string }>(
+					return chQuery<{
+						events: ProfileSessionEvent[];
+						session_id: string;
+					}>(
 						query.sql,
 						query.params
 					);
@@ -280,11 +291,7 @@ describeIntegration("profile query identity against ClickHouse", () => {
 		expect(sessionRows).toHaveLength(2);
 		for (const rows of sessionRows) {
 			expect(rows).toHaveLength(1);
-			const events = rows[0]?.events;
-			expect(Array.isArray(events)).toBe(true);
-			if (Array.isArray(events)) {
-				expect(events).toHaveLength(2);
-			}
+			expect(rows[0]?.events).toHaveLength(2);
 		}
 	});
 

--- a/packages/ai/src/query/builders/profiles.integration.test.ts
+++ b/packages/ai/src/query/builders/profiles.integration.test.ts
@@ -1,6 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import { randomUUIDv7 } from "bun";
 import { chCommand, chQuery, clickHouse } from "@databuddy/db/clickhouse";
+import { SimpleQueryBuilder } from "../simple-builder";
 import { ProfilesBuilders } from "./profiles";
 
 const describeIntegration =
@@ -9,6 +10,31 @@ const describeIntegration =
 const websiteId = `profile-builder-${randomUUIDv7()}`;
 const profileId = "profile-builder-user";
 const anonymousId = "profile-builder-anonymous";
+const collisionWebsiteId = `profile-builder-collision-${randomUUIDv7()}`;
+const collisionProfileA = "profile-builder-collision-a";
+const collisionProfileB = "profile-builder-collision-b";
+const collisionSessionId = "profile-builder-collision-session";
+
+function collisionEvent(
+	anonymous_id: string,
+	profile_id: string,
+	path: string,
+	time: string
+) {
+	return {
+		anonymous_id,
+		client_id: collisionWebsiteId,
+		created_at: time,
+		event_name: "screen_view",
+		id: randomUUIDv7(),
+		path,
+		profile_id,
+		properties: "{}",
+		session_id: collisionSessionId,
+		time,
+		url: `https://example.test${path}`,
+	};
+}
 
 describeIntegration("profile query identity against ClickHouse", () => {
 	beforeAll(async () => {
@@ -74,6 +100,43 @@ describeIntegration("profile query identity against ClickHouse", () => {
 				},
 			],
 		});
+
+		await clickHouse.insert({
+			table: "analytics.events",
+			format: "JSONEachRow",
+			values: [
+				collisionEvent(
+					"profile-builder-collision-anonymous-a",
+					"",
+					"/collision-a-before",
+					"2026-08-01 12:00:00"
+				),
+				collisionEvent(
+					"profile-builder-collision-anonymous-a",
+					collisionProfileA,
+					"/collision-a-identify",
+					"2026-08-01 12:01:00"
+				),
+				collisionEvent(
+					"profile-builder-collision-anonymous-b",
+					"",
+					"/collision-b-before",
+					"2026-08-01 12:02:00"
+				),
+				collisionEvent(
+					"profile-builder-collision-anonymous-b",
+					collisionProfileB,
+					"/collision-b-identify",
+					"2026-08-01 12:03:00"
+				),
+				collisionEvent(
+					"",
+					"",
+					"/collision-unknown",
+					"2026-08-01 12:04:00"
+				),
+			],
+		});
 	});
 
 	afterAll(async () => {
@@ -84,6 +147,10 @@ describeIntegration("profile query identity against ClickHouse", () => {
 		await chCommand(
 			"ALTER TABLE analytics.custom_events DELETE WHERE owner_id = {websiteId:String} SETTINGS mutations_sync = 1",
 			{ websiteId }
+		);
+		await chCommand(
+			"ALTER TABLE analytics.events DELETE WHERE client_id = {websiteId:String} SETTINGS mutations_sync = 1",
+			{ websiteId: collisionWebsiteId }
 		);
 	});
 
@@ -115,6 +182,110 @@ describeIntegration("profile query identity against ClickHouse", () => {
 		expect(Number(rows[0]?.total_events)).toBe(3);
 		expect(Number(rows[0]?.session_count)).toBe(2);
 		expect(Number(rows[0]?.custom_event_count)).toBe(1);
+	});
+
+	it("keeps stitched activity in the identified profile filter", async () => {
+		const query = new SimpleQueryBuilder(ProfilesBuilders.profile_list, {
+			filters: [{ field: "profile_id", op: "ne", value: "" }],
+			from: "2026-08-01",
+			projectId: websiteId,
+			to: "2026-08-02",
+			type: "profile_list",
+		}).compile();
+
+		const rows = await chQuery<{
+			profile_id: string;
+			total_events: number | string;
+		}>(query.sql, query.params);
+
+		expect(rows).toHaveLength(1);
+		expect(rows[0]?.profile_id).toBe(profileId);
+		expect(Number(rows[0]?.total_events)).toBe(3);
+	});
+
+	it("does not cross-attribute reused sessions between profiles", async () => {
+		const listQuery = ProfilesBuilders.profile_list?.customSql?.({
+			endDate: "2026-08-02",
+			limit: 10,
+			offset: 0,
+			startDate: "2026-08-01",
+			websiteId: collisionWebsiteId,
+		});
+		const detailQueries = [collisionProfileA, collisionProfileB].map((id) =>
+			ProfilesBuilders.profile_detail?.customSql?.({
+				endDate: "2026-08-02",
+				filters: [{ field: "anonymous_id", op: "eq", value: id }],
+				startDate: "2026-08-01",
+				websiteId: collisionWebsiteId,
+			})
+		);
+		const sessionQueries = [collisionProfileA, collisionProfileB].map((id) =>
+			ProfilesBuilders.profile_sessions?.customSql?.({
+				endDate: "2026-08-02",
+				filters: [{ field: "anonymous_id", op: "eq", value: id }],
+				startDate: "2026-08-01",
+				websiteId: collisionWebsiteId,
+			})
+		);
+
+		if (
+			!listQuery ||
+			typeof listQuery === "string" ||
+			detailQueries.some((query) => !query || typeof query === "string") ||
+			sessionQueries.some((query) => !query || typeof query === "string")
+		) {
+			throw new Error("Collision profile queries did not compile");
+		}
+
+		const [listRows, detailRows, sessionRows] = await Promise.all([
+			chQuery<{ profile_id: string; total_events: number | string }>(
+				listQuery.sql,
+				listQuery.params
+			),
+			Promise.all(
+				detailQueries.map((query) => {
+					if (!query || typeof query === "string") {
+						throw new Error("Detail query did not compile");
+					}
+					return chQuery<{ total_pageviews: number | string }>(
+						query.sql,
+						query.params
+					);
+				})
+			),
+			Promise.all(
+				sessionQueries.map((query) => {
+					if (!query || typeof query === "string") {
+						throw new Error("Session query did not compile");
+					}
+					return chQuery<{ events: unknown[]; session_id: string }>(
+						query.sql,
+						query.params
+					);
+				})
+			),
+		]);
+
+		const profileTotals = listRows
+			.map((row) => [row.profile_id, Number(row.total_events)] as const)
+			.sort(([left], [right]) => left.localeCompare(right));
+		expect(profileTotals).toEqual([
+			[collisionProfileA, 2],
+			[collisionProfileB, 2],
+		]);
+		expect(detailRows.map((rows) => Number(rows[0]?.total_pageviews))).toEqual([
+			2,
+			2,
+		]);
+		expect(sessionRows).toHaveLength(2);
+		for (const rows of sessionRows) {
+			expect(rows).toHaveLength(1);
+			const events = rows[0]?.events;
+			expect(Array.isArray(events)).toBe(true);
+			if (Array.isArray(events)) {
+				expect(events).toHaveLength(2);
+			}
+		}
 	});
 
 	it("uses the same stitched identity in profile detail and sessions", async () => {

--- a/packages/ai/src/query/builders/profiles.ts
+++ b/packages/ai/src/query/builders/profiles.ts
@@ -77,6 +77,7 @@ const PROFILE_IDENTITY_CTES = `
         FROM visitor_identity_rows
         WHERE session_id != ''
         GROUP BY session_id
+        HAVING uniqExact(profile_id) = 1
       )`;
 
 const PROFILE_TARGET_IDENTITY_CTES = `
@@ -113,13 +114,6 @@ const PROFILE_TARGET_IDENTITY_CTES = `
         FROM target_identity_rows
         WHERE anonymous_id != ''
         GROUP BY anonymous_id
-      ),
-      target_session_ids AS (
-        SELECT
-          session_id
-        FROM target_identity_rows
-        WHERE session_id != ''
-        GROUP BY session_id
       )`;
 
 const identityJoins = (source: string): string => `
@@ -129,17 +123,24 @@ const identityJoins = (source: string): string => `
           ON ifNull(${source}.session_id, '') = session_identity.session_id
         `;
 
-const canonicalVisitorExpression = (source: string): string => `coalesce(
+const canonicalProfileExpression = (source: string): string => `coalesce(
         nullIf(${source}.profile_id, ''),
-        nullIf(session_identity.initial_profile_id, ''),
         nullIf(direct_profile.initial_profile_id, ''),
+        nullIf(
+          if(ifNull(${source}.anonymous_id, '') = '', session_identity.initial_profile_id, ''),
+          ''
+        )
+      )`;
+
+const canonicalVisitorExpression = (source: string): string => `coalesce(
+        ${canonicalProfileExpression(source)},
         nullIf(${source}.anonymous_id, ''),
         ''
       )`;
 
-// Explicit profile ids always win. Anonymous-only rows use the first profile
-// assignment seen for that anonymous/session key so pre-identification activity
-// is backfilled without moving already-attributed rows after a profile change.
+// Explicit profile ids always win. A known anonymous id wins over a session id,
+// because session ids can be reused by multiple visitors. Session identity is
+// only a fallback for rows that have no anonymous id at all.
 
 const SUBQUERY_FILTER_FIELDS = new Set(["event_name"]);
 const PROFILE_LIST_ALLOWED_FILTERS = [
@@ -288,10 +289,7 @@ function profileActivityCte(
             e.profile_id = {visitorId:String}
             OR (
               ifNull(e.profile_id, '') = ''
-              AND (
-                e.anonymous_id IN (SELECT anonymous_id FROM target_anonymous_ids)
-                OR e.session_id IN (SELECT session_id FROM target_session_ids)
-              )
+              AND e.anonymous_id IN (SELECT anonymous_id FROM target_anonymous_ids)
             )
           )`
 		: `AND ${canonicalVisitorExpression("e")} = {visitorId:String}`;
@@ -300,10 +298,7 @@ function profileActivityCte(
             ifNull(ce.profile_id, '') = {visitorId:String}
             OR (
               ifNull(ce.profile_id, '') = ''
-              AND (
-                ifNull(ce.anonymous_id, '') IN (SELECT anonymous_id FROM target_anonymous_ids)
-                OR ifNull(ce.session_id, '') IN (SELECT session_id FROM target_session_ids)
-              )
+              AND ifNull(ce.anonymous_id, '') IN (SELECT anonymous_id FROM target_anonymous_ids)
             )
           )`
 		: `AND ${canonicalVisitorExpression("ce")} = {visitorId:String}`;
@@ -558,7 +553,7 @@ export const ProfilesBuilders: Record<string, SimpleQueryConfig> = {
         e.session_id AS session_id,
         e.path AS path,
         e.properties AS properties,
-        e.profile_id AS profile_id,
+        ${canonicalProfileExpression("e")} AS profile_id,
         e.user_agent AS user_agent,
         e.browser_name AS browser_name,
         e.os_name AS os_name,


### PR DESCRIPTION
## Summary

Fixes two verified identity attribution failures without changing the tracker or database schema:

- Resolve profile filters against stitched profile identity so pre-identification activity remains included.
- Prefer direct anonymous-to-profile mapping over session mapping; use session mapping only for rows without an anonymous ID.
- Reject ambiguous session mappings and remove session-only fallback from profile detail/session activity.

## Evidence

- Local ClickHouse integration: 4 identity tests, 18 expectations, 0 failures.
- @databuddy/ai suite with ClickHouse: 3,972 tests, 0 failures.
- Repository tests: 3,940 passed, 34 skipped, 0 failed.
- Repository check-types, lint, and build pass.
- Same-window read-only benchmark: profile list median ~1.48s current vs ~1.43s previous; profile sessions ~2.67s current vs ~4.09s previous. Cache disabled.
- Greptile P2 review comment addressed in follow-up commit 3bdd0c9c3.

No tracker or schema changes.