### PR TITLE
feat(insights): retain completed recommendations

### DIFF
--- a/apps/api/src/integration/insights-handlers.test.ts
+++ b/apps/api/src/integration/insights-handlers.test.ts
@@ -875,6 +875,7 @@ describe("insight investigation timeline", () => {
 			action?: string;
 			asOf: string;
 			createdAt?: string;
+			entity?: { id: string; label: string; type: "goal" };
 			organizationId?: string;
 			operation?: "edit" | "delete" | null;
 			publish?: boolean;
@@ -902,7 +903,9 @@ describe("insight investigation timeline", () => {
 				organizationId: input.organizationId ?? organization.id,
 				outcome,
 				recheckAt: new Date("2026-02-01T00:00:00.000Z"),
-				signal: signal(input.signalKey),
+				signal: input.entity
+					? { ...signal(input.signalKey), entity: input.entity }
+					: signal(input.signalKey),
 				signalKey: input.signalKey,
 				websiteId: input.websiteId ?? website.id,
 			};
@@ -1009,6 +1012,99 @@ describe("insight investigation timeline", () => {
 			recommendations: [],
 			total: 0,
 		});
+
+		const editableGoalId = randomUUIDv7();
+		const deletedGoalId = randomUUIDv7();
+		await db().insert(goals).values([
+			{
+				createdBy: member.id,
+				description: "An incomplete definition.",
+				id: editableGoalId,
+				name: "Tracked signup",
+				target: "signup_completed",
+				type: "EVENT",
+				websiteId: website.id,
+			},
+			{
+				createdBy: member.id,
+				id: deletedGoalId,
+				name: "Retired signup",
+				target: "signup_started",
+				type: "EVENT",
+				websiteId: website.id,
+			},
+		]);
+		await db().insert(insightObservations).values([
+			observation({
+				action: "Clarify the tracked signup goal.",
+				asOf: "2026-01-10T00:00:00.000Z",
+				entity: {
+					id: editableGoalId,
+					label: "Tracked signup",
+					type: "goal",
+				},
+				signalKey: "goal:tracked-signup",
+				title: "Tracked signup",
+			}),
+			observation({
+				action: "Delete the retired signup goal.",
+				asOf: "2026-01-11T00:00:00.000Z",
+				entity: {
+					id: deletedGoalId,
+					label: "Retired signup",
+					type: "goal",
+				},
+				operation: "delete",
+				signalKey: "goal:retired-signup",
+				title: "Retired signup",
+			}),
+		]);
+		const currentDefinitionActions = await call(
+			appRouter.insights.recommendations,
+			context
+		)({ limit: 10, offset: 0, organizationId: organization.id });
+		expect(
+			currentDefinitionActions.recommendations.map(
+				(item) => item.recommendation.action
+			)
+		).toEqual(
+			expect.arrayContaining([
+				"Clarify the tracked signup goal.",
+				"Delete the retired signup goal.",
+			])
+		);
+
+		const completedAt = new Date("2026-01-12T00:00:00.000Z");
+		await db()
+			.update(goals)
+			.set({ description: "Tracked signup definition." })
+			.where(eq(goals.id, editableGoalId));
+		await db()
+			.update(goals)
+			.set({ deletedAt: completedAt, isActive: false })
+			.where(eq(goals.id, deletedGoalId));
+		const completedDefinitionActions = await call(
+			appRouter.insights.recommendations,
+			context
+		)({ limit: 10, offset: 0, organizationId: organization.id });
+		expect(
+			completedDefinitionActions.recommendations.map(
+				(item) => item.recommendation.action
+			)
+		).not.toEqual(
+			expect.arrayContaining([
+				"Clarify the tracked signup goal.",
+				"Delete the retired signup goal.",
+			])
+		);
+		expect(
+			completedDefinitionActions.completed
+				.map((item) => item.recommendation.action)
+				.sort()
+		).toEqual([
+			"Clarify the tracked signup goal.",
+			"Delete the retired signup goal.",
+		]);
 	});
 
 	iit("expires standalone setup recommendations at their renewal deadline", async () => {
@@ -1127,6 +1223,7 @@ describe("insight investigation timeline", () => {
 			"Add the current tracking setup.",
 			"Keep the active identity recommendation.",
 		]);
+		expect(result.completed).toEqual([]);
 	});
 
 	iit("keeps precise measurement drafts current until their definition exists", async () => {
@@ -1272,6 +1369,7 @@ describe("insight investigation timeline", () => {
 				.map((item) => item.recommendation.kind)
 				.sort()
 		).toEqual(["funnel_draft", "goal_draft"]);
+		expect(beforeCreation.completed).toEqual([]);
 
 		await db().insert(goals).values({
 			createdBy: member.id,
@@ -1292,6 +1390,47 @@ describe("insight investigation timeline", () => {
 				(item) => item.recommendation.kind
 			)
 		).toEqual(["funnel_draft"]);
+		expect(afterGoalCreation.total).toBe(1);
+		expect(
+			afterGoalCreation.completed.map((item) => item.recommendation.kind)
+		).toEqual(["goal_draft"]);
+
+		const resolvedGoal: InvestigationOutcome = {
+			evidence: ["The account_created event is now covered by a goal."],
+			impact: "The team can review this completion as a goal.",
+			next: {
+				reason: "The current goal covers the event.",
+				type: "resolve",
+			},
+			publish: false,
+			recommendation: null,
+			rootCause: null,
+			summary: "Account creation is now covered by a goal.",
+			title: "Account creation goal is configured",
+		};
+		await db().insert(insightObservations).values({
+			asOf: new Date("2026-01-11T00:00:00.000Z"),
+			createdAt: new Date("2026-01-11T00:00:00.000Z"),
+			id: randomUUIDv7(),
+			insightId: null,
+			organizationId: organization.id,
+			outcome: resolvedGoal,
+			recheckAt: new Date("2026-01-18T00:00:00.000Z"),
+			signal: signal(goalSignalKey),
+			signalKey: goalSignalKey,
+			websiteId: website.id,
+		});
+		const afterGoalRecheck = await call(
+			appRouter.insights.recommendations,
+			context
+		)({ limit: 10, offset: 0, organizationId: organization.id });
+		expect(
+			afterGoalRecheck.recommendations.map((item) => item.recommendation.kind)
+		).toEqual(["funnel_draft"]);
+		expect(afterGoalRecheck.total).toBe(1);
+		expect(
+			afterGoalRecheck.completed.map((item) => item.recommendation.kind)
+		).toEqual(["goal_draft"]);
 
 		await db().insert(funnelDefinitions).values({
 			createdBy: member.id,
@@ -1323,6 +1462,11 @@ describe("insight investigation timeline", () => {
 				(item) => item.recommendation.kind
 			)
 		).toEqual(["funnel_draft"]);
+		expect(
+			afterConditionalFunnelCreation.completed.map(
+				(item) => item.recommendation.kind
+			)
+		).toEqual(["goal_draft"]);
 
 		await db().insert(funnelDefinitions).values({
 			createdBy: member.id,
@@ -1348,6 +1492,11 @@ describe("insight investigation timeline", () => {
 			recommendations: [],
 			total: 0,
 		});
+		expect(
+			afterFunnelCreation.completed
+				.map((item) => item.recommendation.kind)
+				.sort()
+		).toEqual(["funnel_draft", "goal_draft"]);
 	});
 
 	iit("persists a reply beside every observation for the same signal", async () => {

--- a/apps/dashboard/app/(main)/insights/recommendations/page.tsx
+++ b/apps/dashboard/app/(main)/insights/recommendations/page.tsx
@@ -18,9 +18,11 @@ import {
 	fromNow,
 	Skeleton,
 } from "@databuddy/ui";
+import { Accordion } from "@databuddy/ui/client";
 import {
 	ArrowRightIcon,
 	ArrowSquareOutIcon,
+	CheckCircleIcon,
 	CodeIcon,
 	FilterIcon,
 	IdBadge2Icon,
@@ -57,10 +59,7 @@ export default function RecommendationsPage() {
 
 	return (
 		<div className="mx-auto w-full max-w-4xl p-4 sm:p-6">
-			<Card
-				aria-label="Current recommendations"
-				className="border-border/70 shadow-sm"
-			>
+			<Card aria-label="Recommendations" className="border-border/70 shadow-sm">
 				<Card.Header className="border-b bg-card">
 					<Card.Title>Recommendations</Card.Title>
 					<Card.Description className="mt-1">
@@ -85,6 +84,7 @@ function RecommendationList({
 	);
 	const items =
 		recommendations.data?.pages.flatMap((page) => page.recommendations) ?? [];
+	const completed = recommendations.data?.pages[0]?.completed ?? [];
 
 	if (recommendations.isLoading) {
 		return (
@@ -101,7 +101,7 @@ function RecommendationList({
 		);
 	}
 
-	if (recommendations.isError && items.length === 0) {
+	if (recommendations.isError && items.length === 0 && completed.length === 0) {
 		return (
 			<div className="px-5 py-12">
 				<EmptyState
@@ -121,7 +121,7 @@ function RecommendationList({
 		);
 	}
 
-	if (items.length === 0) {
+	if (items.length === 0 && completed.length === 0) {
 		return (
 			<div className="px-5 py-12">
 				<EmptyState
@@ -136,11 +136,22 @@ function RecommendationList({
 
 	return (
 		<>
-			<ul>
-				{items.map((insight) => (
-					<RecommendationRow insight={insight} key={insight.id} />
-				))}
-			</ul>
+			{items.length > 0 ? (
+				<ul aria-label="Current recommendations">
+					{items.map((insight) => (
+						<RecommendationRow insight={insight} key={insight.id} />
+					))}
+				</ul>
+			) : (
+				<div className="flex items-center gap-2 px-4 py-3 text-muted-foreground text-sm">
+					<CheckCircleIcon
+						aria-hidden
+						className="size-4 text-success"
+						weight="fill"
+					/>
+					Nothing needs attention right now.
+				</div>
+			)}
 			{recommendations.hasNextPage ? (
 				<div className="flex justify-center border-t px-5 py-4">
 					<Button
@@ -156,7 +167,40 @@ function RecommendationList({
 					</Button>
 				</div>
 			) : null}
+			{completed.length > 0 ? (
+				<CompletedRecommendations insights={completed} />
+			) : null}
 		</>
+	);
+}
+
+function CompletedRecommendations({
+	insights,
+}: {
+	insights: InsightRecommendation[];
+}) {
+	return (
+		<Accordion className="border-t">
+			<Accordion.Trigger className="bg-success/5 hover:bg-success/10">
+				<CheckCircleIcon
+					aria-hidden
+					className="size-4 text-success"
+					weight="fill"
+				/>
+				<span className="font-medium text-foreground">Completed</span>
+				<Badge size="sm" variant="success">
+					{insights.length}
+				</Badge>
+				<span className="text-muted-foreground">Latest verified</span>
+			</Accordion.Trigger>
+			<Accordion.Panel>
+				<ul aria-label="Latest verified completed recommendations">
+					{insights.map((insight) => (
+						<RecommendationRow completed insight={insight} key={insight.id} />
+					))}
+				</ul>
+			</Accordion.Panel>
+		</Accordion>
 	);
 }
 
@@ -173,49 +217,65 @@ function RecommendationSkeleton() {
 	);
 }
 
-function RecommendationRow({ insight }: { insight: InsightRecommendation }) {
+function RecommendationRow({
+	completed = false,
+	insight,
+}: {
+	completed?: boolean;
+	insight: InsightRecommendation;
+}) {
 	const { recommendation } = insight;
 	const presentation = getRecommendationPresentation(insight);
-	const SignalIcon = presentation.icon;
-	const action = recommendationAction(insight);
+	const SignalIcon = completed ? CheckCircleIcon : presentation.icon;
+	const action = completed ? null : recommendationAction(insight);
 
 	return (
 		<List.Row align="start" asChild interactive={false}>
 			<li>
 				<span
-					className={`flex size-8 shrink-0 items-center justify-center rounded ${presentation.iconClassName}`}
+					className={`flex size-8 shrink-0 items-center justify-center rounded ${
+						completed
+							? "bg-success/10 text-success"
+							: presentation.iconClassName
+					}`}
 				>
-					<SignalIcon aria-hidden className="size-4" weight="duotone" />
+					<SignalIcon
+						aria-hidden
+						className="size-4"
+						weight={completed ? "fill" : "duotone"}
+					/>
 				</span>
 				<div className="min-w-0 flex-1 sm:flex sm:items-start sm:gap-4">
 					<div className="min-w-0 flex-1">
 						<span className="flex flex-wrap items-center gap-2">
 							<Badge
 								className={
-									presentation.badgeVariant === "primary"
+									!completed && presentation.badgeVariant === "primary"
 										? "bg-brand-purple text-white"
 										: undefined
 								}
 								size="sm"
-								variant={presentation.badgeVariant}
+								variant={completed ? "success" : presentation.badgeVariant}
 							>
-								{presentation.label}
+								{completed ? "Completed" : presentation.label}
 							</Badge>
 							<span className="min-w-0 truncate text-[11px] text-muted-foreground">
-								{insight.websiteName ?? insight.websiteDomain} ·{" "}
-								{fromNow(insight.createdAt)}
+								{insight.websiteName ?? insight.websiteDomain}
+								{completed ? null : ` · ${fromNow(insight.createdAt)}`}
 							</span>
 						</span>
 						<p className="mt-2 break-words font-medium text-foreground text-sm leading-relaxed [overflow-wrap:anywhere]">
-							{recommendation.action}
+							{completed ? completionMessage(insight) : recommendation.action}
 						</p>
-						<p className="mt-1.5 break-words text-muted-foreground text-xs leading-relaxed [overflow-wrap:anywhere]">
-							<span className="font-medium text-foreground/75">
-								{insight.impact ? "Why it matters: " : "Context: "}
-							</span>
-							{insight.impact ?? insight.summary}
-						</p>
-						{isInstrumentationRecommendation(recommendation) ? (
+						{completed ? null : (
+							<p className="mt-1.5 break-words text-muted-foreground text-xs leading-relaxed [overflow-wrap:anywhere]">
+								<span className="font-medium text-foreground/75">
+									{insight.impact ? "Why it matters: " : "Context: "}
+								</span>
+								{insight.impact ?? insight.summary}
+							</p>
+						)}
+						{!completed && isInstrumentationRecommendation(recommendation) ? (
 							<ul className="mt-2 space-y-1.5 text-muted-foreground text-xs leading-relaxed">
 								{recommendation.events.map((event) => (
 									<li key={event.name}>
@@ -248,6 +308,22 @@ function RecommendationRow({ insight }: { insight: InsightRecommendation }) {
 			</li>
 		</List.Row>
 	);
+}
+
+function completionMessage(insight: InsightRecommendation) {
+	const { recommendation } = insight;
+	if (isConversionDraftRecommendation(recommendation)) {
+		return recommendation.kind === "goal_draft"
+			? "Goal is now set up."
+			: "Funnel is now set up.";
+	}
+	if (isDefinitionRecommendation(recommendation)) {
+		const noun = insight.signal.entity.type === "funnel" ? "Funnel" : "Goal";
+		return recommendation.operation === "delete"
+			? `${noun} is no longer present.`
+			: `${noun} change is now set up.`;
+	}
+	return "This recommendation is complete.";
 }
 
 function recommendationAction(insight: InsightRecommendation) {

--- a/apps/dashboard/app/(main)/insights/recommendations/page.tsx
+++ b/apps/dashboard/app/(main)/insights/recommendations/page.tsx
@@ -10,6 +10,7 @@ import Link from "next/link";
 import { useOrganizationsContext } from "@/components/providers/organizations-provider";
 import { List } from "@/components/ui/composables/list";
 import { type InsightRecommendation, insightQueries } from "@/lib/insight-api";
+import { cn } from "@/lib/utils";
 import {
 	Badge,
 	Button,
@@ -233,11 +234,12 @@ function RecommendationRow({
 		<List.Row align="start" asChild interactive={false}>
 			<li>
 				<span
-					className={`flex size-8 shrink-0 items-center justify-center rounded ${
+					className={cn(
+						"flex size-8 shrink-0 items-center justify-center rounded",
 						completed
 							? "bg-success/10 text-success"
 							: presentation.iconClassName
-					}`}
+					)}
 				>
 					<SignalIcon
 						aria-hidden
@@ -264,7 +266,7 @@ function RecommendationRow({
 								{completed ? null : ` · ${fromNow(insight.createdAt)}`}
 							</span>
 						</span>
-						<p className="mt-2 break-words font-medium text-foreground text-sm leading-relaxed [overflow-wrap:anywhere]">
+						<p className="mt-2 text-pretty break-words font-medium text-foreground text-sm leading-relaxed [overflow-wrap:anywhere]">
 							{completed ? completionMessage(insight) : recommendation.action}
 						</p>
 						{completed ? null : (

--- a/apps/dashboard/hooks/use-funnels.ts
+++ b/apps/dashboard/hooks/use-funnels.ts
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
+import { insightQueries } from "@/lib/insight-api";
 import { listQueryOutcome } from "@/lib/list-query-outcome";
 import { orpc } from "@/lib/orpc";
 import type {
@@ -35,7 +36,7 @@ export function useFunnelActions(websiteId: string) {
 			queryClient.invalidateQueries({
 				queryKey: orpc.funnels.getAnalyticsByLink.key(),
 			}),
-			queryClient.invalidateQueries({ queryKey: orpc.insights.key() }),
+			queryClient.invalidateQueries({ queryKey: insightQueries.all() }),
 		]);
 
 	const createMutation = useMutation({

--- a/apps/dashboard/hooks/use-goals.ts
+++ b/apps/dashboard/hooks/use-goals.ts
@@ -5,6 +5,7 @@ import type { GoalFilter } from "@/types/api";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { toast } from "sonner";
+import { insightQueries } from "@/lib/insight-api";
 import { listQueryOutcome } from "@/lib/list-query-outcome";
 import { orpc } from "@/lib/orpc";
 
@@ -102,7 +103,7 @@ export function useGoalActions(websiteId: string) {
 			queryClient.invalidateQueries({
 				queryKey: orpc.goals.bulkAnalytics.key(),
 			}),
-			queryClient.invalidateQueries({ queryKey: orpc.insights.key() }),
+			queryClient.invalidateQueries({ queryKey: insightQueries.all() }),
 		]);
 
 	const createMutation = useMutation({

--- a/apps/dashboard/lib/insight-api.ts
+++ b/apps/dashboard/lib/insight-api.ts
@@ -71,7 +71,8 @@ export const insightQueries = {
 				fetchInsightRecommendationsPage(
 					orgId ?? "",
 					pageParam,
-					RECOMMENDATIONS_PAGE_SIZE
+					RECOMMENDATIONS_PAGE_SIZE,
+					pageParam === 0
 				),
 			initialPageParam: 0,
 			getNextPageParam: (lastPage, _allPages, lastPageParam) =>
@@ -89,7 +90,7 @@ export const insightQueries = {
 		queryOptions({
 			queryKey: [...INSIGHTS_ROOT, "recommendation-total", orgId] as const,
 			queryFn: async () =>
-				(await fetchInsightRecommendationsPage(orgId ?? "", 0, 1)).total,
+				(await fetchInsightRecommendationsPage(orgId ?? "", 0, 1, false)).total,
 			enabled: !!orgId,
 			staleTime: INSIGHT_CACHE.historyStaleTime,
 			gcTime: INSIGHT_CACHE.gcTime,
@@ -150,9 +151,11 @@ export type Insight = InsightsHistoryPage["insights"][number];
 function fetchInsightRecommendationsPage(
 	organizationId: string,
 	offset: number,
-	limit = 50
+	limit = 50,
+	includeCompleted = true
 ) {
 	return orpc.insights.recommendations.call({
+		includeCompleted,
 		organizationId,
 		limit,
 		offset,

--- a/apps/dashboard/test/e2e/specs/regressions/measurement-recommendations.spec.ts
+++ b/apps/dashboard/test/e2e/specs/regressions/measurement-recommendations.spec.ts
@@ -129,5 +129,23 @@ test(
 		await expect(dialog.locator('input[placeholder="event_name"]')).toHaveValue(
 			"checkout_completed"
 		);
+		await dialog.getByRole("button", { name: "Create Goal" }).click();
+		await expect(dialog).toHaveCount(0);
+		await expect(
+			authenticatedPage.getByText("Nothing needs attention right now.")
+		).toBeVisible();
+		await expect(
+			authenticatedPage.getByRole("link", {
+				exact: true,
+				name: "Recommendations",
+			})
+		).toBeVisible();
+
+		await authenticatedPage
+			.getByRole("button", { name: /Completed 1 Latest verified/ })
+			.click();
+		await expect(
+			authenticatedPage.getByText("Goal is now set up.")
+		).toBeVisible();
 	}
 );

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -6,9 +6,11 @@ import {
 	eq,
 	inArray,
 	isNull,
+	not,
 	notExists,
 	or,
 	sql,
+	type SQLWrapper,
 } from "@databuddy/db";
 import {
 	analyticsInsights,
@@ -46,6 +48,7 @@ import { type Context, protectedProcedure, sessionProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 
 const INSIGHT_TIMELINE_ROWS_PER_KIND = 50;
+const COMPLETED_RECOMMENDATION_LIMIT = 5;
 
 function isAccessDenied(error: unknown): boolean {
 	return (
@@ -1039,10 +1042,11 @@ export const insightsRouter = {
 			method: "POST",
 			path: "/insights/recommendations",
 			tags: ["Insights"],
-			summary: "List current insight recommendations",
+			summary: "List current and completed insight recommendations",
 		})
 		.input(
 			z.object({
+				includeCompleted: z.boolean().default(true),
 				limit: z.number().int().min(1).max(100).default(50),
 				offset: z.number().int().min(0).default(0),
 				organizationId: z.string().min(1),
@@ -1051,6 +1055,7 @@ export const insightsRouter = {
 		)
 		.output(
 			z.object({
+				completed: z.array(insightRecommendationItemSchema),
 				hasMore: z.boolean(),
 				recommendations: z.array(insightRecommendationItemSchema),
 				total: z.number().int().nonnegative(),
@@ -1058,7 +1063,10 @@ export const insightsRouter = {
 		)
 		.handler(async ({ context, input }) => {
 			await authorizeInsightsRead(context, input);
-			const latestRecommendation = (alias: string) => {
+			const latestRecommendation = (
+				alias: string,
+				recommendationOnly = false
+			) => {
 				const latestBySignal = db
 					.selectDistinctOn(
 						[insightObservations.websiteId, insightObservations.signalKey],
@@ -1091,6 +1099,9 @@ export const insightsRouter = {
 							input.websiteId
 								? eq(insightObservations.websiteId, input.websiteId)
 								: undefined,
+							recommendationOnly
+								? sql`${insightObservations.outcome}->>'recommendation' is not null`
+								: undefined,
 							isNull(websites.deletedAt)
 						)
 					)
@@ -1118,7 +1129,7 @@ export const insightsRouter = {
 						websiteName: latestBySignal.websiteName,
 					})
 					.from(latestBySignal)
-					.where(sql`${recommendation} is not null`)
+					.where(sql`${latestBySignal.outcome}->>'recommendation' is not null`)
 					.orderBy(
 						latestBySignal.websiteId,
 						recommendation,
@@ -1130,89 +1141,182 @@ export const insightsRouter = {
 			};
 
 			const pageSource = latestRecommendation("latest_recommendations");
-			const recommendation = sql`${pageSource.outcome}->'recommendation'`;
-			const recommendationKind = sql`${recommendation}->>'kind'`;
-			const recommendationDraft = sql`${recommendation}->'draft'`;
-			const isFreshStandaloneRecommendation = or(
-				sql`coalesce(${recommendationKind}, '') not in ('instrumentation', 'databuddy_setup')`,
-				sql`${pageSource.outcome}->'next'->>'type' <> 'resolve'`,
-				sql`${pageSource.recheckAt} > now()`
+			const completedSource = latestRecommendation(
+				"latest_completed_recommendations",
+				true
 			);
-			const noEquivalentGoalDraft = notExists(
-				db
-					.select({ id: goals.id })
-					.from(goals)
-					.where(
-						and(
-							eq(goals.websiteId, pageSource.websiteId),
-							eq(goals.isActive, true),
-							isNull(goals.deletedAt),
-							sql`${goals.type} = ${recommendationDraft}->>'type'`,
-							sql`${goals.target} = ${recommendationDraft}->>'target'`,
-							sql`coalesce(${goals.filters}, '[]'::jsonb) = coalesce(${recommendationDraft}->'filters', '[]'::jsonb)`,
-							sql`${goals.ignoreHistoricData} = CASE ${recommendationDraft}->>'ignoreHistoricData' WHEN 'true' THEN true ELSE false END`
+			const recommendationState = (source: typeof pageSource) => {
+				const recommendation = sql`${source.outcome}->'recommendation'`;
+				const recommendationChanges = sql`${recommendation}->'changes'`;
+				const recommendationDraft = sql`${recommendation}->'draft'`;
+				const recommendationKind = sql`${recommendation}->>'kind'`;
+				const recommendationOperation = sql`${recommendation}->>'operation'`;
+				const entityId = sql`${source.signal}->'entity'->>'id'`;
+				const entityType = sql`${source.signal}->'entity'->>'type'`;
+				const isFreshStandaloneRecommendation = or(
+					sql`coalesce(${recommendationKind}, '') not in ('instrumentation', 'databuddy_setup')`,
+					sql`${source.outcome}->'next'->>'type' <> 'resolve'`,
+					sql`${source.recheckAt} > now()`
+				);
+				const noEquivalentGoalDraft = notExists(
+					db
+						.select({ id: goals.id })
+						.from(goals)
+						.where(
+							and(
+								eq(goals.websiteId, source.websiteId),
+								eq(goals.isActive, true),
+								isNull(goals.deletedAt),
+								sql`${goals.type} = ${recommendationDraft}->>'type'`,
+								sql`${goals.target} = ${recommendationDraft}->>'target'`,
+								sql`coalesce(${goals.filters}, '[]'::jsonb) = coalesce(${recommendationDraft}->'filters', '[]'::jsonb)`,
+								sql`${goals.ignoreHistoricData} = CASE ${recommendationDraft}->>'ignoreHistoricData' WHEN 'true' THEN true ELSE false END`
+							)
 						)
-					)
-			);
-			const noEquivalentFunnelDraft = notExists(
-				db
-					.select({ id: funnelDefinitions.id })
-					.from(funnelDefinitions)
-					.where(
-						and(
-							eq(funnelDefinitions.websiteId, pageSource.websiteId),
-							eq(funnelDefinitions.isActive, true),
-							isNull(funnelDefinitions.deletedAt),
-							sql`coalesce(${funnelDefinitions.filters}, '[]'::jsonb) = coalesce(${recommendationDraft}->'filters', '[]'::jsonb)`,
-							sql`${funnelDefinitions.ignoreHistoricData} = CASE ${recommendationDraft}->>'ignoreHistoricData' WHEN 'true' THEN true ELSE false END`,
-							sql`(
-								SELECT jsonb_agg(
-									jsonb_build_object(
-										'type', existing_step.value->>'type',
-										'target', existing_step.value->>'target',
-										'conditions', coalesce(nullif(existing_step.value->'conditions', 'null'::jsonb), '{}'::jsonb)
+				);
+				const noEquivalentFunnelDraft = notExists(
+					db
+						.select({ id: funnelDefinitions.id })
+						.from(funnelDefinitions)
+						.where(
+							and(
+								eq(funnelDefinitions.websiteId, source.websiteId),
+								eq(funnelDefinitions.isActive, true),
+								isNull(funnelDefinitions.deletedAt),
+								sql`coalesce(${funnelDefinitions.filters}, '[]'::jsonb) = coalesce(${recommendationDraft}->'filters', '[]'::jsonb)`,
+								sql`${funnelDefinitions.ignoreHistoricData} = CASE ${recommendationDraft}->>'ignoreHistoricData' WHEN 'true' THEN true ELSE false END`,
+								sql`(
+									SELECT jsonb_agg(
+										jsonb_build_object(
+											'type', existing_step.value->>'type',
+											'target', existing_step.value->>'target',
+											'conditions', coalesce(nullif(existing_step.value->'conditions', 'null'::jsonb), '{}'::jsonb)
+										)
+										ORDER BY existing_step.ordinality
 									)
-									ORDER BY existing_step.ordinality
-								)
-								FROM jsonb_array_elements(${funnelDefinitions.steps}) WITH ORDINALITY AS existing_step(value, ordinality)
-							) = (
-								SELECT jsonb_agg(
-									jsonb_build_object(
-										'type', draft_step.value->>'type',
-										'target', draft_step.value->>'target',
-										'conditions', '{}'::jsonb
+									FROM jsonb_array_elements(${funnelDefinitions.steps}) WITH ORDINALITY AS existing_step(value, ordinality)
+								) = (
+									SELECT jsonb_agg(
+										jsonb_build_object(
+											'type', draft_step.value->>'type',
+											'target', draft_step.value->>'target',
+											'conditions', '{}'::jsonb
+										)
+										ORDER BY draft_step.ordinality
 									)
-									ORDER BY draft_step.ordinality
-								)
-								FROM jsonb_array_elements(${recommendationDraft}->'steps') WITH ORDINALITY AS draft_step(value, ordinality)
-							)`
+									FROM jsonb_array_elements(${recommendationDraft}->'steps') WITH ORDINALITY AS draft_step(value, ordinality)
+								)`
+							)
 						)
-					)
-			);
-			const isCurrentRecommendation = and(
-				or(
-					and(sql`${recommendationKind} = 'goal_draft'`, noEquivalentGoalDraft),
+				);
+				const definitionEditApplied = (
+					table: typeof goals | typeof funnelDefinitions,
+					definition: {
+						deletedAt: SQLWrapper;
+						description: SQLWrapper;
+						id: SQLWrapper;
+						name: SQLWrapper;
+						websiteId: SQLWrapper;
+					}
+				) =>
+					sql`exists (
+						select 1 from ${table}
+						where ${definition.websiteId} = ${source.websiteId}
+							and ${definition.id} = ${entityId}
+							and ${definition.deletedAt} is null
+							and (${recommendationChanges}->>'name' is null or ${definition.name} = ${recommendationChanges}->>'name')
+							and (${recommendationChanges}->>'description' is null or ${definition.description} = ${recommendationChanges}->>'description')
+					)`;
+				const definitionDeleted = (
+					table: typeof goals | typeof funnelDefinitions,
+					definition: {
+						deletedAt: SQLWrapper;
+						id: SQLWrapper;
+						websiteId: SQLWrapper;
+					}
+				) =>
+					sql`not exists (
+						select 1 from ${table}
+						where ${definition.websiteId} = ${source.websiteId}
+							and ${definition.id} = ${entityId}
+							and ${definition.deletedAt} is null
+					)`;
+				const goalEditApplied = and(
+					sql`${recommendationOperation} = 'edit'`,
+					sql`${entityType} = 'goal'`,
+					definitionEditApplied(goals, goals)
+				);
+				const funnelEditApplied = and(
+					sql`${recommendationOperation} = 'edit'`,
+					sql`${entityType} = 'funnel'`,
+					definitionEditApplied(funnelDefinitions, funnelDefinitions)
+				);
+				const goalDeleteApplied = and(
+					sql`${recommendationOperation} = 'delete'`,
+					sql`${entityType} = 'goal'`,
+					definitionDeleted(goals, goals)
+				);
+				const funnelDeleteApplied = and(
+					sql`${recommendationOperation} = 'delete'`,
+					sql`${entityType} = 'funnel'`,
+					definitionDeleted(funnelDefinitions, funnelDefinitions)
+				);
+				const isCompletedDefinitionRecommendation = or(
+					goalEditApplied,
+					funnelEditApplied,
+					goalDeleteApplied,
+					funnelDeleteApplied
+				);
+				const hasNativeRecommendation = or(
+					sql`${recommendationOperation} in ('edit', 'delete') and ${entityType} in ('goal', 'funnel')`,
+					sql`${recommendationKind} in ('goal_draft', 'funnel_draft', 'instrumentation', 'databuddy_setup')`
+				);
+				const isCurrentRecommendation = and(
+					or(
+						and(
+							sql`${recommendationKind} = 'goal_draft'`,
+							noEquivalentGoalDraft
+						),
+						and(
+							sql`${recommendationKind} = 'funnel_draft'`,
+							noEquivalentFunnelDraft
+						),
+						and(
+							sql`${recommendationKind} is null or ${recommendationKind} not in ('goal_draft', 'funnel_draft')`,
+							sql`not coalesce(${isCompletedDefinitionRecommendation}, false)`
+						)
+					),
+					isFreshStandaloneRecommendation
+				);
+				const isCompletedRecommendation = or(
+					and(
+						sql`${recommendationKind} = 'goal_draft'`,
+						not(noEquivalentGoalDraft)
+					),
 					and(
 						sql`${recommendationKind} = 'funnel_draft'`,
-						noEquivalentFunnelDraft
+						not(noEquivalentFunnelDraft)
 					),
-					sql`${recommendationKind} is null or ${recommendationKind} not in ('goal_draft', 'funnel_draft')`
-				),
-				isFreshStandaloneRecommendation
-			);
-			const hasNativeRecommendation = or(
-				sql`${pageSource.outcome}->'recommendation'->>'operation' in ('edit', 'delete')`,
-				sql`${pageSource.outcome}->'recommendation'->>'kind' in ('goal_draft', 'funnel_draft', 'instrumentation', 'databuddy_setup')`
-			);
-			const [rows, [summary]] = await Promise.all([
+					isCompletedDefinitionRecommendation
+				);
+
+				return {
+					hasNativeRecommendation,
+					isCompletedRecommendation,
+					isCurrentRecommendation,
+				};
+			};
+			const pageState = recommendationState(pageSource);
+			const completedState = recommendationState(completedSource);
+			const [rows, [summary], completedRows] = await Promise.all([
 				db
 					.select()
 					.from(pageSource)
 					.where(
 						and(
 							sql`${pageSource.outcome}->>'recommendation' is not null`,
-							hasNativeRecommendation,
-							isCurrentRecommendation
+							pageState.hasNativeRecommendation,
+							pageState.isCurrentRecommendation
 						)
 					)
 					.orderBy(
@@ -1228,18 +1332,38 @@ export const insightsRouter = {
 					.where(
 						and(
 							sql`${pageSource.outcome}->>'recommendation' is not null`,
-							hasNativeRecommendation,
-							isCurrentRecommendation
+							pageState.hasNativeRecommendation,
+							pageState.isCurrentRecommendation
 						)
 					),
+				input.includeCompleted
+					? db
+							.select()
+							.from(completedSource)
+							.where(
+								and(
+									sql`${completedSource.outcome}->>'recommendation' is not null`,
+									completedState.hasNativeRecommendation,
+									completedState.isCompletedRecommendation
+								)
+							)
+							.orderBy(
+								desc(completedSource.asOf),
+								desc(completedSource.createdAt),
+								desc(completedSource.id)
+							)
+							.limit(COMPLETED_RECOMMENDATION_LIMIT)
+					: Promise.resolve([]),
 			]);
-			const page = rows.slice(0, input.limit).flatMap((row) => {
+			const toRecommendation = (row: (typeof rows)[number]) => {
 				const insight = serializeInsightBrief(row);
 				return insight?.recommendation
 					? [{ ...insight, recommendation: insight.recommendation }]
 					: [];
-			});
+			};
+			const page = rows.slice(0, input.limit).flatMap(toRecommendation);
 			return {
+				completed: completedRows.flatMap(toRecommendation),
 				hasMore: rows.length > input.limit,
 				recommendations: page,
 				total: summary?.total ?? 0,


### PR DESCRIPTION
## Summary
- retain verified goal and funnel recommendation completions in a compact Completed section
- keep active counts active-only and refresh every Insights surface after goal or funnel mutations
- preserve completions through later rechecks; show legacy definition edits/deletes only when the exact current definition proves the target state

## Verification
- bun run lint
- bun run check-types
- TZ=UTC bunx --bun vitest run --config vitest.integration.config.ts src/integration/insights-handlers.test.ts
- isolated Playwright regression: measurement-recommendations.spec.ts
- pre-push full test suite (3,940 passed, 33 skipped)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retains verified goal and funnel recommendation completions and shows them in a compact Completed section without changing active counts or pagination. Previously, completed items disappeared; now current recommendations exclude resolved items, which persist as “Completed (latest verified)” for quick audit.

- API: `insights.recommendations` adds optional `includeCompleted` (default true) and returns a `completed` array (max 5, newest first) on the first page only. `total` and `hasMore` reflect active recommendations only. Drafts complete when an equivalent goal/funnel exists. Definition edits/deletes complete only when the exact recommended changes are present or the entity is absent. Signals include entity metadata to verify completion.
- Dashboard: renders a Completed accordion with count and “Latest verified”; shows “Nothing needs attention right now” when no active items. Completed rows use a success icon/badge, omit timestamps, align with the list, and show concise messages (e.g., “Goal is now set up.”, “Goal is no longer present.”).
- Caching: goal/funnel mutations now invalidate `insightQueries.all()` to refresh all Insights surfaces.
- Tests: expands integration coverage for completion retention and adds Playwright checks for the Completed section and messages.

**Rollout**
- No migration required. Clients can ignore `completed` or set `includeCompleted: false`. If you paginate, expect `completed` only on the first page. If you validate response shapes, extend types to include `completed`.

<sup>Written for commit b64e0190ebf9f29d75e3faf6ef782f0cf38f032a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

