### PR TITLE
fix(dashboard): center revenue empty state

### DIFF
--- a/.agents/skills/databuddy-internal/SKILL.md
+++ b/.agents/skills/databuddy-internal/SKILL.md
@@ -126,6 +126,7 @@ Read [codebase-map.md](./references/codebase-map.md) when you need deeper routin
 ### Dashboard work
 
 - Start in `apps/dashboard`
+- Keep large page-owned settings sheets and dialogs in adjacent feature files; route components should own page data and layout rather than embedding unrelated form lifecycles.
 - For dashboard navigation audits, check all route surfaces: `components/layout/navigation/navigation-config.tsx`, `components/ui/command-search.tsx`, and local `PageNavigation` layouts under `app/**/layout.tsx` before calling a page orphaned.
 - When fixing broken dashboard links to moved sections, update the real docs/search/navigation links and section anchors directly; do not add compatibility redirect pages unless explicitly requested.
 - Custom events UI is shared in `apps/dashboard/components/events/custom-events`; keep many-series legends outside the Recharts plot, use compact controls for property-summary event selection, and avoid separate event-count chip/list sections.

--- a/.agents/skills/databuddy-internal/SKILL.md
+++ b/.agents/skills/databuddy-internal/SKILL.md
@@ -126,6 +126,7 @@ Read [codebase-map.md](./references/codebase-map.md) when you need deeper routin
 ### Dashboard work
 
 - Start in `apps/dashboard`
+- The Feature Flags list is a dense data table; keep flag identity metadata clean and place activity telemetry in a dedicated labeled column with its accuracy caveat in the Activity header tooltip.
 - Keep large page-owned settings sheets and dialogs in adjacent feature files; route components should own page data and layout rather than embedding unrelated form lifecycles.
 - For dashboard navigation audits, check all route surfaces: `components/layout/navigation/navigation-config.tsx`, `components/ui/command-search.tsx`, and local `PageNavigation` layouts under `app/**/layout.tsx` before calling a page orphaned.
 - When fixing broken dashboard links to moved sections, update the real docs/search/navigation links and section anchors directly; do not add compatibility redirect pages unless explicitly requested.

--- a/apps/api/src/audit/audit-outbox-replay.ts
+++ b/apps/api/src/audit/audit-outbox-replay.ts
@@ -21,7 +21,16 @@ export function startAuditOutboxReplayLoop(): AuditOutboxReplayLoop {
 			return active;
 		}
 		active = replayAuditOutbox(db)
-			.then(() => undefined)
+			.then(({ failed, replayed }) => {
+				if (replayed > 0 || failed > 0) {
+					log.info({
+						service: "api",
+						component: "audit_outbox_replay",
+						replayed,
+						failed,
+					});
+				}
+			})
 			.catch((error) => {
 				log.error({
 					service: "api",

--- a/apps/api/src/integration/cache-auth-bypass.test.ts
+++ b/apps/api/src/integration/cache-auth-bypass.test.ts
@@ -50,7 +50,11 @@ async function seedTargetGroup(websiteId: string, createdBy: string) {
 		});
 }
 
-async function seedFlag(websiteId: string, createdBy: string) {
+async function seedFlag(
+	websiteId: string,
+	createdBy: string,
+	userId?: string
+) {
 	await db()
 		.insert(flags)
 		.values({
@@ -63,6 +67,7 @@ async function seedFlag(websiteId: string, createdBy: string) {
 			status: "active",
 			rules: [{ field: "country", operator: "equals", value: "US" }],
 			createdBy,
+			userId,
 		});
 }
 
@@ -159,6 +164,18 @@ describe("cache-bypass auth: target-groups.list", () => {
 });
 
 describe("cache-bypass auth: flags.list", () => {
+	iit("preserves user-scoped flag identity in the response contract", async () => {
+		const { user, org, site } = await setupOwnedSite();
+		await seedFlag(site.id, user.id, user.id);
+
+		const result = await call(
+			appRouter.flags.list,
+			userContext(user, org.id)
+		)({ websiteId: site.id });
+
+		expect(result[0]).toMatchObject({ userId: user.id });
+	});
+
 	iit("anon caller cannot read flags after authed prime", async () => {
 		const { user, org, site } = await setupOwnedSite();
 		await seedFlag(site.id, user.id);

--- a/apps/api/src/routes/public/flags.ts
+++ b/apps/api/src/routes/public/flags.ts
@@ -1133,8 +1133,10 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 				flag_write: "create",
 			});
 
+			let auditApiKey: ApiKeyRow | undefined;
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
+				auditApiKey = auth.apiKey;
 				if (!auth.ok) {
 					await recordPublicFlagAudit({
 						action: auth.status === 403 ? "denied" : "failure",
@@ -1192,6 +1194,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 				const existing = existingRows.at(0) ?? null;
 
 				if (existing && !existing.deletedAt) {
+					await recordPublicFlagAudit({
+						action: "failure",
+						apiKey: auditApiKey,
+						operation: "flags.create",
+						reason: "A flag with this key already exists",
+						request,
+						targetId: body.clientId,
+					});
 					set.status = 409;
 					return { error: "A flag with this key already exists" };
 				}
@@ -1214,6 +1224,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 							)
 						);
 					if (dependencyRows.length !== dependencies.length) {
+						await recordPublicFlagAudit({
+							action: "failure",
+							apiKey: auditApiKey,
+							operation: "flags.create",
+							reason: "One or more dependency flags were not found",
+							request,
+							targetId: body.clientId,
+						});
 						set.status = 400;
 						return { error: "One or more dependency flags were not found" };
 					}
@@ -1334,6 +1352,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					},
 				};
 			} catch (error) {
+				await recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.create",
+					reason: "Failed to create flag",
+					request,
+					targetId: body.clientId,
+				});
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),
@@ -1377,8 +1403,10 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 				flag_write: "update",
 			});
 
+			let auditApiKey: ApiKeyRow | undefined;
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
+				auditApiKey = auth.apiKey;
 				if (!auth.ok) {
 					await recordPublicFlagAudit({
 						action: auth.status === 403 ? "denied" : "failure",
@@ -1413,6 +1441,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				const flag = existing.at(0);
 				if (!flag) {
+					await recordPublicFlagAudit({
+						action: "failure",
+						apiKey: auditApiKey,
+						operation: "flags.update",
+						reason: "Flag not found",
+						request,
+						targetId: params.id,
+					});
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1420,6 +1456,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.websiteId !== body.clientId &&
 					flag.organizationId !== body.clientId
 				) {
+					await recordPublicFlagAudit({
+						action: "failure",
+						apiKey: auditApiKey,
+						operation: "flags.update",
+						reason: "Flag not found",
+						request,
+						targetId: params.id,
+					});
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1498,6 +1542,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					},
 				};
 			} catch (error) {
+				await recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.update",
+					reason: "Failed to update flag",
+					request,
+					targetId: params.id,
+				});
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),
@@ -1533,8 +1585,10 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 				flag_write: "delete",
 			});
 
+			let auditApiKey: ApiKeyRow | undefined;
 			try {
 				const auth = await resolveFlagAdmin(request.headers, query.clientId);
+				auditApiKey = auth.apiKey;
 				if (!auth.ok) {
 					await recordPublicFlagAudit({
 						action: auth.status === 403 ? "denied" : "failure",
@@ -1569,6 +1623,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				const flag = existing.at(0);
 				if (!flag) {
+					await recordPublicFlagAudit({
+						action: "failure",
+						apiKey: auditApiKey,
+						operation: "flags.delete",
+						reason: "Flag not found",
+						request,
+						targetId: params.id,
+					});
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1576,6 +1638,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.websiteId !== query.clientId &&
 					flag.organizationId !== query.clientId
 				) {
+					await recordPublicFlagAudit({
+						action: "failure",
+						apiKey: auditApiKey,
+						operation: "flags.delete",
+						reason: "Flag not found",
+						request,
+						targetId: params.id,
+					});
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1624,6 +1694,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				return { success: true };
 			} catch (error) {
+				await recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.delete",
+					reason: "Failed to delete flag",
+					request,
+					targetId: params.id,
+				});
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),

--- a/apps/api/src/routes/public/flags.ts
+++ b/apps/api/src/routes/public/flags.ts
@@ -16,6 +16,7 @@ import {
 	withTransaction,
 } from "@databuddy/db";
 import {
+	buildFlagChangeSnapshot,
 	flagChangeEvents,
 	type FlagUserRule,
 	type FlagVariant,
@@ -25,7 +26,11 @@ import {
 import { cacheNamespaces, cacheTags, cacheable } from "@databuddy/redis";
 import { getRateLimitHeaders, ratelimit } from "@databuddy/redis/rate-limit";
 import { invalidateFlagCache } from "@databuddy/rpc/flags";
+import { appendAuditEvent } from "@databuddy/services/audit";
+import { auditActions } from "@databuddy/shared/audit";
+import { getTrustedClientIp } from "@databuddy/shared/utils/trusted-client-ip";
 import { randomUUIDv7 } from "bun";
+import { getRequestId } from "@/http/request-id";
 import { Elysia, t } from "elysia";
 import { useLogger } from "evlog/elysia";
 import { LRUCache } from "lru-cache";
@@ -668,6 +673,7 @@ interface FlagAdminSuccess {
 }
 
 interface FlagAdminFailure {
+	apiKey?: ApiKeyRow;
 	error: string;
 	ok: false;
 	status: 401 | 403;
@@ -701,9 +707,50 @@ async function resolveFlagAdmin(
 		hasWebsiteAccess = Boolean(website);
 	}
 	if (!(hasWebsiteAccess || hasOrgAccess)) {
-		return { ok: false, status: 403, error: "Forbidden" };
+		return { apiKey, ok: false, status: 403, error: "Forbidden" };
 	}
 	return { ok: true, apiKey };
+}
+
+async function recordPublicFlagAudit(input: {
+	action: "denied" | "failure" | "success";
+	apiKey?: ApiKeyRow;
+	operation: string;
+	request: Request;
+	reason?: string;
+	targetId: string;
+	targetName?: string;
+}): Promise<void> {
+	const organizationId = input.apiKey?.organizationId;
+	if (!(organizationId && input.apiKey)) {
+		return;
+	}
+
+	try {
+		await appendAuditEvent(db, organizationId, {
+			action: auditActions.FLAG_CHANGED,
+			actor: {
+				displayName: input.apiKey.name,
+				id: input.apiKey.id,
+				type: "api",
+			},
+			operation: input.operation,
+			outcome: input.action,
+			reason: input.reason,
+			request: {
+				ip: getTrustedClientIp(input.request.headers),
+				requestId: getRequestId(input.request),
+				userAgent: input.request.headers.get("user-agent") ?? undefined,
+			},
+			source: "public_api",
+			target: { displayName: input.targetName, id: input.targetId },
+		});
+	} catch (error) {
+		useLogger().error(
+			error instanceof Error ? error : new Error(String(error)),
+			{ flags: { audit: true, operation: input.operation } }
+		);
+	}
 }
 
 function invalidateMemCacheForClient(clientId: string) {
@@ -732,23 +779,6 @@ function resolveScope(
 		return { websiteId: null, organizationId: clientId };
 	}
 	return { websiteId: null, organizationId: null };
-}
-
-function buildFlagChangeSnapshot(flag: typeof flags.$inferSelect) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
 }
 
 interface BulkFlagInput extends UserContext {
@@ -1106,17 +1136,41 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: auth.error,
+						request,
+						targetId: body.clientId,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: "Forbidden",
+						request,
+						targetId: body.clientId,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
 
 				const scope = resolveScope(auth.apiKey, body.clientId);
 				if (!(scope.websiteId || scope.organizationId)) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: "Insufficient permissions",
+						request,
+						targetId: body.clientId,
+					});
 					set.status = 403;
 					return { error: "Insufficient permissions" };
 				}
@@ -1257,6 +1311,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					result.key
 				);
 				invalidateMemCacheForClient(body.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: existing ? "flags.restore" : "flags.create",
+					request,
+					targetId: result.id,
+					targetName: result.key,
+				});
 
 				return {
 					flag: {
@@ -1318,11 +1380,27 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.update",
+						reason: auth.error,
+						request,
+						targetId: params.id,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.update",
+						reason: "Forbidden",
+						request,
+						targetId: params.id,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
@@ -1397,6 +1475,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					updated.key
 				);
 				invalidateMemCacheForClient(body.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: "flags.update",
+					request,
+					targetId: updated.id,
+					targetName: updated.key,
+				});
 
 				return {
 					flag: {
@@ -1450,11 +1536,27 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, query.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.delete",
+						reason: auth.error,
+						request,
+						targetId: params.id,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.delete",
+						reason: "Forbidden",
+						request,
+						targetId: params.id,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
@@ -1511,6 +1613,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.key
 				);
 				invalidateMemCacheForClient(query.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: "flags.delete",
+					request,
+					targetId: flag.id,
+					targetName: flag.key,
+				});
 
 				return { success: true };
 			} catch (error) {

--- a/apps/api/src/routes/public/flags.ts
+++ b/apps/api/src/routes/public/flags.ts
@@ -1134,6 +1134,15 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			});
 
 			let auditApiKey: ApiKeyRow | undefined;
+			const auditFailure = (reason: string) =>
+				recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.create",
+					reason,
+					request,
+					targetId: body.clientId,
+				});
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				auditApiKey = auth.apiKey;
@@ -1194,14 +1203,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 				const existing = existingRows.at(0) ?? null;
 
 				if (existing && !existing.deletedAt) {
-					await recordPublicFlagAudit({
-						action: "failure",
-						apiKey: auditApiKey,
-						operation: "flags.create",
-						reason: "A flag with this key already exists",
-						request,
-						targetId: body.clientId,
-					});
+					await auditFailure("A flag with this key already exists");
 					set.status = 409;
 					return { error: "A flag with this key already exists" };
 				}
@@ -1224,14 +1226,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 							)
 						);
 					if (dependencyRows.length !== dependencies.length) {
-						await recordPublicFlagAudit({
-							action: "failure",
-							apiKey: auditApiKey,
-							operation: "flags.create",
-							reason: "One or more dependency flags were not found",
-							request,
-							targetId: body.clientId,
-						});
+						await auditFailure("One or more dependency flags were not found");
 						set.status = 400;
 						return { error: "One or more dependency flags were not found" };
 					}
@@ -1352,14 +1347,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					},
 				};
 			} catch (error) {
-				await recordPublicFlagAudit({
-					action: "failure",
-					apiKey: auditApiKey,
-					operation: "flags.create",
-					reason: "Failed to create flag",
-					request,
-					targetId: body.clientId,
-				});
+				await auditFailure("Failed to create flag");
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),
@@ -1404,6 +1392,15 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			});
 
 			let auditApiKey: ApiKeyRow | undefined;
+			const auditFailure = (reason: string) =>
+				recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.update",
+					reason,
+					request,
+					targetId: params.id,
+				});
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				auditApiKey = auth.apiKey;
@@ -1441,14 +1438,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				const flag = existing.at(0);
 				if (!flag) {
-					await recordPublicFlagAudit({
-						action: "failure",
-						apiKey: auditApiKey,
-						operation: "flags.update",
-						reason: "Flag not found",
-						request,
-						targetId: params.id,
-					});
+					await auditFailure("Flag not found");
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1456,14 +1446,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.websiteId !== body.clientId &&
 					flag.organizationId !== body.clientId
 				) {
-					await recordPublicFlagAudit({
-						action: "failure",
-						apiKey: auditApiKey,
-						operation: "flags.update",
-						reason: "Flag not found",
-						request,
-						targetId: params.id,
-					});
+					await auditFailure("Flag not found");
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1542,14 +1525,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					},
 				};
 			} catch (error) {
-				await recordPublicFlagAudit({
-					action: "failure",
-					apiKey: auditApiKey,
-					operation: "flags.update",
-					reason: "Failed to update flag",
-					request,
-					targetId: params.id,
-				});
+				await auditFailure("Failed to update flag");
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),
@@ -1586,6 +1562,15 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			});
 
 			let auditApiKey: ApiKeyRow | undefined;
+			const auditFailure = (reason: string) =>
+				recordPublicFlagAudit({
+					action: "failure",
+					apiKey: auditApiKey,
+					operation: "flags.delete",
+					reason,
+					request,
+					targetId: params.id,
+				});
 			try {
 				const auth = await resolveFlagAdmin(request.headers, query.clientId);
 				auditApiKey = auth.apiKey;
@@ -1623,14 +1608,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				const flag = existing.at(0);
 				if (!flag) {
-					await recordPublicFlagAudit({
-						action: "failure",
-						apiKey: auditApiKey,
-						operation: "flags.delete",
-						reason: "Flag not found",
-						request,
-						targetId: params.id,
-					});
+					await auditFailure("Flag not found");
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1638,14 +1616,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.websiteId !== query.clientId &&
 					flag.organizationId !== query.clientId
 				) {
-					await recordPublicFlagAudit({
-						action: "failure",
-						apiKey: auditApiKey,
-						operation: "flags.delete",
-						reason: "Flag not found",
-						request,
-						targetId: params.id,
-					});
+					await auditFailure("Flag not found");
 					set.status = 404;
 					return { error: "Flag not found" };
 				}
@@ -1694,14 +1665,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 
 				return { success: true };
 			} catch (error) {
-				await recordPublicFlagAudit({
-					action: "failure",
-					apiKey: auditApiKey,
-					operation: "flags.delete",
-					reason: "Failed to delete flag",
-					request,
-					targetId: params.id,
-				});
+				await auditFailure("Failed to delete flag");
 				mergeWideEvent({ flag_error: true });
 				useLogger().error(
 					error instanceof Error ? error : new Error(String(error)),

--- a/apps/api/src/rpc/handlers.ts
+++ b/apps/api/src/rpc/handlers.ts
@@ -28,11 +28,17 @@ export const rpcHandler = new RPCHandler(appRouter, {
 
 export function createAuthenticatedOrpcContext(request: Request) {
 	const preResolvedAuth = getPreResolvedAuth(request.headers);
-	return createRPCContext({ headers: request.headers }, preResolvedAuth);
+	return createRPCContext(
+		{ headers: request.headers, requestId: getRequestId(request) },
+		preResolvedAuth
+	);
 }
 
 export function createAnonymousOrpcContext(request: Request) {
-	return createRPCContext({ headers: request.headers }, ANONYMOUS_AUTH);
+	return createRPCContext(
+		{ headers: request.headers, requestId: getRequestId(request) },
+		ANONYMOUS_AUTH
+	);
 }
 
 export function handleAuthenticatedOrpcRequest(

--- a/apps/dashboard/app/(main)/organizations/components/organization-provider.tsx
+++ b/apps/dashboard/app/(main)/organizations/components/organization-provider.tsx
@@ -13,6 +13,7 @@ import {
 	GlobeIcon,
 	PlugIcon,
 	UsersIcon,
+	ShieldCheckIcon,
 } from "@databuddy/ui/icons";
 import { Button, EmptyState, Skeleton } from "@databuddy/ui";
 
@@ -63,6 +64,12 @@ const PAGE_INFO_MAP: Record<string, PageInfo> = {
 		title: "Integrations",
 		description: "Connect external tools to this organization",
 		icon: PlugIcon,
+		requiresOrg: true,
+	},
+	"/organizations/settings/audit": {
+		title: "Audit Log",
+		description: "Review privileged activity in this organization",
+		icon: ShieldCheckIcon,
 		requiresOrg: true,
 	},
 	"/organizations/settings/websites": {

--- a/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
+++ b/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Badge, Button, Card, EmptyState, Skeleton, Text } from "@databuddy/ui";
+import { ShieldCheckIcon } from "@databuddy/ui/icons";
+import { useOrganizations } from "@/hooks/use-organizations";
+import { orpc } from "@/lib/orpc";
+
+const outcomeVariant = {
+	denied: "warning",
+	failure: "destructive",
+	success: "success",
+} as const;
+
+function formatAction(action: string): string {
+	return action
+		.split(".")
+		.map((part) => part.replaceAll("_", " "))
+		.join(" / ");
+}
+
+function AuditSkeleton() {
+	return (
+		<div className="mx-auto max-w-4xl space-y-6 p-5">
+			<Card>
+				<Card.Header>
+					<Skeleton className="h-4 w-32" />
+					<Skeleton className="h-3 w-64" />
+				</Card.Header>
+				<Card.Content className="space-y-3">
+					{["a", "b", "c", "d"].map((key) => (
+						<div className="flex items-center gap-3" key={key}>
+							<Skeleton className="size-2 rounded-full" />
+							<Skeleton className="h-4 flex-1" />
+							<Skeleton className="h-4 w-32" />
+						</div>
+					))}
+				</Card.Content>
+			</Card>
+		</div>
+	);
+}
+
+export default function AuditLogPage() {
+	const { activeOrganization } = useOrganizations();
+	const [cursor, setCursor] = useState<string>();
+	const query = useQuery({
+		...orpc.audit.list.queryOptions({
+			input: {
+				limit: 50,
+				organizationId: activeOrganization?.id,
+				...(cursor ? { cursor } : {}),
+			},
+		}),
+		enabled: Boolean(activeOrganization?.id),
+	});
+
+	if (!activeOrganization || query.isLoading) {
+		return <AuditSkeleton />;
+	}
+
+	if (query.isError) {
+		return (
+			<div className="mx-auto max-w-4xl p-5">
+				<EmptyState
+					description="Audit history is only available to organization administrators and owners."
+					icon={<ShieldCheckIcon size={18} weight="duotone" />}
+					title="Audit log unavailable"
+					variant="minimal"
+				/>
+			</div>
+		);
+	}
+
+	const events = query.data?.events ?? [];
+
+	return (
+		<div className="mx-auto max-w-4xl space-y-6 p-5">
+			<Card>
+				<Card.Header className="flex-row items-start justify-between gap-4">
+					<div>
+						<Card.Title>Audit log</Card.Title>
+						<Card.Description>
+							Privileged activity recorded for {activeOrganization.name}.
+						</Card.Description>
+					</div>
+					<ShieldCheckIcon className="size-5 text-muted-foreground" />
+				</Card.Header>
+				<Card.Content className="p-0">
+					{events.length === 0 ? (
+						<EmptyState
+							description="New organization, access, flag, and workspace changes will appear here."
+							icon={<ShieldCheckIcon size={18} weight="duotone" />}
+							title="No audit events yet"
+							variant="minimal"
+						/>
+					) : (
+						<div className="divide-y">
+							{events.map((event) => (
+								<div
+									className="flex flex-col gap-2 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+									key={event.id}
+								>
+									<div className="min-w-0">
+										<div className="flex flex-wrap items-center gap-2">
+											<Text className="font-medium capitalize" variant="label">
+												{formatAction(event.action)}
+											</Text>
+											<Badge size="sm" variant={outcomeVariant[event.outcome]}>
+												{event.outcome}
+											</Badge>
+										</div>
+										<Text
+											className="mt-1 truncate"
+											tone="muted"
+											variant="caption"
+										>
+											{event.actorDisplayName ?? event.actorId} · {event.source}
+										</Text>
+									</div>
+									<Text
+										className="shrink-0 tabular-nums"
+										tone="muted"
+										variant="caption"
+									>
+										{new Date(event.createdAt).toLocaleString()}
+									</Text>
+								</div>
+							))}
+						</div>
+					)}
+				</Card.Content>
+				{query.data?.hasMore && query.data.nextCursor && (
+					<Card.Footer className="justify-end">
+						<Button
+							onClick={() => setCursor(query.data?.nextCursor ?? undefined)}
+							size="sm"
+							variant="outline"
+						>
+							Load older events
+						</Button>
+					</Card.Footer>
+				)}
+			</Card>
+		</div>
+	);
+}

--- a/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
+++ b/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
@@ -1,8 +1,15 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import { useState } from "react";
-import { Badge, Button, Card, EmptyState, Skeleton, Text } from "@databuddy/ui";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import {
+	Badge,
+	Button,
+	Card,
+	EmptyState,
+	formatDateTime,
+	Skeleton,
+	Text,
+} from "@databuddy/ui";
 import { ShieldCheckIcon } from "@databuddy/ui/icons";
 import { useOrganizations } from "@/hooks/use-organizations";
 import { orpc } from "@/lib/orpc";
@@ -18,6 +25,17 @@ function formatAction(action: string): string {
 		.split(".")
 		.map((part) => part.replaceAll("_", " "))
 		.join(" / ");
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (!(error && typeof error === "object")) {
+		return;
+	}
+	const details = error as {
+		code?: string;
+		data?: { code?: string };
+	};
+	return details.data?.code ?? details.code;
 }
 
 function AuditSkeleton() {
@@ -44,36 +62,50 @@ function AuditSkeleton() {
 
 export default function AuditLogPage() {
 	const { activeOrganization } = useOrganizations();
-	const [cursor, setCursor] = useState<string>();
-	const query = useQuery({
-		...orpc.audit.list.queryOptions({
-			input: {
+	const query = useInfiniteQuery({
+		queryKey: [...orpc.audit.list.key(), activeOrganization?.id] as const,
+		queryFn: ({ pageParam }) =>
+			orpc.audit.list.call({
 				limit: 50,
 				organizationId: activeOrganization?.id,
-				...(cursor ? { cursor } : {}),
-			},
-		}),
+				...(pageParam ? { cursor: pageParam } : {}),
+			}),
+		initialPageParam: null as string | null,
+		getNextPageParam: (lastPage) =>
+			lastPage.hasMore ? (lastPage.nextCursor ?? undefined) : undefined,
 		enabled: Boolean(activeOrganization?.id),
 	});
 
-	if (!activeOrganization || query.isLoading) {
+	const events = query.data?.pages.flatMap((page) => page.events) ?? [];
+
+	if (!activeOrganization || query.isPending) {
 		return <AuditSkeleton />;
 	}
 
-	if (query.isError) {
+	if (query.isError && events.length === 0) {
+		const isAccessError = ["FORBIDDEN", "UNAUTHORIZED"].includes(
+			getErrorCode(query.error) ?? ""
+		);
 		return (
 			<div className="mx-auto max-w-4xl p-5">
 				<EmptyState
-					description="Audit history is only available to organization administrators and owners."
+					description={
+						isAccessError
+							? "Audit history is only available to organization administrators and owners."
+							: "We could not load the audit history. Try again in a moment."
+					}
+					action={
+						isAccessError
+							? undefined
+							: { label: "Retry", onClick: () => query.refetch() }
+					}
 					icon={<ShieldCheckIcon size={18} weight="duotone" />}
 					title="Audit log unavailable"
-					variant="minimal"
+					variant="error"
 				/>
 			</div>
 		);
 	}
-
-	const events = query.data?.events ?? [];
 
 	return (
 		<div className="mx-auto max-w-4xl space-y-6 p-5">
@@ -124,24 +156,38 @@ export default function AuditLogPage() {
 										tone="muted"
 										variant="caption"
 									>
-										{new Date(event.createdAt).toLocaleString()}
+										{formatDateTime(event.createdAt)}
 									</Text>
 								</div>
 							))}
 						</div>
 					)}
 				</Card.Content>
-				{query.data?.hasMore && query.data.nextCursor && (
+				{query.isFetchNextPageError ? (
+					<Card.Footer className="items-center justify-end gap-3">
+						<Text tone="muted" variant="caption">
+							Could not load older events.
+						</Text>
+						<Button
+							onClick={() => query.fetchNextPage()}
+							size="sm"
+							variant="outline"
+						>
+							Retry
+						</Button>
+					</Card.Footer>
+				) : query.hasNextPage ? (
 					<Card.Footer className="justify-end">
 						<Button
-							onClick={() => setCursor(query.data?.nextCursor ?? undefined)}
+							loading={query.isFetchingNextPage}
+							onClick={() => query.fetchNextPage()}
 							size="sm"
 							variant="outline"
 						>
 							Load older events
 						</Button>
 					</Card.Footer>
-				)}
+				) : null}
 			</Card>
 		</div>
 	);

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -7,26 +7,31 @@ import { orpc } from "@/lib/orpc";
 import { cn } from "@/lib/utils";
 import { FlagVariants } from "./flag-variants";
 import { RolloutProgress } from "./rollout-progress";
-import type { Flag, TargetGroup } from "./types";
+import type { Flag, FlagStats, TargetGroup } from "./types";
 import {
 	ArchiveIcon,
+	ClockIcon,
 	DotsThreeIcon,
 	FlagIcon,
 	FlaskIcon,
 	GaugeIcon,
+	InfoIcon,
 	LinkIcon,
 	PencilSimpleIcon,
 	ShareNetworkIcon,
 	TrashIcon,
+	UsersIcon,
 } from "@databuddy/ui/icons";
 import { DropdownMenu, Switch } from "@databuddy/ui/client";
-import { Badge, Button, Skeleton, Tooltip } from "@databuddy/ui";
+import { Badge, Button, Skeleton, Tooltip, fromNow } from "@databuddy/ui";
 
 interface FlagsListProps {
 	flags: Flag[];
 	groups: Map<string, TargetGroup[]>;
 	onDelete: (flagId: string) => void;
 	onEdit: (flag: Flag) => void;
+	stats: Map<string, FlagStats>;
+	statsLoading: boolean;
 }
 
 const TYPE_CONFIG = {
@@ -261,11 +266,103 @@ function DependencyBadges({
 	);
 }
 
+function FlagActivity({
+	loading,
+	stats,
+}: {
+	loading: boolean;
+	stats?: FlagStats;
+}) {
+	if (loading) {
+		return <Skeleton className="h-8 w-32" />;
+	}
+
+	if (!stats?.lastEvaluatedAt) {
+		return (
+			<span className="text-center text-[11px] text-muted-foreground/70">
+				No activity in 30d
+			</span>
+		);
+	}
+
+	return (
+		<Tooltip
+			content={
+				<div className="max-w-64 space-y-1.5 text-xs">
+					<p className="font-medium">Observed activity</p>
+					<p className="text-muted-foreground">
+						Directional browser telemetry from the last 30 days—not an exact
+						count of people who used the feature. It may undercount when
+						tracking is blocked, sampled, opted out, or evaluated on the server.
+					</p>
+					<p>
+						{stats.identifiedUsers.toLocaleString()} identified visitors ·{" "}
+						{stats.evaluationCount.toLocaleString()} evaluations
+					</p>
+				</div>
+			}
+			delay={200}
+		>
+			<div className="flex min-w-[132px] flex-col gap-0.5 text-xs">
+				<span className="flex items-center gap-1.5 whitespace-nowrap text-foreground">
+					<ClockIcon className="size-3.5 shrink-0" weight="duotone" />
+					<span>Last seen {fromNow(stats.lastEvaluatedAt)}</span>
+				</span>
+				<span className="flex items-center gap-1.5 whitespace-nowrap text-[11px] text-muted-foreground">
+					<UsersIcon className="size-3.5 shrink-0" weight="duotone" />
+					<span>{stats.evaluatedUsers.toLocaleString()} observed · 30d</span>
+				</span>
+			</div>
+		</Tooltip>
+	);
+}
+
+function FlagsListHead() {
+	return (
+		<List.Head className="min-w-[980px] items-center">
+			<div className="flex min-w-0 flex-1 items-center gap-4">
+				<span className="flex max-w-[min(320px,100%)] shrink-0">Flag</span>
+				<span className="min-w-0 flex-1">Description</span>
+				<span className="flex w-[100px] shrink-0 justify-center">Type</span>
+				<span className="flex w-20 shrink-0 justify-center">Rollout</span>
+				<span className="flex w-[100px] shrink-0 justify-center">Rules</span>
+				<span className="flex w-[100px] shrink-0 justify-center">Groups</span>
+			</div>
+			<Tooltip
+				content={
+					<div className="max-w-64 space-y-1.5 text-xs">
+						<p className="font-medium">Observed activity</p>
+						<p className="text-muted-foreground">
+							Directional browser telemetry, not an exact count of people who
+							used the feature. It can undercount when tracking is blocked,
+							sampled, opted out, or evaluated on the server.
+						</p>
+					</div>
+				}
+				delay={200}
+			>
+				<span className="flex w-[150px] shrink-0 items-center justify-center gap-1.5">
+					Activity
+					<InfoIcon
+						aria-label="Learn about flag activity accuracy"
+						className="size-3.5 text-muted-foreground"
+						weight="duotone"
+					/>
+				</span>
+			</Tooltip>
+			<span className="flex w-[120px] shrink-0 justify-center">Status</span>
+			<span aria-hidden="true" className="w-8 shrink-0" />
+		</List.Head>
+	);
+}
+
 function FlagRow({
 	flag,
 	groups,
 	dependents,
 	flagMap,
+	stats,
+	statsLoading,
 	onEdit,
 	onDelete,
 }: {
@@ -273,6 +370,8 @@ function FlagRow({
 	groups: TargetGroup[];
 	dependents: Flag[];
 	flagMap: Map<string, Flag>;
+	stats?: FlagStats;
+	statsLoading: boolean;
 	onEdit: (flag: Flag) => void;
 	onDelete: (flagId: string) => void;
 }) {
@@ -359,6 +458,10 @@ function FlagRow({
 				</span>
 			</Button>
 
+			<List.Cell className="w-[150px] justify-center">
+				<FlagActivity loading={statsLoading} stats={stats} />
+			</List.Cell>
+
 			<List.Cell className="flex w-[120px] shrink-0 justify-center">
 				{flag.status === "archived" ? (
 					<Badge className="gap-1" variant="warning">
@@ -377,7 +480,14 @@ function FlagRow({
 	);
 }
 
-export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
+export function FlagsList({
+	flags,
+	groups,
+	stats,
+	statsLoading,
+	onEdit,
+	onDelete,
+}: FlagsListProps) {
 	const flagMap = useMemo(() => {
 		const map = new Map<string, Flag>();
 		for (const f of flags) {
@@ -402,6 +512,7 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 
 	return (
 		<List className="rounded bg-card">
+			<FlagsListHead />
 			{flags.map((flag) => (
 				<FlagRow
 					dependents={dependentsMap.get(flag.key) ?? []}
@@ -409,6 +520,8 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 					flagMap={flagMap}
 					groups={groups.get(flag.id) ?? []}
 					key={flag.id}
+					stats={stats.get(flag.key)}
+					statsLoading={statsLoading}
 					onDelete={onDelete}
 					onEdit={onEdit}
 				/>
@@ -420,6 +533,7 @@ export function FlagsList({ flags, groups, onEdit, onDelete }: FlagsListProps) {
 export function FlagsListSkeleton() {
 	return (
 		<List className="rounded bg-card">
+			<FlagsListHead />
 			{Array.from({ length: 5 }).map((_, i) => (
 				<div
 					className="flex min-h-15 items-center gap-4 border-border/80 border-b px-4 py-3 last:border-b-0"
@@ -446,6 +560,9 @@ export function FlagsListSkeleton() {
 					</div>
 					<div className="flex w-[100px] shrink-0 justify-center">
 						<Skeleton className="h-4 w-12" />
+					</div>
+					<div className="flex w-[150px] shrink-0 justify-center">
+						<Skeleton className="h-8 w-32" />
 					</div>
 					<div className="flex w-[120px] shrink-0 justify-center">
 						<Skeleton className="h-5 w-14" />

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/flags-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { FLAG_STATS_WINDOW_DAYS } from "@databuddy/shared/flags";
 import { useMemo } from "react";
 import { List } from "@/components/ui/composables/list";
 import { orpc } from "@/lib/orpc";
@@ -21,6 +22,7 @@ import {
 	ShareNetworkIcon,
 	TrashIcon,
 	UsersIcon,
+	WarningCircleIcon,
 } from "@databuddy/ui/icons";
 import { DropdownMenu, Switch } from "@databuddy/ui/client";
 import { Badge, Button, Skeleton, Tooltip, fromNow } from "@databuddy/ui";
@@ -30,9 +32,14 @@ interface FlagsListProps {
 	groups: Map<string, TargetGroup[]>;
 	onDelete: (flagId: string) => void;
 	onEdit: (flag: Flag) => void;
+	onRetryStats: () => Promise<unknown>;
 	stats: Map<string, FlagStats>;
+	statsError: boolean;
 	statsLoading: boolean;
 }
+
+const FLAG_LIST_MIN_WIDTH_CLASS = "min-w-[980px]";
+const FLAG_ACTIVITY_ACCURACY_COPY = `Directional browser telemetry from the last ${FLAG_STATS_WINDOW_DAYS} days—not an exact count of people who used the feature. It may undercount when tracking is blocked, sampled, opted out, or evaluated on the server.`;
 
 const TYPE_CONFIG = {
 	boolean: { icon: FlagIcon, label: "Boolean", color: "text-blue-500" },
@@ -267,9 +274,13 @@ function DependencyBadges({
 }
 
 function FlagActivity({
+	onRetry,
+	error,
 	loading,
 	stats,
 }: {
+	onRetry: () => Promise<unknown>;
+	error: boolean;
 	loading: boolean;
 	stats?: FlagStats;
 }) {
@@ -277,49 +288,75 @@ function FlagActivity({
 		return <Skeleton className="h-8 w-32" />;
 	}
 
+	if (error) {
+		return (
+			<Button
+				aria-label="Flag activity unavailable. Retry loading activity."
+				className="h-auto min-h-8 min-w-[132px] justify-start gap-1.5 px-0 font-normal text-destructive hover:bg-transparent"
+				onClick={onRetry}
+				size="sm"
+				variant="ghost"
+			>
+				<WarningCircleIcon className="size-3.5 shrink-0" weight="duotone" />
+				<span>Activity unavailable</span>
+			</Button>
+		);
+	}
+
 	if (!stats?.lastEvaluatedAt) {
 		return (
 			<span className="text-center text-[11px] text-muted-foreground/70">
-				No activity in 30d
+				No activity in {FLAG_STATS_WINDOW_DAYS}d
 			</span>
 		);
 	}
 
 	return (
-		<Tooltip
-			content={
-				<div className="max-w-64 space-y-1.5 text-xs">
-					<p className="font-medium">Observed activity</p>
-					<p className="text-muted-foreground">
-						Directional browser telemetry from the last 30 days—not an exact
-						count of people who used the feature. It may undercount when
-						tracking is blocked, sampled, opted out, or evaluated on the server.
-					</p>
-					<p>
-						{stats.identifiedUsers.toLocaleString()} identified visitors ·{" "}
-						{stats.evaluationCount.toLocaleString()} evaluations
-					</p>
-				</div>
-			}
-			delay={200}
-		>
-			<div className="flex min-w-[132px] flex-col gap-0.5 text-xs">
+		<div className="flex min-w-[150px] items-center gap-1">
+			<div className="flex min-w-0 flex-1 flex-col gap-0.5 text-xs">
 				<span className="flex items-center gap-1.5 whitespace-nowrap text-foreground">
 					<ClockIcon className="size-3.5 shrink-0" weight="duotone" />
 					<span>Last seen {fromNow(stats.lastEvaluatedAt)}</span>
 				</span>
 				<span className="flex items-center gap-1.5 whitespace-nowrap text-[11px] text-muted-foreground">
 					<UsersIcon className="size-3.5 shrink-0" weight="duotone" />
-					<span>{stats.evaluatedUsers.toLocaleString()} observed · 30d</span>
+					<span>
+						{stats.evaluatedUsers.toLocaleString()} observed ·{" "}
+						{FLAG_STATS_WINDOW_DAYS}d
+					</span>
 				</span>
 			</div>
-		</Tooltip>
+			<Tooltip
+				content={
+					<div className="max-w-64 space-y-1.5 text-xs">
+						<p className="font-medium">Observed activity</p>
+						<p className="text-muted-foreground">
+							{FLAG_ACTIVITY_ACCURACY_COPY}
+						</p>
+						<p>
+							{stats.identifiedUsers.toLocaleString()} identified visitors ·{" "}
+							{stats.evaluationCount.toLocaleString()} evaluations
+						</p>
+					</div>
+				}
+				delay={200}
+			>
+				<Button
+					aria-label="Learn about flag activity accuracy"
+					className="size-6 shrink-0 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+					size="icon-sm"
+					variant="ghost"
+				>
+					<InfoIcon className="size-3.5" weight="duotone" />
+				</Button>
+			</Tooltip>
+		</div>
 	);
 }
 
 function FlagsListHead() {
 	return (
-		<List.Head className="min-w-[980px] items-center">
+		<List.Head className={cn(FLAG_LIST_MIN_WIDTH_CLASS, "items-center")}>
 			<div className="flex min-w-0 flex-1 items-center gap-4">
 				<span className="flex max-w-[min(320px,100%)] shrink-0">Flag</span>
 				<span className="min-w-0 flex-1">Description</span>
@@ -328,28 +365,29 @@ function FlagsListHead() {
 				<span className="flex w-[100px] shrink-0 justify-center">Rules</span>
 				<span className="flex w-[100px] shrink-0 justify-center">Groups</span>
 			</div>
-			<Tooltip
-				content={
-					<div className="max-w-64 space-y-1.5 text-xs">
-						<p className="font-medium">Observed activity</p>
-						<p className="text-muted-foreground">
-							Directional browser telemetry, not an exact count of people who
-							used the feature. It can undercount when tracking is blocked,
-							sampled, opted out, or evaluated on the server.
-						</p>
-					</div>
-				}
-				delay={200}
-			>
-				<span className="flex w-[150px] shrink-0 items-center justify-center gap-1.5">
-					Activity
-					<InfoIcon
+			<span className="flex w-[150px] shrink-0 items-center justify-center gap-1.5">
+				Activity
+				<Tooltip
+					content={
+						<div className="max-w-64 space-y-1.5 text-xs">
+							<p className="font-medium">Observed activity</p>
+							<p className="text-muted-foreground">
+								{FLAG_ACTIVITY_ACCURACY_COPY}
+							</p>
+						</div>
+					}
+					delay={200}
+				>
+					<Button
 						aria-label="Learn about flag activity accuracy"
-						className="size-3.5 text-muted-foreground"
-						weight="duotone"
-					/>
-				</span>
-			</Tooltip>
+						className="size-6 p-0 text-muted-foreground hover:bg-transparent hover:text-foreground"
+						size="icon-sm"
+						variant="ghost"
+					>
+						<InfoIcon className="size-3.5" weight="duotone" />
+					</Button>
+				</Tooltip>
+			</span>
 			<span className="flex w-[120px] shrink-0 justify-center">Status</span>
 			<span aria-hidden="true" className="w-8 shrink-0" />
 		</List.Head>
@@ -361,7 +399,9 @@ function FlagRow({
 	groups,
 	dependents,
 	flagMap,
+	onRetryStats,
 	stats,
+	statsError,
 	statsLoading,
 	onEdit,
 	onDelete,
@@ -370,7 +410,9 @@ function FlagRow({
 	groups: TargetGroup[];
 	dependents: Flag[];
 	flagMap: Map<string, Flag>;
+	onRetryStats: () => Promise<unknown>;
 	stats?: FlagStats;
+	statsError: boolean;
 	statsLoading: boolean;
 	onEdit: (flag: Flag) => void;
 	onDelete: (flagId: string) => void;
@@ -386,7 +428,8 @@ function FlagRow({
 	return (
 		<List.Row
 			className={cn(
-				"min-w-full text-left",
+				FLAG_LIST_MIN_WIDTH_CLASS,
+				"text-left",
 				flag.status === "archived" && "opacity-50"
 			)}
 		>
@@ -459,7 +502,12 @@ function FlagRow({
 			</Button>
 
 			<List.Cell className="w-[150px] justify-center">
-				<FlagActivity loading={statsLoading} stats={stats} />
+				<FlagActivity
+					error={statsError}
+					loading={statsLoading}
+					onRetry={onRetryStats}
+					stats={stats}
+				/>
 			</List.Cell>
 
 			<List.Cell className="flex w-[120px] shrink-0 justify-center">
@@ -483,7 +531,9 @@ function FlagRow({
 export function FlagsList({
 	flags,
 	groups,
+	onRetryStats,
 	stats,
+	statsError,
 	statsLoading,
 	onEdit,
 	onDelete,
@@ -520,7 +570,9 @@ export function FlagsList({
 					flagMap={flagMap}
 					groups={groups.get(flag.id) ?? []}
 					key={flag.id}
+					onRetryStats={onRetryStats}
 					stats={stats.get(flag.key)}
+					statsError={statsError}
 					statsLoading={statsLoading}
 					onDelete={onDelete}
 					onEdit={onEdit}
@@ -536,7 +588,10 @@ export function FlagsListSkeleton() {
 			<FlagsListHead />
 			{Array.from({ length: 5 }).map((_, i) => (
 				<div
-					className="flex min-h-15 items-center gap-4 border-border/80 border-b px-4 py-3 last:border-b-0"
+					className={cn(
+						FLAG_LIST_MIN_WIDTH_CLASS,
+						"flex min-h-15 items-center gap-4 border-border/80 border-b px-4 py-3 last:border-b-0"
+					)}
 					key={`skeleton-${i + 1}`}
 				>
 					<div className="flex min-w-0 max-w-[min(320px,100%)] shrink-0 items-center gap-3">

--- a/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/_components/types.ts
@@ -27,6 +27,14 @@ export interface Flag {
 	websiteId?: string | null;
 }
 
+export interface FlagStats {
+	evaluatedUsers: number;
+	evaluationCount: number;
+	identifiedUsers: number;
+	key: string;
+	lastEvaluatedAt: Date | string | null;
+}
+
 export interface UserRule {
 	batch: boolean;
 	batchValues?: string[];

--- a/apps/dashboard/app/(main)/websites/[id]/flags/layout.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/layout.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useFlag } from "@databuddy/sdk/react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useParams, usePathname } from "next/navigation";
 import { useCallback, useMemo } from "react";
@@ -35,6 +35,7 @@ export default function FlagsLayout({
 	const websiteId = id as string;
 	const pathname = usePathname();
 	const [isRefreshing, setIsRefreshing] = useAtom(isAnalyticsRefreshingAtom);
+	const queryClient = useQueryClient();
 	const [, setIsFlagSheetOpen] = useAtom(isFlagSheetOpenAtom);
 	const [, setIsGroupSheetOpen] = useAtom(isGroupSheetOpenAtom);
 
@@ -73,7 +74,14 @@ export default function FlagsLayout({
 			if (isGroupsPage) {
 				await refetchGroups();
 			} else if (!isTemplatesPage) {
-				await refetchFlags();
+				await Promise.all([
+					refetchFlags(),
+					queryClient.refetchQueries({
+						queryKey: orpc.flags.stats.key({
+							input: { websiteId, days: 30 },
+						}),
+					}),
+				]);
 			}
 		} catch {
 			// Error handled by refetch
@@ -85,6 +93,8 @@ export default function FlagsLayout({
 		refetchFlags,
 		refetchGroups,
 		setIsRefreshing,
+		queryClient,
+		websiteId,
 	]);
 
 	return (

--- a/apps/dashboard/app/(main)/websites/[id]/flags/layout.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/layout.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFlag } from "@databuddy/sdk/react";
+import { FLAG_STATS_WINDOW_DAYS } from "@databuddy/shared/flags";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useParams, usePathname } from "next/navigation";
@@ -78,7 +79,7 @@ export default function FlagsLayout({
 					refetchFlags(),
 					queryClient.refetchQueries({
 						queryKey: orpc.flags.stats.key({
-							input: { websiteId, days: 30 },
+							input: { websiteId, days: FLAG_STATS_WINDOW_DAYS },
 						}),
 					}),
 				]);

--- a/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
@@ -11,7 +11,7 @@ import { orpc } from "@/lib/orpc";
 import { isFlagSheetOpenAtom } from "@/stores/jotai/flagsAtoms";
 import { FlagSheet } from "./_components/flag-sheet";
 import { FlagsList, FlagsListSkeleton } from "./_components/flags-list";
-import type { Flag, TargetGroup } from "./_components/types";
+import type { Flag, FlagStats, TargetGroup } from "./_components/types";
 import { FlagIcon } from "@databuddy/ui/icons";
 import { EmptyState } from "@databuddy/ui";
 import { DeleteDialog } from "@databuddy/ui/client";
@@ -26,6 +26,9 @@ export default function FlagsPage() {
 
 	const { data: flags, isLoading: flagsLoading } = useQuery({
 		...orpc.flags.list.queryOptions({ input: { websiteId } }),
+	});
+	const { data: flagStats, isLoading: flagStatsLoading } = useQuery({
+		...orpc.flags.stats.queryOptions({ input: { websiteId, days: 30 } }),
 	});
 
 	const activeFlags = useMemo(
@@ -51,6 +54,14 @@ export default function FlagsPage() {
 		}
 		return map;
 	}, [activeFlags]);
+
+	const statsMap = useMemo(() => {
+		const map = new Map<string, FlagStats>();
+		for (const stat of flagStats ?? []) {
+			map.set(stat.key, stat);
+		}
+		return map;
+	}, [flagStats]);
 
 	const deleteFlagMutation = useMutation({
 		...orpc.flags.delete.mutationOptions(),
@@ -114,6 +125,8 @@ export default function FlagsPage() {
 							<FlagsList
 								flags={activeFlags as unknown as Flag[]}
 								groups={groupsMap}
+								stats={statsMap}
+								statsLoading={flagStatsLoading}
 								onDelete={handleDeleteFlagRequest}
 								onEdit={handleEditFlag}
 							/>

--- a/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/flags/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
+import { FLAG_STATS_WINDOW_DAYS } from "@databuddy/shared/flags";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useAtom } from "jotai";
 import { useParams } from "next/navigation";
@@ -27,8 +28,15 @@ export default function FlagsPage() {
 	const { data: flags, isLoading: flagsLoading } = useQuery({
 		...orpc.flags.list.queryOptions({ input: { websiteId } }),
 	});
-	const { data: flagStats, isLoading: flagStatsLoading } = useQuery({
-		...orpc.flags.stats.queryOptions({ input: { websiteId, days: 30 } }),
+	const {
+		data: flagStats,
+		isError: flagStatsError,
+		isLoading: flagStatsLoading,
+		refetch: refetchFlagStats,
+	} = useQuery({
+		...orpc.flags.stats.queryOptions({
+			input: { websiteId, days: FLAG_STATS_WINDOW_DAYS },
+		}),
 	});
 
 	const activeFlags = useMemo(
@@ -126,7 +134,9 @@ export default function FlagsPage() {
 								flags={activeFlags as unknown as Flag[]}
 								groups={groupsMap}
 								stats={statsMap}
+								statsError={flagStatsError}
 								statsLoading={flagStatsLoading}
+								onRetryStats={refetchFlagStats}
 								onDelete={handleDeleteFlagRequest}
 								onEdit={handleEditFlag}
 							/>

--- a/apps/dashboard/app/(main)/websites/[id]/realtime/_components/realtime-map.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/realtime/_components/realtime-map.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import type { FeatureCollection, Geometry } from "geojson";
 import { type GeoPermissibleObjects, geoNaturalEarth1, geoPath } from "d3-geo";
 import { useEffect, useRef, useState } from "react";
 import { feature } from "topojson-client";
@@ -16,29 +17,167 @@ interface RealtimeMapProps {
 	countries: Country[];
 }
 
-const BAYER: number[][] = [
+interface TooltipState {
+	name: string;
+	visitors: number;
+	x: number;
+	y: number;
+}
+
+interface MapGeometry {
+	baseCanvas: HTMLCanvasElement;
+	countryPixels: Map<number, number[]>;
+	height: number;
+	hitMap: Uint16Array;
+	width: number;
+}
+
+const BAYER = [
 	[0, 8, 2, 10],
 	[12, 4, 14, 6],
 	[3, 11, 1, 9],
 	[15, 7, 13, 5],
 ];
 
-const G = 3;
+const GRID_SIZE = 3;
+const MAX_DEVICE_PIXEL_RATIO = 2;
+
+const WORLD_FEATURES = (
+	feature(
+		worldTopo,
+		worldTopo.objects.countries
+	) as unknown as FeatureCollection<Geometry>
+).features;
+
+function getCssColor(name: string, fallback: string): string {
+	return (
+		getComputedStyle(document.documentElement).getPropertyValue(name).trim() ||
+		fallback
+	);
+}
+
+function getCountryId(countryCode: string): number | undefined {
+	return COUNTRY_NAME_TO_ISO_NUMERIC[countryCode.toUpperCase()];
+}
+
+function buildMapGeometry(
+	width: number,
+	height: number,
+	background: string,
+	border: string
+): MapGeometry {
+	const projection = geoNaturalEarth1().fitExtent(
+		[
+			[-40, -10],
+			[width + 40, height + 10],
+		],
+		{ type: "Sphere" } as GeoPermissibleObjects
+	);
+	const path = geoPath(projection);
+	const baseCanvas = document.createElement("canvas");
+	baseCanvas.width = width;
+	baseCanvas.height = height;
+
+	const baseContext = baseCanvas.getContext("2d");
+	if (!baseContext) {
+		throw new Error("Unable to create the realtime map canvas");
+	}
+
+	baseContext.fillStyle = background;
+	baseContext.fillRect(0, 0, width, height);
+	for (const country of WORLD_FEATURES) {
+		baseContext.beginPath();
+		path.context(baseContext)(country);
+		baseContext.fillStyle = background;
+		baseContext.fill();
+		baseContext.strokeStyle = border;
+		baseContext.lineWidth = 0.5;
+		baseContext.stroke();
+	}
+
+	const countryPixels = new Map<number, number[]>();
+	const hitMap = new Uint16Array(width * height);
+
+	for (const country of WORLD_FEATURES) {
+		const countryId = Number(country.id);
+		if (!Number.isInteger(countryId) || countryId <= 0 || countryId > 65_535) {
+			continue;
+		}
+
+		const bounds = path.bounds(country);
+		const minX = Math.max(0, Math.floor(bounds[0][0] - 1));
+		const minY = Math.max(0, Math.floor(bounds[0][1] - 1));
+		const maxX = Math.min(width - 1, Math.ceil(bounds[1][0] + 1));
+		const maxY = Math.min(height - 1, Math.ceil(bounds[1][1] + 1));
+		const localWidth = maxX - minX + 1;
+		const localHeight = maxY - minY + 1;
+
+		if (localWidth <= 0 || localHeight <= 0) {
+			continue;
+		}
+
+		const countryCanvas = document.createElement("canvas");
+		countryCanvas.width = localWidth;
+		countryCanvas.height = localHeight;
+		const countryContext = countryCanvas.getContext("2d");
+		if (!countryContext) {
+			continue;
+		}
+
+		countryContext.translate(-minX, -minY);
+		countryContext.beginPath();
+		path.context(countryContext)(country);
+		countryContext.fillStyle = "white";
+		countryContext.fill();
+
+		const pixels = countryContext.getImageData(
+			0,
+			0,
+			localWidth,
+			localHeight
+		).data;
+		const activePixels: number[] = [];
+
+		for (let y = minY; y <= maxY; y += GRID_SIZE) {
+			for (let x = minX; x <= maxX; x += GRID_SIZE) {
+				const localX = x - minX;
+				const localY = y - minY;
+				const alpha = pixels[(localY * localWidth + localX) * 4 + 3] ?? 0;
+				if (alpha > 100) {
+					activePixels.push(x, y);
+				}
+			}
+		}
+
+		if (activePixels.length > 0) {
+			countryPixels.set(countryId, activePixels);
+		}
+
+		for (let y = minY; y <= maxY; y++) {
+			for (let x = minX; x <= maxX; x++) {
+				const localX = x - minX;
+				const localY = y - minY;
+				const alpha = pixels[(localY * localWidth + localX) * 4 + 3] ?? 0;
+				if (alpha > 100) {
+					hitMap[y * width + x] = countryId;
+				}
+			}
+		}
+	}
+
+	return { baseCanvas, countryPixels, hitMap, height, width };
+}
 
 export function RealtimeMap({ countries }: RealtimeMapProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const wrapperRef = useRef<HTMLDivElement>(null);
 	const rafRef = useRef<number | null>(null);
 	const countriesRef = useRef<Country[]>(countries);
-	const [tooltip, setTooltip] = useState<{
-		x: number;
-		y: number;
-		name: string;
-		visitors: number;
-	} | null>(null);
-	countriesRef.current = countries;
-
 	const numericToCountryRef = useRef<Map<number, Country>>(new Map());
+	const brightnessRef = useRef(
+		new Map<number, { target: number; value: number }>()
+	);
+	const mapGeometryRef = useRef<MapGeometry | null>(null);
 	const viewRef = useRef({ scale: 1, x: 0, y: 0 });
 	const dragRef = useRef<{
 		startX: number;
@@ -46,6 +185,8 @@ export function RealtimeMap({ countries }: RealtimeMapProps) {
 		ox: number;
 		oy: number;
 	} | null>(null);
+	const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+	countriesRef.current = countries;
 
 	useEffect(() => {
 		const canvas = canvasRef.current;
@@ -53,310 +194,294 @@ export function RealtimeMap({ countries }: RealtimeMapProps) {
 		if (!(canvas && wrapper)) {
 			return;
 		}
-		const ctx = canvas.getContext("2d");
-		if (!ctx) {
+
+		const context = canvas.getContext("2d");
+		if (!context) {
 			return;
 		}
 
 		let destroyed = false;
-
-		const logW = wrapper.offsetWidth || 800;
-		const logH = wrapper.offsetHeight || 700;
-		canvas.width = logW;
-		canvas.height = logH;
-		canvas.style.width = `${logW}px`;
-		canvas.style.height = `${logH}px`;
-
-		const rootStyle = getComputedStyle(document.documentElement);
-		const BG = rootStyle.getPropertyValue("--background").trim() || "#19191D";
-		const BORDER = rootStyle.getPropertyValue("--border").trim() || "#33333B";
-		const ACCENT = rootStyle.getPropertyValue("--chart-4").trim() || "#2d9cdb";
-
-		const projection = geoNaturalEarth1().fitExtent(
-			[
-				[-40, -10],
-				[logW + 40, logH + 10],
-			],
-			{ type: "Sphere" } as GeoPermissibleObjects
-		);
-
-		const features = (
-			feature(worldTopo as any, (worldTopo as any).objects.countries) as any
-		).features;
-
-		const baseCanvas = document.createElement("canvas");
-		baseCanvas.width = logW;
-		baseCanvas.height = logH;
-		const bx = baseCanvas.getContext("2d");
-		if (!bx) {
-			return;
-		}
-
-		bx.fillStyle = BG;
-		bx.fillRect(0, 0, logW, logH);
-		const basePath = geoPath(projection, bx);
-		for (const f of features) {
-			bx.beginPath();
-			basePath(f);
-			bx.fillStyle = BG;
-			bx.fill();
-			bx.strokeStyle = BORDER;
-			bx.lineWidth = 0.5;
-			bx.stroke();
-		}
-
-		const countryPixels = new Map<number, number[]>();
-		const hitMap = new Uint16Array(logW * logH);
-
-		for (const f of features) {
-			const id = +(f.id ?? -1);
-			const off = document.createElement("canvas");
-			off.width = logW;
-			off.height = logH;
-			const ox = off.getContext("2d");
-			if (!ox) {
-				continue;
-			}
-			const oPath = geoPath(projection, ox);
-			ox.beginPath();
-			oPath(f);
-			ox.fillStyle = "#fff";
-			ox.fill();
-			const data = ox.getImageData(0, 0, logW, logH).data;
-			const pixels: number[] = [];
-			for (let y = 0; y < logH; y += G) {
-				for (let x = 0; x < logW; x += G) {
-					if ((data[(y * logW + x) * 4] ?? 0) > 100) {
-						pixels.push(x, y);
-					}
-				}
-			}
-			if (pixels.length > 0) {
-				countryPixels.set(id, pixels);
-			}
-			for (let y = 0; y < logH; y++) {
-				for (let x = 0; x < logW; x++) {
-					if ((data[(y * logW + x) * 4] ?? 0) > 100) {
-						hitMap[y * logW + x] = id;
-					}
-				}
-			}
-		}
-
-		const brightness = new Map<number, { value: number; target: number }>();
-		let hoveredId: number | null = null;
+		let devicePixelRatio = 1;
 		let last = performance.now();
+		let hoveredId: number | null = null;
+		let background = "transparent";
+		let accent = "transparent";
 
-		function applyTransform() {
-			if (!canvas) {
-				return;
-			}
+		const applyTransform = () => {
 			const { scale, x, y } = viewRef.current;
 			canvas.style.transform = `scale(${scale}) translate(${x}px, ${y}px)`;
 			canvas.style.imageRendering = scale > 1.5 ? "pixelated" : "auto";
-		}
+		};
 
-		function draw(ts: number) {
-			if (!ctx || destroyed) {
+		const resize = () => {
+			const width = Math.floor(wrapper.clientWidth || wrapper.offsetWidth);
+			const height = Math.floor(wrapper.clientHeight || wrapper.offsetHeight);
+			if (width <= 0 || height <= 0) {
 				return;
 			}
-			const dt = Math.min(ts - last, 50);
-			last = ts;
 
+			devicePixelRatio = Math.min(
+				window.devicePixelRatio || 1,
+				MAX_DEVICE_PIXEL_RATIO
+			);
+			canvas.width = Math.round(width * devicePixelRatio);
+			canvas.height = Math.round(height * devicePixelRatio);
+			canvas.style.width = `${width}px`;
+			canvas.style.height = `${height}px`;
+			context.setTransform(devicePixelRatio, 0, 0, devicePixelRatio, 0, 0);
+			background = getCssColor("--background", background);
+			accent = getCssColor("--chart-4", accent);
+
+			mapGeometryRef.current = buildMapGeometry(
+				width,
+				height,
+				background,
+				getCssColor("--border", "transparent")
+			);
+			brightnessRef.current.clear();
+			numericToCountryRef.current.clear();
+			hoveredId = null;
+			setTooltip(null);
+			viewRef.current = { scale: 1, x: 0, y: 0 };
+			applyTransform();
+		};
+
+		const draw = (timestamp: number) => {
+			if (destroyed) {
+				return;
+			}
+
+			const geometry = mapGeometryRef.current;
+			if (!geometry) {
+				rafRef.current = requestAnimationFrame(draw);
+				return;
+			}
+
+			const delta = Math.min(timestamp - last, 50);
+			last = timestamp;
 			const activeCountries = countriesRef.current;
-			const maxVisitors = Math.max(
-				...activeCountries.map((c) => c.visitors),
+			const maxVisitors = activeCountries.reduce(
+				(max, country) => Math.max(max, country.visitors),
 				1
 			);
 
 			numericToCountryRef.current.clear();
-			for (const c of activeCountries) {
-				const numId = COUNTRY_NAME_TO_ISO_NUMERIC[c.country_code];
-				if (numId !== undefined) {
-					numericToCountryRef.current.set(numId, c);
-					const existing = brightness.get(numId);
-					const target = Math.min(0.3 + (c.visitors / maxVisitors) * 0.7, 1);
-					if (existing) {
-						existing.target = target;
-					} else {
-						brightness.set(numId, { value: 0, target });
-					}
-				}
-			}
-
-			for (const [id, b] of brightness) {
-				const isActive = numericToCountryRef.current.has(id);
-				if (!isActive) {
-					b.target = 0;
-				}
-				if (b.value < b.target) {
-					b.value = Math.min(b.target, b.value + dt / 400);
-				} else {
-					b.value = Math.max(0, b.value - dt / 2000);
-				}
-			}
-
-			ctx.fillStyle = BG;
-			ctx.fillRect(0, 0, logW, logH);
-			ctx.drawImage(baseCanvas, 0, 0);
-
-			for (const [id, b] of brightness) {
-				if (b.value <= 0) {
+			for (const country of activeCountries) {
+				const countryId = getCountryId(country.country_code);
+				if (countryId === undefined) {
 					continue;
 				}
-				const pixels = countryPixels.get(id);
+
+				numericToCountryRef.current.set(countryId, country);
+				const target = Math.min(
+					0.3 + (Math.max(0, country.visitors) / maxVisitors) * 0.7,
+					1
+				);
+				const brightness = brightnessRef.current.get(countryId);
+				if (brightness) {
+					brightness.target = target;
+				} else {
+					brightnessRef.current.set(countryId, { target, value: 0 });
+				}
+			}
+
+			for (const [countryId, brightness] of brightnessRef.current) {
+				if (!numericToCountryRef.current.has(countryId)) {
+					brightness.target = 0;
+				}
+				if (brightness.value < brightness.target) {
+					brightness.value = Math.min(
+						brightness.target,
+						brightness.value + delta / 400
+					);
+				} else {
+					brightness.value = Math.max(0, brightness.value - delta / 2000);
+				}
+			}
+
+			context.fillStyle = background;
+			context.fillRect(0, 0, geometry.width, geometry.height);
+			context.drawImage(geometry.baseCanvas, 0, 0);
+
+			for (const [countryId, brightness] of brightnessRef.current) {
+				if (brightness.value <= 0) {
+					continue;
+				}
+				const pixels = geometry.countryPixels.get(countryId);
 				if (!pixels) {
 					continue;
 				}
 
-				ctx.fillStyle = id === hoveredId ? "#fff" : ACCENT;
-				for (let i = 0; i < pixels.length; i += 2) {
-					const x = pixels[i];
-					const y = pixels[i + 1];
-					const bayer =
-						(BAYER[Math.floor(y / G) % 4]?.[Math.floor(x / G) % 4] ?? 0) / 16;
-					if (b.value > bayer) {
-						ctx.fillRect(x, y, 2, 2);
+				context.fillStyle = countryId === hoveredId ? "white" : accent;
+				for (let index = 0; index < pixels.length; index += 2) {
+					const x = pixels[index] ?? 0;
+					const y = pixels[index + 1] ?? 0;
+					const threshold =
+						(BAYER[Math.floor(y / GRID_SIZE) % 4]?.[
+							Math.floor(x / GRID_SIZE) % 4
+						] ?? 0) / 16;
+					if (brightness.value > threshold) {
+						context.fillRect(x, y, 2, 2);
 					}
 				}
 			}
 
 			if (hoveredId !== null && !numericToCountryRef.current.has(hoveredId)) {
-				const pixels = countryPixels.get(hoveredId);
+				const pixels = geometry.countryPixels.get(hoveredId);
 				if (pixels) {
-					ctx.fillStyle = "rgba(255, 255, 255, 0.15)";
-					for (let i = 0; i < pixels.length; i += 2) {
-						ctx.fillRect(pixels[i], pixels[i + 1], 2, 2);
+					context.fillStyle = "white";
+					context.globalAlpha = 0.15;
+					for (let index = 0; index < pixels.length; index += 2) {
+						context.fillRect(pixels[index] ?? 0, pixels[index + 1] ?? 0, 2, 2);
 					}
+					context.globalAlpha = 1;
 				}
+				hoveredId = null;
+				setTooltip(null);
 			}
 
 			rafRef.current = requestAnimationFrame(draw);
-		}
-
-		const handleWheel = (e: WheelEvent) => {
-			e.preventDefault();
-			const view = viewRef.current;
-			const oldScale = view.scale;
-			const zoom = e.deltaY > 0 ? 0.9 : 1.1;
-			view.scale = Math.min(5, Math.max(1, oldScale * zoom));
-
-			if (view.scale === 1) {
-				view.x = 0;
-				view.y = 0;
-			}
-
-			applyTransform();
 		};
 
-		const handleMouseDown = (e: MouseEvent) => {
-			if (viewRef.current.scale <= 1) {
-				return;
-			}
-			dragRef.current = {
-				startX: e.clientX,
-				startY: e.clientY,
-				ox: viewRef.current.x,
-				oy: viewRef.current.y,
-			};
-			wrapper.style.cursor = "grabbing";
-		};
-
-		const handleMouseMove = (e: MouseEvent) => {
-			if (dragRef.current) {
-				const scale = viewRef.current.scale;
-				viewRef.current.x =
-					dragRef.current.ox + (e.clientX - dragRef.current.startX) / scale;
-				viewRef.current.y =
-					dragRef.current.oy + (e.clientY - dragRef.current.startY) / scale;
-				applyTransform();
+		const setHoveredCountry = (event: PointerEvent) => {
+			const geometry = mapGeometryRef.current;
+			if (!geometry) {
 				return;
 			}
 
 			const rect = canvas.getBoundingClientRect();
-			const scaleX = logW / rect.width;
-			const scaleY = logH / rect.height;
-			const x = Math.floor((e.clientX - rect.left) * scaleX);
-			const y = Math.floor((e.clientY - rect.top) * scaleY);
+			const scaleX = geometry.width / rect.width;
+			const scaleY = geometry.height / rect.height;
+			const x = Math.floor((event.clientX - rect.left) * scaleX);
+			const y = Math.floor((event.clientY - rect.top) * scaleY);
 
-			if (x < 0 || x >= logW || y < 0 || y >= logH) {
+			if (x < 0 || x >= geometry.width || y < 0 || y >= geometry.height) {
 				hoveredId = null;
 				setTooltip(null);
 				return;
 			}
 
-			const id = hitMap[y * logW + x];
-			if (id && id !== hoveredId) {
-				hoveredId = id;
-				const country = numericToCountryRef.current.get(id);
-				if (country) {
-					setTooltip({
-						x: e.clientX - wrapper.getBoundingClientRect().left,
-						y: e.clientY - wrapper.getBoundingClientRect().top,
-						name: country.country_name || country.country_code,
-						visitors: country.visitors,
-					});
-				} else {
-					setTooltip(null);
-				}
-			} else if (!id) {
+			const countryId = geometry.hitMap[y * geometry.width + x] ?? 0;
+			if (!countryId) {
 				hoveredId = null;
 				setTooltip(null);
-			} else if (id === hoveredId) {
-				setTooltip((prev) =>
-					prev
-						? {
-								...prev,
-								x: e.clientX - wrapper.getBoundingClientRect().left,
-								y: e.clientY - wrapper.getBoundingClientRect().top,
-							}
-						: null
-				);
+				return;
 			}
+
+			hoveredId = countryId;
+			const country = numericToCountryRef.current.get(countryId);
+			if (!country) {
+				setTooltip(null);
+				return;
+			}
+
+			const wrapperRect = wrapper.getBoundingClientRect();
+			setTooltip({
+				name: country.country_name || country.country_code,
+				visitors: country.visitors,
+				x: event.clientX - wrapperRect.left,
+				y: event.clientY - wrapperRect.top,
+			});
 		};
 
-		const handleMouseUp = () => {
+		const handleWheel = (event: WheelEvent) => {
+			event.preventDefault();
+			const view = viewRef.current;
+			view.scale = Math.min(
+				5,
+				Math.max(1, view.scale * (event.deltaY > 0 ? 0.9 : 1.1))
+			);
+			if (view.scale === 1) {
+				view.x = 0;
+				view.y = 0;
+			}
+			applyTransform();
+		};
+
+		const handlePointerDown = (event: PointerEvent) => {
+			if (viewRef.current.scale <= 1) {
+				return;
+			}
+			event.preventDefault();
+			dragRef.current = {
+				startX: event.clientX,
+				startY: event.clientY,
+				ox: viewRef.current.x,
+				oy: viewRef.current.y,
+			};
+			wrapper.setPointerCapture(event.pointerId);
+			wrapper.style.cursor = "grabbing";
+		};
+
+		const handlePointerMove = (event: PointerEvent) => {
+			if (dragRef.current) {
+				const scale = viewRef.current.scale;
+				viewRef.current.x =
+					dragRef.current.ox + (event.clientX - dragRef.current.startX) / scale;
+				viewRef.current.y =
+					dragRef.current.oy + (event.clientY - dragRef.current.startY) / scale;
+				applyTransform();
+				return;
+			}
+			setHoveredCountry(event);
+		};
+
+		const handlePointerUp = (event: PointerEvent) => {
 			dragRef.current = null;
+			if (wrapper.hasPointerCapture(event.pointerId)) {
+				wrapper.releasePointerCapture(event.pointerId);
+			}
 			wrapper.style.cursor = viewRef.current.scale > 1 ? "grab" : "";
 		};
 
-		const handleMouseLeave = () => {
+		const handlePointerLeave = () => {
+			if (dragRef.current) {
+				return;
+			}
 			hoveredId = null;
-			dragRef.current = null;
 			setTooltip(null);
-			wrapper.style.cursor = "";
 		};
 
-		const handleDblClick = () => {
+		const handleDoubleClick = () => {
 			viewRef.current = { scale: 1, x: 0, y: 0 };
 			applyTransform();
 		};
 
+		const resizeObserver = new ResizeObserver(resize);
+		resizeObserver.observe(wrapper);
+		resize();
 		wrapper.addEventListener("wheel", handleWheel, { passive: false });
-		wrapper.addEventListener("mousedown", handleMouseDown);
-		wrapper.addEventListener("mousemove", handleMouseMove);
-		wrapper.addEventListener("mouseup", handleMouseUp);
-		wrapper.addEventListener("mouseleave", handleMouseLeave);
-		wrapper.addEventListener("dblclick", handleDblClick);
-
+		wrapper.addEventListener("pointerdown", handlePointerDown);
+		wrapper.addEventListener("pointermove", handlePointerMove);
+		wrapper.addEventListener("pointerup", handlePointerUp);
+		wrapper.addEventListener("pointercancel", handlePointerUp);
+		wrapper.addEventListener("pointerleave", handlePointerLeave);
+		wrapper.addEventListener("dblclick", handleDoubleClick);
 		rafRef.current = requestAnimationFrame(draw);
 
 		return () => {
 			destroyed = true;
+			resizeObserver.disconnect();
 			wrapper.removeEventListener("wheel", handleWheel);
-			wrapper.removeEventListener("mousedown", handleMouseDown);
-			wrapper.removeEventListener("mousemove", handleMouseMove);
-			wrapper.removeEventListener("mouseup", handleMouseUp);
-			wrapper.removeEventListener("mouseleave", handleMouseLeave);
-			wrapper.removeEventListener("dblclick", handleDblClick);
-			if (rafRef.current) {
+			wrapper.removeEventListener("pointerdown", handlePointerDown);
+			wrapper.removeEventListener("pointermove", handlePointerMove);
+			wrapper.removeEventListener("pointerup", handlePointerUp);
+			wrapper.removeEventListener("pointercancel", handlePointerUp);
+			wrapper.removeEventListener("pointerleave", handlePointerLeave);
+			wrapper.removeEventListener("dblclick", handleDoubleClick);
+			if (rafRef.current !== null) {
 				cancelAnimationFrame(rafRef.current);
 			}
 		};
 	}, []);
 
 	return (
-		<div className="relative h-full w-full overflow-hidden" ref={wrapperRef}>
+		<div
+			aria-label="Realtime visitor map"
+			className="relative h-full w-full touch-none overflow-hidden"
+			ref={wrapperRef}
+			role="img"
+		>
 			<canvas className="origin-center" ref={canvasRef} />
 			{tooltip && (
 				<div

--- a/apps/dashboard/app/(main)/websites/[id]/realtime/page.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/realtime/page.tsx
@@ -7,6 +7,28 @@ import { useDynamicQuery } from "@/hooks/use-dynamic-query";
 import { Skeleton } from "@databuddy/ui";
 import { GeistPixelSquare } from "geist/font/pixel";
 
+interface RealtimeCountry {
+	country_code: string;
+	country_name?: string;
+	visitors: number;
+}
+
+interface RealtimeStats {
+	active_users: number;
+}
+
+interface RealtimeVelocity {
+	events: number;
+	minute: string;
+	pageviews: number;
+}
+
+interface RealtimeData extends Record<string, unknown[] | undefined> {
+	active_stats?: RealtimeStats[];
+	realtime_countries?: RealtimeCountry[];
+	realtime_velocity?: RealtimeVelocity[];
+}
+
 const RealtimeMap = dynamic(
 	() =>
 		import("./_components/realtime-map").then((mod) => ({
@@ -35,7 +57,7 @@ export default function RealtimePage() {
 		};
 	}, []);
 
-	const { data } = useDynamicQuery(
+	const { data } = useDynamicQuery<RealtimeData>(
 		websiteId,
 		dateRange,
 		{
@@ -45,23 +67,14 @@ export default function RealtimePage() {
 		{ refetchInterval: 5000, staleTime: 0, gcTime: 10_000 }
 	);
 
-	const countries = ((data as any)?.realtime_countries || []) as Array<{
-		country_code: string;
-		country_name: string;
-		visitors: number;
-	}>;
+	const countries = data?.realtime_countries ?? [];
 
-	const stats = (data as any)?.active_stats?.[0];
-	const activeUsers: number = stats?.active_users || 0;
+	const activeUsers = data?.active_stats?.[0]?.active_users ?? 0;
 
-	const velocity = ((data as any)?.realtime_velocity || []) as Array<{
-		minute: string;
-		pageviews: number;
-		events: number;
-	}>;
+	const velocity = data?.realtime_velocity ?? [];
 	const lastMinute = velocity.length > 0 ? velocity.at(-1) : null;
-	const viewsPerMin = lastMinute?.pageviews || 0;
-	const eventsPerMin = lastMinute?.events || 0;
+	const viewsPerMin = lastMinute?.pageviews ?? 0;
+	const eventsPerMin = lastMinute?.events ?? 0;
 
 	return (
 		<div className={`${GeistPixelSquare.className} flex h-full flex-col`}>

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-attribution-tables.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-attribution-tables.tsx
@@ -70,15 +70,12 @@ export function RevenueAttributionTables({
 		[queryFilters]
 	);
 
-	const {
-		error,
-		getDataForQuery,
-		isError,
-		isLoading: queryLoading,
-		refetch,
-	} = useBatchDynamicQuery(websiteId, dateRange, queries, { enabled });
-
-	const isLoading = queryLoading;
+	const { getDataForQuery, isError, isLoading, refetch } = useBatchDynamicQuery(
+		websiteId,
+		dateRange,
+		queries,
+		{ enabled }
+	);
 
 	const productData = useMemo(
 		() =>
@@ -337,7 +334,7 @@ export function RevenueAttributionTables({
 		return (
 			<Card className="lg:col-span-2">
 				<Card.Header className="py-3">
-					<Card.Title>Revenue attribution</Card.Title>
+					<Card.Title>Revenue Attribution</Card.Title>
 					<Card.Description>
 						Breakdowns by traffic, product, location, and technology
 					</Card.Description>
@@ -350,11 +347,7 @@ export function RevenueAttributionTables({
 								await refetch();
 							},
 						}}
-						description={
-							error instanceof Error
-								? error.message
-								: "We couldn't load attribution data. Try again in a moment."
-						}
+						description="We couldn't load attribution data. Try again in a moment."
 						icon={<WarningCircleIcon />}
 						title="Couldn't load attribution"
 						variant="error"

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-attribution-tables.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-attribution-tables.tsx
@@ -10,6 +10,8 @@ import {
 	type RevenueEntry,
 } from "@/components/table/rows";
 import { useBatchDynamicQuery } from "@/hooks/use-dynamic-query";
+import { WarningCircleIcon } from "@databuddy/ui/icons";
+import { Card, EmptyState } from "@databuddy/ui";
 
 interface RevenueAttributionTablesProps {
 	currency: string;
@@ -68,12 +70,13 @@ export function RevenueAttributionTables({
 		[queryFilters]
 	);
 
-	const { isLoading: queryLoading, getDataForQuery } = useBatchDynamicQuery(
-		websiteId,
-		dateRange,
-		queries,
-		{ enabled }
-	);
+	const {
+		error,
+		getDataForQuery,
+		isError,
+		isLoading: queryLoading,
+		refetch,
+	} = useBatchDynamicQuery(websiteId, dateRange, queries, { enabled });
 
 	const isLoading = queryLoading;
 
@@ -329,6 +332,37 @@ export function RevenueAttributionTables({
 		],
 		[techData, deviceColumns, browserColumns, osColumns]
 	);
+
+	if (isError) {
+		return (
+			<Card className="lg:col-span-2">
+				<Card.Header className="py-3">
+					<Card.Title>Revenue attribution</Card.Title>
+					<Card.Description>
+						Breakdowns by traffic, product, location, and technology
+					</Card.Description>
+				</Card.Header>
+				<div className="flex min-h-[350px] items-center justify-center p-4">
+					<EmptyState
+						action={{
+							label: "Retry",
+							onClick: async () => {
+								await refetch();
+							},
+						}}
+						description={
+							error instanceof Error
+								? error.message
+								: "We couldn't load attribution data. Try again in a moment."
+						}
+						icon={<WarningCircleIcon />}
+						title="Couldn't load attribution"
+						variant="error"
+					/>
+				</div>
+			</Card>
+		);
+	}
 
 	return (
 		<div className="grid grid-cols-1 gap-3 sm:gap-4 lg:grid-cols-2">

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-chart.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-chart.tsx
@@ -120,8 +120,8 @@ export function RevenueChart({
 
 	if (isLoading) {
 		return (
-			<div className={cn("w-full overflow-x-auto", className)}>
-				<SkeletonChart className="w-full" height={height} />
+			<div className="w-full overflow-x-auto">
+				<SkeletonChart className={cn("w-full", className)} height={height} />
 			</div>
 		);
 	}

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-chart.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-chart.tsx
@@ -22,6 +22,7 @@ import {
 	toggleRevenueMetricAtom,
 } from "@/stores/jotai/chartAtoms";
 import { ChartLineIcon } from "@databuddy/ui/icons";
+import { EmptyState, dayjs } from "@databuddy/ui";
 
 const {
 	Area,
@@ -128,19 +129,12 @@ export function RevenueChart({
 	if (!hasData) {
 		return (
 			<div className={cn(chartSurfaceClassName, className)}>
-				<div className="flex items-center justify-center p-8">
-					<div className="flex flex-col items-center py-12 text-center">
-						<div className="relative flex size-12 items-center justify-center rounded bg-accent">
-							<ChartLineIcon className="size-6" />
-						</div>
-						<p className="mt-6 font-medium text-foreground text-lg">
-							No data available
-						</p>
-						<p className="mx-auto max-w-sm text-muted-foreground text-sm">
-							Revenue data will appear here once transactions are processed
-						</p>
-					</div>
-				</div>
+				<EmptyState
+					className="min-h-[300px] p-8"
+					description="Revenue trend data will appear here once transactions are processed."
+					icon={<ChartLineIcon />}
+					title="No trend data"
+				/>
 			</div>
 		);
 	}
@@ -191,7 +185,9 @@ export function RevenueChart({
 						<XAxis
 							axisLine={false}
 							dataKey="date"
+							minTickGap={24}
 							tick={chartAxisTickDefault}
+							tickFormatter={(value) => dayjs(String(value)).format("MMM D")}
 							tickLine={false}
 						/>
 						<YAxis
@@ -237,7 +233,11 @@ export function RevenueChart({
 								}
 							}}
 							verticalAlign="bottom"
-							wrapperStyle={chartRechartsLegendInteractiveWrapperStyle}
+							wrapperStyle={{
+								...chartRechartsLegendInteractiveWrapperStyle,
+								flexWrap: "wrap",
+								rowGap: 8,
+							}}
 						/>
 						{metrics.map((metric) => (
 							<Area

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
@@ -302,17 +302,17 @@ function RevenueSettingsSheet({
 
 	return (
 		<Sheet onOpenChange={onOpenChangeAction} open={open}>
-			<Sheet.Content className="sm:max-w-lg">
+			<Sheet.Content className="w-full sm:max-w-lg" side="right">
 				<Sheet.Header>
-					<div className="flex items-center gap-3">
-						<div className="flex size-10 items-center justify-center rounded border bg-secondary">
+					<div className="flex items-center gap-4">
+						<div className="flex size-11 items-center justify-center rounded border bg-secondary">
 							<CurrencyDollarIcon
 								className="size-5 text-primary"
 								weight="duotone"
 							/>
 						</div>
 						<div>
-							<Sheet.Title>Revenue Tracking</Sheet.Title>
+							<Sheet.Title className="text-lg">Revenue Tracking</Sheet.Title>
 							<Sheet.Description>
 								Connect payment providers via webhooks
 							</Sheet.Description>
@@ -320,259 +320,344 @@ function RevenueSettingsSheet({
 					</div>
 				</Sheet.Header>
 
-				<Sheet.Close />
-
-				<Sheet.Body>
-					{isLoading ? (
-						<div className="flex items-center justify-center py-12">
-							<SpinnerIcon className="size-6 animate-spin text-muted-foreground" />
-						</div>
-					) : isConfigError ? (
-						<div className="flex min-h-[280px] items-center justify-center p-4">
-							<EmptyState
-								action={{
-									label: "Retry",
-									onClick: async () => {
-										await refetchConfig();
-									},
-								}}
-								description={
-									configError instanceof Error
-										? configError.message
-										: "We couldn't load revenue settings. Try again in a moment."
-								}
-								icon={<WarningCircleIcon />}
-								title="Couldn't load settings"
-								variant="error"
-							/>
-						</div>
-					) : (
-						<div className="space-y-5">
-							<Field error={currencyInvalid}>
-								<Field.Label>Currency</Field.Label>
-								<Input
-									autoCapitalize="characters"
-									className="font-mono uppercase"
-									maxLength={3}
-									onChange={(event) =>
-										setCurrencyDraft(event.target.value.toUpperCase())
+				<Sheet.Form
+					onSubmit={(event) => {
+						event.preventDefault();
+						handleSave();
+					}}
+				>
+					<Sheet.Body className="space-y-5">
+						{isLoading ? (
+							<div className="flex items-center justify-center py-12">
+								<SpinnerIcon className="size-6 animate-spin text-muted-foreground" />
+							</div>
+						) : isConfigError ? (
+							<div className="flex min-h-[280px] items-center justify-center p-4">
+								<EmptyState
+									action={{
+										label: "Retry",
+										onClick: async () => {
+											await refetchConfig();
+										},
+									}}
+									description={
+										configError instanceof Error
+											? configError.message
+											: "We couldn't load revenue settings. Try again in a moment."
 									}
-									placeholder="USD"
-									value={currencyValue}
+									icon={<WarningCircleIcon />}
+									title="Couldn't load settings"
+									variant="error"
 								/>
-								{currencyInvalid ? (
-									<Field.Error>
-										Enter a valid three-letter ISO currency code.
-									</Field.Error>
-								) : (
-									<Field.Description>
-										Only matching transactions are shown in revenue reports.
-									</Field.Description>
-								)}
-							</Field>
+							</div>
+						) : (
+							<>
+								<Field error={currencyInvalid}>
+									<Field.Label>Currency</Field.Label>
+									<Input
+										autoCapitalize="characters"
+										className="font-mono uppercase"
+										maxLength={3}
+										onChange={(event) =>
+											setCurrencyDraft(event.target.value.toUpperCase())
+										}
+										placeholder="USD"
+										value={currencyValue}
+									/>
+									{currencyInvalid ? (
+										<Field.Error>
+											Enter a valid three-letter ISO currency code.
+										</Field.Error>
+									) : (
+										<Field.Description>
+											Only matching transactions are shown in revenue reports.
+										</Field.Description>
+									)}
+								</Field>
 
-							<div className="space-y-1">
-								<CollapsibleSection
-									badge={
-										webhookHash ? (
-											<CheckCircleIcon
-												className="size-4 text-success"
-												weight="duotone"
-											/>
-										) : undefined
-									}
-									icon={LinkIcon}
-									isExpanded={expandedSection === "webhooks"}
-									onToggleAction={() => toggleSection("webhooks")}
-									title="Webhook URLs"
-								>
-									{webhookHash ? (
+								<div className="space-y-1">
+									<CollapsibleSection
+										badge={
+											webhookHash ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={LinkIcon}
+										isExpanded={expandedSection === "webhooks"}
+										onToggleAction={() => toggleSection("webhooks")}
+										title="Webhook URLs"
+									>
+										{webhookHash ? (
+											<div className="space-y-4">
+												<div className="space-y-1.5">
+													<div className="flex items-center justify-between">
+														<p className="font-medium text-foreground text-xs">
+															Stripe
+														</p>
+														<a
+															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+															href="https://dashboard.stripe.com/webhooks/create"
+															rel="noopener noreferrer"
+															target="_blank"
+														>
+															Open dashboard
+															<ArrowSquareOutIcon className="size-3" />
+														</a>
+													</div>
+													<div className="flex items-center gap-2">
+														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
+															{stripeUrl}
+														</code>
+														<Button
+															aria-label="Copy Stripe webhook URL"
+															onClick={() =>
+																stripeUrl && copyStripeUrl(stripeUrl)
+															}
+															size="sm"
+															variant="ghost"
+														>
+															{copiedStripeUrl ? (
+																<CheckIcon className="size-4 text-success" />
+															) : (
+																<ClipboardIcon
+																	className="size-4"
+																	weight="duotone"
+																/>
+															)}
+														</Button>
+													</div>
+												</div>
+
+												<div className="space-y-1.5">
+													<div className="flex items-center justify-between">
+														<p className="font-medium text-foreground text-xs">
+															Paddle
+														</p>
+														<a
+															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+															href="https://vendors.paddle.com/notifications"
+															rel="noopener noreferrer"
+															target="_blank"
+														>
+															Open dashboard
+															<ArrowSquareOutIcon className="size-3" />
+														</a>
+													</div>
+													<div className="flex items-center gap-2">
+														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
+															{paddleUrl}
+														</code>
+														<Button
+															aria-label="Copy Paddle webhook URL"
+															onClick={() =>
+																paddleUrl && copyPaddleUrl(paddleUrl)
+															}
+															size="sm"
+															variant="ghost"
+														>
+															{copiedPaddleUrl ? (
+																<CheckIcon className="size-4 text-success" />
+															) : (
+																<ClipboardIcon
+																	className="size-4"
+																	weight="duotone"
+																/>
+															)}
+														</Button>
+													</div>
+												</div>
+
+												<Button
+													className="h-auto w-full justify-center px-0 pt-2 text-muted-foreground text-xs"
+													disabled={regenerateMutation.isPending}
+													onClick={() => regenerateMutation.mutate()}
+													size="sm"
+													variant="ghost"
+												>
+													{regenerateMutation.isPending ? (
+														<SpinnerIcon className="size-3 animate-spin" />
+													) : (
+														<ArrowClockwiseIcon className="size-3" />
+													)}
+													Regenerate URLs
+												</Button>
+											</div>
+										) : (
+											<div>
+												<p className="mb-3 text-muted-foreground text-xs">
+													Generate URLs to receive payment events.
+												</p>
+												<Button
+													className="w-full"
+													disabled={currencyInvalid}
+													loading={createWebhookMutation.isPending}
+													onClick={() => createWebhookMutation.mutate()}
+													size="sm"
+													variant="secondary"
+												>
+													Generate Webhook URLs
+												</Button>
+											</div>
+										)}
+									</CollapsibleSection>
+
+									<CollapsibleSection
+										badge={
+											config?.stripeConfigured ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={StripeLogoIcon}
+										isExpanded={expandedSection === "stripe"}
+										onToggleAction={() => toggleSection("stripe")}
+										title="Stripe"
+									>
 										<div className="space-y-4">
 											<div className="space-y-1.5">
-												<div className="flex items-center justify-between">
-													<p className="font-medium text-foreground text-xs">
-														Stripe
-													</p>
-													<a
-														className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
-														href="https://dashboard.stripe.com/webhooks/create"
-														rel="noopener noreferrer"
-														target="_blank"
-													>
-														Open dashboard
-														<ArrowSquareOutIcon className="size-3" />
-													</a>
-												</div>
+												<p className="font-medium text-foreground text-xs">
+													Signing secret
+												</p>
 												<div className="flex items-center gap-2">
-													<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
-														{stripeUrl}
-													</code>
+													<Input
+														className="flex-1 font-mono text-xs"
+														onChange={(e) => setStripeSecret(e.target.value)}
+														placeholder={
+															config?.stripeConfigured
+																? "••••••••"
+																: "whsec_..."
+														}
+														type={showStripeSecret ? "text" : "password"}
+														value={stripeSecret}
+													/>
 													<Button
-														aria-label="Copy Stripe webhook URL"
+														aria-label={
+															showStripeSecret
+																? "Hide Stripe signing secret"
+																: "Show Stripe signing secret"
+														}
 														onClick={() =>
-															stripeUrl && copyStripeUrl(stripeUrl)
+															setShowStripeSecret(!showStripeSecret)
 														}
 														size="sm"
 														variant="ghost"
 													>
-														{copiedStripeUrl ? (
-															<CheckIcon className="size-4 text-success" />
-														) : (
-															<ClipboardIcon
+														{showStripeSecret ? (
+															<EyeSlashIcon
 																className="size-4"
 																weight="duotone"
 															/>
+														) : (
+															<EyeIcon className="size-4" weight="duotone" />
 														)}
 													</Button>
 												</div>
 											</div>
 
+											<div className="space-y-2">
+												<p className="text-muted-foreground text-xs">
+													Required events
+												</p>
+												<div className="flex flex-wrap gap-1">
+													{STRIPE_WEBHOOK_EVENTS.required.map(({ event }) => (
+														<code
+															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
+															key={event}
+														>
+															{event}
+														</code>
+													))}
+												</div>
+											</div>
+
+											{STRIPE_WEBHOOK_EVENTS.optional.length > 0 && (
+												<div className="space-y-2">
+													<p className="text-muted-foreground text-xs">
+														Optional
+													</p>
+													<div className="flex flex-wrap gap-1">
+														{STRIPE_WEBHOOK_EVENTS.optional.map(({ event }) => (
+															<code
+																className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+																key={event}
+															>
+																{event}
+															</code>
+														))}
+													</div>
+												</div>
+											)}
+										</div>
+									</CollapsibleSection>
+
+									<CollapsibleSection
+										badge={
+											config?.paddleConfigured ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={CurrencyDollarIcon}
+										isExpanded={expandedSection === "paddle"}
+										onToggleAction={() => toggleSection("paddle")}
+										title="Paddle"
+									>
+										<div className="space-y-4">
 											<div className="space-y-1.5">
-												<div className="flex items-center justify-between">
-													<p className="font-medium text-foreground text-xs">
-														Paddle
-													</p>
-													<a
-														className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
-														href="https://vendors.paddle.com/notifications"
-														rel="noopener noreferrer"
-														target="_blank"
-													>
-														Open dashboard
-														<ArrowSquareOutIcon className="size-3" />
-													</a>
-												</div>
+												<p className="font-medium text-foreground text-xs">
+													Signing secret
+												</p>
 												<div className="flex items-center gap-2">
-													<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
-														{paddleUrl}
-													</code>
+													<Input
+														className="flex-1 font-mono text-xs"
+														onChange={(e) => setPaddleSecret(e.target.value)}
+														placeholder={
+															config?.paddleConfigured
+																? "••••••••"
+																: "pdl_ntfset_..."
+														}
+														type={showPaddleSecret ? "text" : "password"}
+														value={paddleSecret}
+													/>
 													<Button
-														aria-label="Copy Paddle webhook URL"
+														aria-label={
+															showPaddleSecret
+																? "Hide Paddle signing secret"
+																: "Show Paddle signing secret"
+														}
 														onClick={() =>
-															paddleUrl && copyPaddleUrl(paddleUrl)
+															setShowPaddleSecret(!showPaddleSecret)
 														}
 														size="sm"
 														variant="ghost"
 													>
-														{copiedPaddleUrl ? (
-															<CheckIcon className="size-4 text-success" />
-														) : (
-															<ClipboardIcon
+														{showPaddleSecret ? (
+															<EyeSlashIcon
 																className="size-4"
 																weight="duotone"
 															/>
+														) : (
+															<EyeIcon className="size-4" weight="duotone" />
 														)}
 													</Button>
 												</div>
 											</div>
 
-											<Button
-												className="h-auto w-full justify-center px-0 pt-2 text-muted-foreground text-xs"
-												disabled={regenerateMutation.isPending}
-												onClick={() => regenerateMutation.mutate()}
-												size="sm"
-												variant="ghost"
-											>
-												{regenerateMutation.isPending ? (
-													<SpinnerIcon className="size-3 animate-spin" />
-												) : (
-													<ArrowClockwiseIcon className="size-3" />
-												)}
-												Regenerate URLs
-											</Button>
-										</div>
-									) : (
-										<div>
-											<p className="mb-3 text-muted-foreground text-xs">
-												Generate URLs to receive payment events.
-											</p>
-											<Button
-												className="w-full"
-												disabled={currencyInvalid}
-												loading={createWebhookMutation.isPending}
-												onClick={() => createWebhookMutation.mutate()}
-												size="sm"
-												variant="secondary"
-											>
-												Generate Webhook URLs
-											</Button>
-										</div>
-									)}
-								</CollapsibleSection>
-
-								<CollapsibleSection
-									badge={
-										config?.stripeConfigured ? (
-											<CheckCircleIcon
-												className="size-4 text-success"
-												weight="duotone"
-											/>
-										) : undefined
-									}
-									icon={StripeLogoIcon}
-									isExpanded={expandedSection === "stripe"}
-									onToggleAction={() => toggleSection("stripe")}
-									title="Stripe"
-								>
-									<div className="space-y-4">
-										<div className="space-y-1.5">
-											<p className="font-medium text-foreground text-xs">
-												Signing secret
-											</p>
-											<div className="flex items-center gap-2">
-												<Input
-													className="flex-1 font-mono text-xs"
-													onChange={(e) => setStripeSecret(e.target.value)}
-													placeholder={
-														config?.stripeConfigured ? "••••••••" : "whsec_..."
-													}
-													type={showStripeSecret ? "text" : "password"}
-													value={stripeSecret}
-												/>
-												<Button
-													aria-label={
-														showStripeSecret
-															? "Hide Stripe signing secret"
-															: "Show Stripe signing secret"
-													}
-													onClick={() => setShowStripeSecret(!showStripeSecret)}
-													size="sm"
-													variant="ghost"
-												>
-													{showStripeSecret ? (
-														<EyeSlashIcon className="size-4" weight="duotone" />
-													) : (
-														<EyeIcon className="size-4" weight="duotone" />
-													)}
-												</Button>
-											</div>
-										</div>
-
-										<div className="space-y-2">
-											<p className="text-muted-foreground text-xs">
-												Required events
-											</p>
-											<div className="flex flex-wrap gap-1">
-												{STRIPE_WEBHOOK_EVENTS.required.map(({ event }) => (
-													<code
-														className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
-														key={event}
-													>
-														{event}
-													</code>
-												))}
-											</div>
-										</div>
-
-										{STRIPE_WEBHOOK_EVENTS.optional.length > 0 && (
 											<div className="space-y-2">
 												<p className="text-muted-foreground text-xs">
-													Optional
+													Required events
 												</p>
 												<div className="flex flex-wrap gap-1">
-													{STRIPE_WEBHOOK_EVENTS.optional.map(({ event }) => (
+													{PADDLE_EVENTS.required.map((event) => (
 														<code
-															className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
 															key={event}
 														>
 															{event}
@@ -580,119 +665,52 @@ function RevenueSettingsSheet({
 													))}
 												</div>
 											</div>
-										)}
-									</div>
-								</CollapsibleSection>
 
-								<CollapsibleSection
-									badge={
-										config?.paddleConfigured ? (
-											<CheckCircleIcon
-												className="size-4 text-success"
-												weight="duotone"
-											/>
-										) : undefined
-									}
-									icon={CurrencyDollarIcon}
-									isExpanded={expandedSection === "paddle"}
-									onToggleAction={() => toggleSection("paddle")}
-									title="Paddle"
-								>
-									<div className="space-y-4">
-										<div className="space-y-1.5">
-											<p className="font-medium text-foreground text-xs">
-												Signing secret
-											</p>
-											<div className="flex items-center gap-2">
-												<Input
-													className="flex-1 font-mono text-xs"
-													onChange={(e) => setPaddleSecret(e.target.value)}
-													placeholder={
-														config?.paddleConfigured
-															? "••••••••"
-															: "pdl_ntfset_..."
-													}
-													type={showPaddleSecret ? "text" : "password"}
-													value={paddleSecret}
-												/>
-												<Button
-													aria-label={
-														showPaddleSecret
-															? "Hide Paddle signing secret"
-															: "Show Paddle signing secret"
-													}
-													onClick={() => setShowPaddleSecret(!showPaddleSecret)}
-													size="sm"
-													variant="ghost"
-												>
-													{showPaddleSecret ? (
-														<EyeSlashIcon className="size-4" weight="duotone" />
-													) : (
-														<EyeIcon className="size-4" weight="duotone" />
-													)}
-												</Button>
-											</div>
-										</div>
-
-										<div className="space-y-2">
-											<p className="text-muted-foreground text-xs">
-												Required events
-											</p>
-											<div className="flex flex-wrap gap-1">
-												{PADDLE_EVENTS.required.map((event) => (
-													<code
-														className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
-														key={event}
-													>
-														{event}
-													</code>
-												))}
-											</div>
-										</div>
-
-										{PADDLE_EVENTS.optional.length > 0 && (
-											<div className="space-y-2">
-												<p className="text-muted-foreground text-xs">
-													Optional
-												</p>
-												<div className="flex flex-wrap gap-1">
-													{PADDLE_EVENTS.optional.map((event) => (
-														<code
-															className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
-															key={event}
-														>
-															{event}
-														</code>
-													))}
+											{PADDLE_EVENTS.optional.length > 0 && (
+												<div className="space-y-2">
+													<p className="text-muted-foreground text-xs">
+														Optional
+													</p>
+													<div className="flex flex-wrap gap-1">
+														{PADDLE_EVENTS.optional.map((event) => (
+															<code
+																className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+																key={event}
+															>
+																{event}
+															</code>
+														))}
+													</div>
 												</div>
-											</div>
-										)}
-									</div>
-								</CollapsibleSection>
-							</div>
-						</div>
-					)}
-				</Sheet.Body>
+											)}
+										</div>
+									</CollapsibleSection>
+								</div>
+							</>
+						)}
+					</Sheet.Body>
 
-				<Sheet.Footer>
-					<Button
-						onClick={() => onOpenChangeAction(false)}
-						type="button"
-						variant="secondary"
-					>
-						Cancel
-					</Button>
-					<Button
-						className="min-w-24"
-						disabled={
-							isLoading || isConfigError || currencyInvalid || !hasChanges
-						}
-						loading={upsertMutation.isPending}
-						onClick={handleSave}
-					>
-						Save
-					</Button>
-				</Sheet.Footer>
+					<Sheet.Footer>
+						<Button
+							onClick={() => onOpenChangeAction(false)}
+							type="button"
+							variant="secondary"
+						>
+							Cancel
+						</Button>
+						<Button
+							className="min-w-24"
+							disabled={
+								isLoading || isConfigError || currencyInvalid || !hasChanges
+							}
+							loading={upsertMutation.isPending}
+							type="submit"
+						>
+							Save
+						</Button>
+					</Sheet.Footer>
+				</Sheet.Form>
+				<Sheet.Close />
 			</Sheet.Content>
 		</Sheet>
 	);

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
@@ -916,31 +916,33 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 					/>
 				</div>
 			) : (
-				<EmptyState
-					action={{
-						label: hasInvalidCurrency
-							? "Fix currency"
-							: isConfigured
-								? "Check webhook settings"
-								: "Configure webhooks",
-						onClick: () => setSettingsOpen(true),
-					}}
-					description={
-						hasInvalidCurrency
-							? "Choose the currency used to filter and format revenue reports."
-							: isConfigured
-								? "Revenue will appear here once your payment provider sends webhook events."
-								: "Connect Stripe or Paddle to start tracking revenue and attribution."
-					}
-					icon={<CurrencyDollarIcon />}
-					title={
-						hasInvalidCurrency
-							? "Choose a valid currency"
-							: isConfigured
-								? "Waiting for transactions"
-								: "Set up revenue tracking"
-					}
-				/>
+				<div className="flex min-h-[320px] items-center justify-center p-4 sm:min-h-[400px]">
+					<EmptyState
+						action={{
+							label: hasInvalidCurrency
+								? "Fix currency"
+								: isConfigured
+									? "Check webhook settings"
+									: "Configure webhooks",
+							onClick: () => setSettingsOpen(true),
+						}}
+						description={
+							hasInvalidCurrency
+								? "Choose the currency used to filter and format revenue reports."
+								: isConfigured
+									? "Revenue will appear here once your payment provider sends webhook events."
+									: "Connect Stripe or Paddle to start tracking revenue and attribution."
+						}
+						icon={<CurrencyDollarIcon />}
+						title={
+							hasInvalidCurrency
+								? "Choose a valid currency"
+								: isConfigured
+									? "Waiting for transactions"
+									: "Set up revenue tracking"
+						}
+					/>
+				</div>
 			)}
 
 			<RevenueSettingsSheet

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import { publicConfig } from "@databuddy/env/public";
 import { normalizeCurrencyCode } from "@databuddy/shared/currency";
-import { STRIPE_WEBHOOK_EVENTS } from "@databuddy/shared/stripe-webhooks";
 
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { useAtom } from "jotai";
-import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useMemo, useState } from "react";
-import { toast } from "sonner";
 import { StatCard } from "@/components/analytics/stat-card";
-import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { useDateFilters } from "@/hooks/use-date-filters";
 import { useBatchDynamicQuery } from "@/hooks/use-dynamic-query";
 import { useMediaQuery } from "@/hooks/use-media-query";
@@ -27,7 +22,6 @@ import {
 	paymentFailureReasonLabel,
 	type RevenueOverview,
 } from "@/lib/revenue-overview";
-import { cn } from "@/lib/utils";
 import {
 	addDynamicFilterAtom,
 	dynamicQueryFiltersAtom,
@@ -36,28 +30,18 @@ import type { DynamicQueryRequest } from "@/types/api";
 import { TopBar } from "@/components/layout/top-bar";
 import { RevenueAttributionTables } from "./revenue-attribution-tables";
 import { RevenueChart } from "./revenue-chart";
+import { RevenueSettingsSheet } from "./revenue-settings-sheet";
 import {
 	ArrowClockwiseIcon,
-	ArrowSquareOutIcon,
-	CaretDownIcon,
-	CheckCircleIcon,
-	CheckIcon,
-	ClipboardIcon,
-	CreditCardIcon as StripeLogoIcon,
 	CreditCardIcon,
 	CurrencyDollarIcon,
-	EyeIcon,
-	EyeSlashIcon,
 	GearIcon,
-	LinkIcon,
 	ReceiptIcon,
-	SpinnerIcon,
 	TrendUpIcon,
 	UsersIcon,
 	WarningCircleIcon,
 } from "@databuddy/ui/icons";
-import { Sheet } from "@databuddy/ui/client";
-import { Button, Card, EmptyState, Field, Input, dayjs } from "@databuddy/ui";
+import { Button, Card, EmptyState, dayjs } from "@databuddy/ui";
 
 interface RevenueContentProps {
 	websiteId: string;
@@ -71,13 +55,6 @@ interface RevenueTimeSeries {
 	revenue: number;
 	transactions: number;
 }
-
-const BASKET_URL = publicConfig.urls.basket;
-
-const PADDLE_EVENTS = {
-	required: ["transaction.completed"],
-	optional: [],
-};
 
 function padTimeSeriesData<T extends { date: string }>(
 	data: T[],
@@ -109,613 +86,6 @@ function padTimeSeriesData<T extends { date: string }>(
 
 	return result;
 }
-
-type ExpandedSection = "webhooks" | "stripe" | "paddle" | null;
-
-function CollapsibleSection({
-	icon: Icon,
-	title,
-	badge,
-	isExpanded,
-	onToggleAction,
-	children,
-}: {
-	icon: React.ComponentType<{ className?: string; weight?: "duotone" }>;
-	title: string;
-	badge?: React.ReactNode;
-	isExpanded: boolean;
-	onToggleAction: () => void;
-	children: React.ReactNode;
-}) {
-	return (
-		<div className="space-y-2">
-			<div className="-mx-3">
-				<Button
-					aria-expanded={isExpanded}
-					className="group h-auto w-full justify-between rounded px-3 py-3 text-left"
-					onClick={onToggleAction}
-					size="md"
-					variant="ghost"
-				>
-					<div className="flex items-center gap-2.5">
-						<Icon className="size-4" weight="duotone" />
-						<span className="font-semibold text-sm">{title}</span>
-						{badge}
-					</div>
-					<CaretDownIcon
-						className={cn(
-							"size-4 text-muted-foreground transition-transform duration-200",
-							isExpanded && "rotate-180"
-						)}
-						weight="fill"
-					/>
-				</Button>
-			</div>
-
-			<AnimatePresence initial={false}>
-				{isExpanded && (
-					<motion.div
-						animate={{ height: "auto", opacity: 1 }}
-						className="overflow-hidden"
-						exit={{ height: 0, opacity: 0 }}
-						initial={{ height: 0, opacity: 0 }}
-						transition={{ duration: 0.2, ease: "easeInOut" }}
-					>
-						<div className="pb-4">{children}</div>
-					</motion.div>
-				)}
-			</AnimatePresence>
-		</div>
-	);
-}
-
-function RevenueSettingsSheet({
-	websiteId,
-	open,
-	onOpenChangeAction,
-}: {
-	websiteId: string;
-	open: boolean;
-	onOpenChangeAction: (open: boolean) => void;
-}) {
-	const queryClient = useQueryClient();
-	const [stripeSecret, setStripeSecret] = useState("");
-	const [paddleSecret, setPaddleSecret] = useState("");
-	const [currencyDraft, setCurrencyDraft] = useState<string | null>(null);
-	const [showStripeSecret, setShowStripeSecret] = useState(false);
-	const [showPaddleSecret, setShowPaddleSecret] = useState(false);
-	const [expandedSection, setExpandedSection] =
-		useState<ExpandedSection>("webhooks");
-	const { isCopied: copiedStripeUrl, copyToClipboard: copyStripeUrl } =
-		useCopyToClipboard({
-			onCopy: () => toast.success("Webhook URL copied"),
-		});
-	const { isCopied: copiedPaddleUrl, copyToClipboard: copyPaddleUrl } =
-		useCopyToClipboard({
-			onCopy: () => toast.success("Webhook URL copied"),
-		});
-
-	const {
-		data: config,
-		error: configError,
-		isError: isConfigError,
-		isLoading,
-		refetch: refetchConfig,
-	} = useQuery({
-		queryKey: ["revenue-config", websiteId],
-		queryFn: () => orpc.revenue.get.call({ websiteId }),
-	});
-	const savedCurrency = normalizeCurrencyCode(config?.currency);
-	const configuredCurrency =
-		typeof config?.currency === "string"
-			? config.currency.trim().toUpperCase()
-			: "USD";
-	const currencyValue = currencyDraft ?? configuredCurrency;
-	const normalizedCurrency = normalizeCurrencyCode(currencyValue);
-	const currencyInvalid = normalizedCurrency === null;
-	const hasChanges =
-		!(isLoading || isConfigError) &&
-		Boolean(
-			stripeSecret ||
-				paddleSecret ||
-				(normalizedCurrency && normalizedCurrency !== savedCurrency)
-		);
-
-	const createWebhookMutation = useMutation({
-		mutationFn: () => {
-			if (!normalizedCurrency) {
-				throw new Error("Invalid revenue currency");
-			}
-			return orpc.revenue.upsert.call({
-				websiteId,
-				currency: normalizedCurrency,
-			});
-		},
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: ["revenue-config", websiteId],
-			});
-			toast.success("Webhook URLs generated");
-		},
-		onError: () => toast.error("Failed to generate webhook URL"),
-	});
-
-	const upsertMutation = useMutation({
-		mutationFn: (data: {
-			stripeWebhookSecret?: string;
-			paddleWebhookSecret?: string;
-			currency: string;
-		}) => orpc.revenue.upsert.call({ websiteId, ...data }),
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: ["revenue-config", websiteId],
-			});
-			setStripeSecret("");
-			setPaddleSecret("");
-			setCurrencyDraft(null);
-			toast.success("Configuration saved");
-		},
-		onError: () => toast.error("Failed to save"),
-	});
-
-	const regenerateMutation = useMutation({
-		mutationFn: () => orpc.revenue.regenerateHash.call({ websiteId }),
-		onSuccess: () => {
-			queryClient.invalidateQueries({
-				queryKey: ["revenue-config", websiteId],
-			});
-			toast.success("Webhook URLs regenerated");
-		},
-		onError: () => toast.error("Failed to regenerate"),
-	});
-
-	const handleSave = () => {
-		if (!normalizedCurrency) {
-			return;
-		}
-
-		const updates: {
-			stripeWebhookSecret?: string;
-			paddleWebhookSecret?: string;
-			currency: string;
-		} = { currency: normalizedCurrency };
-		if (stripeSecret) {
-			updates.stripeWebhookSecret = stripeSecret;
-		}
-		if (paddleSecret) {
-			updates.paddleWebhookSecret = paddleSecret;
-		}
-		upsertMutation.mutate(updates);
-	};
-
-	const toggleSection = (section: ExpandedSection) => {
-		setExpandedSection((prev) => (prev === section ? null : section));
-	};
-
-	const webhookHash = config?.webhookHash;
-	const stripeUrl = webhookHash
-		? `${BASKET_URL}/webhooks/stripe/${webhookHash}`
-		: null;
-	const paddleUrl = webhookHash
-		? `${BASKET_URL}/webhooks/paddle/${webhookHash}`
-		: null;
-
-	return (
-		<Sheet onOpenChange={onOpenChangeAction} open={open}>
-			<Sheet.Content className="w-full sm:max-w-lg" side="right">
-				<Sheet.Header>
-					<div className="flex items-center gap-4">
-						<div className="flex size-11 items-center justify-center rounded border bg-secondary">
-							<CurrencyDollarIcon
-								className="size-5 text-primary"
-								weight="duotone"
-							/>
-						</div>
-						<div>
-							<Sheet.Title className="text-lg">Revenue Tracking</Sheet.Title>
-							<Sheet.Description>
-								Connect payment providers via webhooks
-							</Sheet.Description>
-						</div>
-					</div>
-				</Sheet.Header>
-
-				<Sheet.Form
-					onSubmit={(event) => {
-						event.preventDefault();
-						handleSave();
-					}}
-				>
-					<Sheet.Body className="space-y-5">
-						{isLoading ? (
-							<div className="flex items-center justify-center py-12">
-								<SpinnerIcon className="size-6 animate-spin text-muted-foreground" />
-							</div>
-						) : isConfigError ? (
-							<div className="flex min-h-[280px] items-center justify-center p-4">
-								<EmptyState
-									action={{
-										label: "Retry",
-										onClick: async () => {
-											await refetchConfig();
-										},
-									}}
-									description={
-										configError instanceof Error
-											? configError.message
-											: "We couldn't load revenue settings. Try again in a moment."
-									}
-									icon={<WarningCircleIcon />}
-									title="Couldn't load settings"
-									variant="error"
-								/>
-							</div>
-						) : (
-							<>
-								<Field error={currencyInvalid}>
-									<Field.Label>Currency</Field.Label>
-									<Input
-										autoCapitalize="characters"
-										className="font-mono uppercase"
-										maxLength={3}
-										onChange={(event) =>
-											setCurrencyDraft(event.target.value.toUpperCase())
-										}
-										placeholder="USD"
-										value={currencyValue}
-									/>
-									{currencyInvalid ? (
-										<Field.Error>
-											Enter a valid three-letter ISO currency code.
-										</Field.Error>
-									) : (
-										<Field.Description>
-											Only matching transactions are shown in revenue reports.
-										</Field.Description>
-									)}
-								</Field>
-
-								<div className="space-y-1">
-									<CollapsibleSection
-										badge={
-											webhookHash ? (
-												<CheckCircleIcon
-													className="size-4 text-success"
-													weight="duotone"
-												/>
-											) : undefined
-										}
-										icon={LinkIcon}
-										isExpanded={expandedSection === "webhooks"}
-										onToggleAction={() => toggleSection("webhooks")}
-										title="Webhook URLs"
-									>
-										{webhookHash ? (
-											<div className="space-y-4">
-												<div className="space-y-1.5">
-													<div className="flex items-center justify-between">
-														<p className="font-medium text-foreground text-xs">
-															Stripe
-														</p>
-														<a
-															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
-															href="https://dashboard.stripe.com/webhooks/create"
-															rel="noopener noreferrer"
-															target="_blank"
-														>
-															Open dashboard
-															<ArrowSquareOutIcon className="size-3" />
-														</a>
-													</div>
-													<div className="flex items-center gap-2">
-														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
-															{stripeUrl}
-														</code>
-														<Button
-															aria-label="Copy Stripe webhook URL"
-															onClick={() =>
-																stripeUrl && copyStripeUrl(stripeUrl)
-															}
-															size="sm"
-															variant="ghost"
-														>
-															{copiedStripeUrl ? (
-																<CheckIcon className="size-4 text-success" />
-															) : (
-																<ClipboardIcon
-																	className="size-4"
-																	weight="duotone"
-																/>
-															)}
-														</Button>
-													</div>
-												</div>
-
-												<div className="space-y-1.5">
-													<div className="flex items-center justify-between">
-														<p className="font-medium text-foreground text-xs">
-															Paddle
-														</p>
-														<a
-															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
-															href="https://vendors.paddle.com/notifications"
-															rel="noopener noreferrer"
-															target="_blank"
-														>
-															Open dashboard
-															<ArrowSquareOutIcon className="size-3" />
-														</a>
-													</div>
-													<div className="flex items-center gap-2">
-														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
-															{paddleUrl}
-														</code>
-														<Button
-															aria-label="Copy Paddle webhook URL"
-															onClick={() =>
-																paddleUrl && copyPaddleUrl(paddleUrl)
-															}
-															size="sm"
-															variant="ghost"
-														>
-															{copiedPaddleUrl ? (
-																<CheckIcon className="size-4 text-success" />
-															) : (
-																<ClipboardIcon
-																	className="size-4"
-																	weight="duotone"
-																/>
-															)}
-														</Button>
-													</div>
-												</div>
-
-												<Button
-													className="h-auto w-full justify-center px-0 pt-2 text-muted-foreground text-xs"
-													disabled={regenerateMutation.isPending}
-													onClick={() => regenerateMutation.mutate()}
-													size="sm"
-													variant="ghost"
-												>
-													{regenerateMutation.isPending ? (
-														<SpinnerIcon className="size-3 animate-spin" />
-													) : (
-														<ArrowClockwiseIcon className="size-3" />
-													)}
-													Regenerate URLs
-												</Button>
-											</div>
-										) : (
-											<div>
-												<p className="mb-3 text-muted-foreground text-xs">
-													Generate URLs to receive payment events.
-												</p>
-												<Button
-													className="w-full"
-													disabled={currencyInvalid}
-													loading={createWebhookMutation.isPending}
-													onClick={() => createWebhookMutation.mutate()}
-													size="sm"
-													variant="secondary"
-												>
-													Generate Webhook URLs
-												</Button>
-											</div>
-										)}
-									</CollapsibleSection>
-
-									<CollapsibleSection
-										badge={
-											config?.stripeConfigured ? (
-												<CheckCircleIcon
-													className="size-4 text-success"
-													weight="duotone"
-												/>
-											) : undefined
-										}
-										icon={StripeLogoIcon}
-										isExpanded={expandedSection === "stripe"}
-										onToggleAction={() => toggleSection("stripe")}
-										title="Stripe"
-									>
-										<div className="space-y-4">
-											<div className="space-y-1.5">
-												<p className="font-medium text-foreground text-xs">
-													Signing secret
-												</p>
-												<div className="flex items-center gap-2">
-													<Input
-														className="flex-1 font-mono text-xs"
-														onChange={(e) => setStripeSecret(e.target.value)}
-														placeholder={
-															config?.stripeConfigured
-																? "••••••••"
-																: "whsec_..."
-														}
-														type={showStripeSecret ? "text" : "password"}
-														value={stripeSecret}
-													/>
-													<Button
-														aria-label={
-															showStripeSecret
-																? "Hide Stripe signing secret"
-																: "Show Stripe signing secret"
-														}
-														onClick={() =>
-															setShowStripeSecret(!showStripeSecret)
-														}
-														size="sm"
-														variant="ghost"
-													>
-														{showStripeSecret ? (
-															<EyeSlashIcon
-																className="size-4"
-																weight="duotone"
-															/>
-														) : (
-															<EyeIcon className="size-4" weight="duotone" />
-														)}
-													</Button>
-												</div>
-											</div>
-
-											<div className="space-y-2">
-												<p className="text-muted-foreground text-xs">
-													Required events
-												</p>
-												<div className="flex flex-wrap gap-1">
-													{STRIPE_WEBHOOK_EVENTS.required.map(({ event }) => (
-														<code
-															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
-															key={event}
-														>
-															{event}
-														</code>
-													))}
-												</div>
-											</div>
-
-											{STRIPE_WEBHOOK_EVENTS.optional.length > 0 && (
-												<div className="space-y-2">
-													<p className="text-muted-foreground text-xs">
-														Optional
-													</p>
-													<div className="flex flex-wrap gap-1">
-														{STRIPE_WEBHOOK_EVENTS.optional.map(({ event }) => (
-															<code
-																className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
-																key={event}
-															>
-																{event}
-															</code>
-														))}
-													</div>
-												</div>
-											)}
-										</div>
-									</CollapsibleSection>
-
-									<CollapsibleSection
-										badge={
-											config?.paddleConfigured ? (
-												<CheckCircleIcon
-													className="size-4 text-success"
-													weight="duotone"
-												/>
-											) : undefined
-										}
-										icon={CurrencyDollarIcon}
-										isExpanded={expandedSection === "paddle"}
-										onToggleAction={() => toggleSection("paddle")}
-										title="Paddle"
-									>
-										<div className="space-y-4">
-											<div className="space-y-1.5">
-												<p className="font-medium text-foreground text-xs">
-													Signing secret
-												</p>
-												<div className="flex items-center gap-2">
-													<Input
-														className="flex-1 font-mono text-xs"
-														onChange={(e) => setPaddleSecret(e.target.value)}
-														placeholder={
-															config?.paddleConfigured
-																? "••••••••"
-																: "pdl_ntfset_..."
-														}
-														type={showPaddleSecret ? "text" : "password"}
-														value={paddleSecret}
-													/>
-													<Button
-														aria-label={
-															showPaddleSecret
-																? "Hide Paddle signing secret"
-																: "Show Paddle signing secret"
-														}
-														onClick={() =>
-															setShowPaddleSecret(!showPaddleSecret)
-														}
-														size="sm"
-														variant="ghost"
-													>
-														{showPaddleSecret ? (
-															<EyeSlashIcon
-																className="size-4"
-																weight="duotone"
-															/>
-														) : (
-															<EyeIcon className="size-4" weight="duotone" />
-														)}
-													</Button>
-												</div>
-											</div>
-
-											<div className="space-y-2">
-												<p className="text-muted-foreground text-xs">
-													Required events
-												</p>
-												<div className="flex flex-wrap gap-1">
-													{PADDLE_EVENTS.required.map((event) => (
-														<code
-															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
-															key={event}
-														>
-															{event}
-														</code>
-													))}
-												</div>
-											</div>
-
-											{PADDLE_EVENTS.optional.length > 0 && (
-												<div className="space-y-2">
-													<p className="text-muted-foreground text-xs">
-														Optional
-													</p>
-													<div className="flex flex-wrap gap-1">
-														{PADDLE_EVENTS.optional.map((event) => (
-															<code
-																className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
-																key={event}
-															>
-																{event}
-															</code>
-														))}
-													</div>
-												</div>
-											)}
-										</div>
-									</CollapsibleSection>
-								</div>
-							</>
-						)}
-					</Sheet.Body>
-
-					<Sheet.Footer>
-						<Button
-							onClick={() => onOpenChangeAction(false)}
-							type="button"
-							variant="secondary"
-						>
-							Cancel
-						</Button>
-						<Button
-							className="min-w-24"
-							disabled={
-								isLoading || isConfigError || currencyInvalid || !hasChanges
-							}
-							loading={upsertMutation.isPending}
-							type="submit"
-						>
-							Save
-						</Button>
-					</Sheet.Footer>
-				</Sheet.Form>
-				<Sheet.Close />
-			</Sheet.Content>
-		</Sheet>
-	);
-}
-
 export function RevenueContent({ websiteId }: RevenueContentProps) {
 	const [settingsOpen, setSettingsOpen] = useState(false);
 	const isMobile = useMediaQuery("(max-width: 640px)");
@@ -731,7 +101,6 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 
 	const {
 		data: config,
-		error: configError,
 		isError: isConfigError,
 		isLoading: isConfigLoading,
 		refetch: refetchConfig,
@@ -764,7 +133,6 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 	);
 
 	const {
-		error: revenueError,
 		getDataForQuery,
 		isError: isRevenueError,
 		isLoading: isRevenueLoading,
@@ -774,7 +142,6 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 	});
 	const isLoading = isConfigLoading || isRevenueLoading;
 	const hasError = isConfigError || isRevenueError;
-	const error = configError ?? revenueError;
 
 	const handleRetry = async () => {
 		const retries: Promise<unknown>[] = [];
@@ -859,11 +226,7 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 					<div className="flex min-h-full items-center justify-center p-4 py-16">
 						<EmptyState
 							action={{ label: "Retry", onClick: handleRetry }}
-							description={
-								error instanceof Error
-									? error.message
-									: "We couldn't load revenue data. Try again in a moment."
-							}
+							description="We couldn't load revenue data. Try again in a moment."
 							icon={<WarningCircleIcon />}
 							title="Couldn't load revenue"
 							variant="error"

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-content.tsx
@@ -54,6 +54,7 @@ import {
 	SpinnerIcon,
 	TrendUpIcon,
 	UsersIcon,
+	WarningCircleIcon,
 } from "@databuddy/ui/icons";
 import { Sheet } from "@databuddy/ui/client";
 import { Button, Card, EmptyState, Field, Input, dayjs } from "@databuddy/ui";
@@ -129,10 +130,12 @@ function CollapsibleSection({
 	return (
 		<div className="space-y-2">
 			<div className="-mx-3">
-				<button
-					className="group flex w-full cursor-pointer items-center justify-between rounded px-3 py-3 text-left transition-colors hover:bg-accent/50"
+				<Button
+					aria-expanded={isExpanded}
+					className="group h-auto w-full justify-between rounded px-3 py-3 text-left"
 					onClick={onToggleAction}
-					type="button"
+					size="md"
+					variant="ghost"
 				>
 					<div className="flex items-center gap-2.5">
 						<Icon className="size-4" weight="duotone" />
@@ -146,7 +149,7 @@ function CollapsibleSection({
 						)}
 						weight="fill"
 					/>
-				</button>
+				</Button>
 			</div>
 
 			<AnimatePresence initial={false}>
@@ -192,7 +195,13 @@ function RevenueSettingsSheet({
 			onCopy: () => toast.success("Webhook URL copied"),
 		});
 
-	const { data: config, isLoading } = useQuery({
+	const {
+		data: config,
+		error: configError,
+		isError: isConfigError,
+		isLoading,
+		refetch: refetchConfig,
+	} = useQuery({
 		queryKey: ["revenue-config", websiteId],
 		queryFn: () => orpc.revenue.get.call({ websiteId }),
 	});
@@ -204,11 +213,13 @@ function RevenueSettingsSheet({
 	const currencyValue = currencyDraft ?? configuredCurrency;
 	const normalizedCurrency = normalizeCurrencyCode(currencyValue);
 	const currencyInvalid = normalizedCurrency === null;
-	const hasChanges = Boolean(
-		stripeSecret ||
-			paddleSecret ||
-			(normalizedCurrency && normalizedCurrency !== savedCurrency)
-	);
+	const hasChanges =
+		!(isLoading || isConfigError) &&
+		Boolean(
+			stripeSecret ||
+				paddleSecret ||
+				(normalizedCurrency && normalizedCurrency !== savedCurrency)
+		);
 
 	const createWebhookMutation = useMutation({
 		mutationFn: () => {
@@ -316,6 +327,25 @@ function RevenueSettingsSheet({
 						<div className="flex items-center justify-center py-12">
 							<SpinnerIcon className="size-6 animate-spin text-muted-foreground" />
 						</div>
+					) : isConfigError ? (
+						<div className="flex min-h-[280px] items-center justify-center p-4">
+							<EmptyState
+								action={{
+									label: "Retry",
+									onClick: async () => {
+										await refetchConfig();
+									},
+								}}
+								description={
+									configError instanceof Error
+										? configError.message
+										: "We couldn't load revenue settings. Try again in a moment."
+								}
+								icon={<WarningCircleIcon />}
+								title="Couldn't load settings"
+								variant="error"
+							/>
+						</div>
 					) : (
 						<div className="space-y-5">
 							<Field error={currencyInvalid}>
@@ -378,6 +408,7 @@ function RevenueSettingsSheet({
 														{stripeUrl}
 													</code>
 													<Button
+														aria-label="Copy Stripe webhook URL"
 														onClick={() =>
 															stripeUrl && copyStripeUrl(stripeUrl)
 														}
@@ -416,6 +447,7 @@ function RevenueSettingsSheet({
 														{paddleUrl}
 													</code>
 													<Button
+														aria-label="Copy Paddle webhook URL"
 														onClick={() =>
 															paddleUrl && copyPaddleUrl(paddleUrl)
 														}
@@ -434,11 +466,12 @@ function RevenueSettingsSheet({
 												</div>
 											</div>
 
-											<button
-												className="flex w-full items-center justify-center gap-1.5 pt-2 text-muted-foreground text-xs transition-colors hover:text-foreground disabled:opacity-50"
+											<Button
+												className="h-auto w-full justify-center px-0 pt-2 text-muted-foreground text-xs"
 												disabled={regenerateMutation.isPending}
 												onClick={() => regenerateMutation.mutate()}
-												type="button"
+												size="sm"
+												variant="ghost"
 											>
 												{regenerateMutation.isPending ? (
 													<SpinnerIcon className="size-3 animate-spin" />
@@ -446,7 +479,7 @@ function RevenueSettingsSheet({
 													<ArrowClockwiseIcon className="size-3" />
 												)}
 												Regenerate URLs
-											</button>
+											</Button>
 										</div>
 									) : (
 										<div>
@@ -497,6 +530,11 @@ function RevenueSettingsSheet({
 													value={stripeSecret}
 												/>
 												<Button
+													aria-label={
+														showStripeSecret
+															? "Hide Stripe signing secret"
+															: "Show Stripe signing secret"
+													}
 													onClick={() => setShowStripeSecret(!showStripeSecret)}
 													size="sm"
 													variant="ghost"
@@ -578,6 +616,11 @@ function RevenueSettingsSheet({
 													value={paddleSecret}
 												/>
 												<Button
+													aria-label={
+														showPaddleSecret
+															? "Hide Paddle signing secret"
+															: "Show Paddle signing secret"
+													}
 													onClick={() => setShowPaddleSecret(!showPaddleSecret)}
 													size="sm"
 													variant="ghost"
@@ -641,7 +684,9 @@ function RevenueSettingsSheet({
 					</Button>
 					<Button
 						className="min-w-24"
-						disabled={currencyInvalid || !hasChanges}
+						disabled={
+							isLoading || isConfigError || currencyInvalid || !hasChanges
+						}
 						loading={upsertMutation.isPending}
 						onClick={handleSave}
 					>
@@ -666,7 +711,13 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 		[addFilterAction]
 	);
 
-	const { data: config, isLoading: isConfigLoading } = useQuery({
+	const {
+		data: config,
+		error: configError,
+		isError: isConfigError,
+		isLoading: isConfigLoading,
+		refetch: refetchConfig,
+	} = useQuery({
 		queryKey: ["revenue-config", websiteId],
 		queryFn: () => orpc.revenue.get.call({ websiteId }),
 	});
@@ -694,13 +745,29 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 		[revenueFilters]
 	);
 
-	const { isLoading: isRevenueLoading, getDataForQuery } = useBatchDynamicQuery(
-		websiteId,
-		dateRange,
-		queries,
-		{ enabled: revenueQueryEnabled }
-	);
+	const {
+		error: revenueError,
+		getDataForQuery,
+		isError: isRevenueError,
+		isLoading: isRevenueLoading,
+		refetch: refetchRevenue,
+	} = useBatchDynamicQuery(websiteId, dateRange, queries, {
+		enabled: revenueQueryEnabled,
+	});
 	const isLoading = isConfigLoading || isRevenueLoading;
+	const hasError = isConfigError || isRevenueError;
+	const error = configError ?? revenueError;
+
+	const handleRetry = async () => {
+		const retries: Promise<unknown>[] = [];
+		if (isConfigError) {
+			retries.push(refetchConfig());
+		}
+		if (isRevenueError) {
+			retries.push(refetchRevenue());
+		}
+		await Promise.all(retries);
+	};
 
 	const overviewData = (getDataForQuery(
 		"revenue-overview",
@@ -754,7 +821,7 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 			: 0;
 
 	return (
-		<>
+		<div className="relative flex h-full flex-col">
 			<TopBar.Title>
 				<h1 className="font-semibold text-sm">Revenue</h1>
 			</TopBar.Title>
@@ -769,187 +836,204 @@ export function RevenueContent({ websiteId }: RevenueContentProps) {
 				</Button>
 			</TopBar.Actions>
 
-			{isLoading || hasData ? (
-				<div className="space-y-3 p-4 sm:space-y-4">
-					<div className="grid grid-cols-1 gap-1.5 rounded-xl bg-secondary p-1.5 sm:grid-cols-2 lg:grid-cols-5">
-						<StatCard
-							displayMode="text"
-							icon={CurrencyDollarIcon}
-							id="total-revenue"
-							isLoading={isLoading}
-							title="Revenue"
-							value={formatRevenueCurrency(
-								overview?.total_revenue ?? 0,
-								displayCurrency
-							)}
-						/>
-						<StatCard
-							displayMode="text"
-							icon={ReceiptIcon}
-							id="transactions"
-							isLoading={isLoading}
-							title="Transactions"
-							value={overview?.total_transactions ?? 0}
-						/>
-						<StatCard
-							displayMode="text"
-							icon={CreditCardIcon}
-							id="avg-transaction"
-							isLoading={isLoading}
-							title="Avg Transaction"
-							value={formatRevenueCurrency(avgTransaction, displayCurrency)}
-						/>
-						<StatCard
-							displayMode="text"
-							icon={UsersIcon}
-							id="unique-customers"
-							isLoading={isLoading}
-							title="Customers"
-							value={overview?.unique_customers ?? 0}
-						/>
-						<StatCard
+			<div className="min-h-0 flex-1 overflow-y-auto overscroll-none">
+				{hasError ? (
+					<div className="flex min-h-full items-center justify-center p-4 py-16">
+						<EmptyState
+							action={{ label: "Retry", onClick: handleRetry }}
 							description={
-								overview?.attributed_transactions
-									? `${overview.attributed_transactions} of ${overview.total_transactions} attributed`
-									: undefined
+								error instanceof Error
+									? error.message
+									: "We couldn't load revenue data. Try again in a moment."
 							}
-							displayMode="text"
-							icon={TrendUpIcon}
-							id="attribution-rate"
-							isLoading={isLoading}
-							title="Attribution"
-							value={
-								overview?.total_transactions
-									? `${Math.round((overview.attributed_transactions / overview.total_transactions) * 100)}%`
-									: "0%"
-							}
+							icon={<WarningCircleIcon />}
+							title="Couldn't load revenue"
+							variant="error"
 						/>
 					</div>
-
-					{hasPaymentData && (
+				) : isLoading || hasData ? (
+					<div className="space-y-3 p-4 sm:space-y-4">
 						<div className="grid grid-cols-1 gap-1.5 rounded-xl bg-secondary p-1.5 sm:grid-cols-2 lg:grid-cols-5">
-							<StatCard
-								description={paymentFailureObservationDescription(overview)}
-								displayMode="text"
-								icon={CreditCardIcon}
-								id="payment-failure-rate"
-								isLoading={isLoading}
-								title="Payment failure rate"
-								value={paymentFailureRateLabel(overview)}
-							/>
-							<StatCard
-								description={
-									overview?.top_payment_failure_reason
-										? `Top cause: ${paymentFailureReasonLabel(overview.top_payment_failure_reason)}`
-										: undefined
-								}
-								displayMode="text"
-								icon={CreditCardIcon}
-								id="failed-payments"
-								isLoading={isLoading}
-								title="Failed payments"
-								value={overview?.failed_payment_attempts ?? 0}
-							/>
-							<StatCard
-								displayMode="text"
-								icon={ArrowClockwiseIcon}
-								id="recovered-payments"
-								isLoading={isLoading}
-								title="Recovered payments"
-								value={overview?.recovered_payment_attempts ?? 0}
-							/>
-							<StatCard
-								description={
-									overview?.top_payment_cancellation_reason
-										? `Top reason: ${paymentFailureReasonLabel(overview.top_payment_cancellation_reason)}`
-										: undefined
-								}
-								displayMode="text"
-								icon={CreditCardIcon}
-								id="canceled-payments"
-								isLoading={isLoading}
-								title="Canceled payments"
-								value={overview?.canceled_payment_attempts ?? 0}
-							/>
 							<StatCard
 								displayMode="text"
 								icon={CurrencyDollarIcon}
-								id="failed-payment-amount"
+								id="total-revenue"
 								isLoading={isLoading}
-								title="Failed amount"
+								title="Revenue"
 								value={formatRevenueCurrency(
-									overview?.failed_payment_amount ?? 0,
+									overview?.total_revenue ?? 0,
 									displayCurrency
 								)}
 							/>
-						</div>
-					)}
-
-					<Card>
-						<Card.Header className="flex-row items-center justify-between gap-3 py-3">
-							<div className="min-w-0 flex-1">
-								<Card.Title className="truncate text-sm">
-									Revenue Trends
-								</Card.Title>
-								<Card.Description className="line-clamp-2 text-pretty">
-									Revenue, transactions, customers, and refunds over time
-								</Card.Description>
-							</div>
-						</Card.Header>
-						<div className="overflow-x-auto">
-							<RevenueChart
-								currency={displayCurrency}
-								data={chartData}
-								height={isMobile ? 250 : 350}
+							<StatCard
+								displayMode="text"
+								icon={ReceiptIcon}
+								id="transactions"
 								isLoading={isLoading}
+								title="Transactions"
+								value={overview?.total_transactions ?? 0}
+							/>
+							<StatCard
+								displayMode="text"
+								icon={CreditCardIcon}
+								id="avg-transaction"
+								isLoading={isLoading}
+								title="Avg Transaction"
+								value={formatRevenueCurrency(avgTransaction, displayCurrency)}
+							/>
+							<StatCard
+								displayMode="text"
+								icon={UsersIcon}
+								id="unique-customers"
+								isLoading={isLoading}
+								title="Customers"
+								value={overview?.unique_customers ?? 0}
+							/>
+							<StatCard
+								description={
+									overview?.attributed_transactions
+										? `${overview.attributed_transactions} of ${overview.total_transactions} attributed`
+										: undefined
+								}
+								displayMode="text"
+								icon={TrendUpIcon}
+								id="attribution-rate"
+								isLoading={isLoading}
+								title="Attribution"
+								value={
+									overview?.total_transactions
+										? `${Math.round((overview.attributed_transactions / overview.total_transactions) * 100)}%`
+										: "0%"
+								}
 							/>
 						</div>
-					</Card>
 
-					<RevenueAttributionTables
-						currency={displayCurrency}
-						dateRange={dateRange}
-						enabled={revenueQueryEnabled}
-						onAddFilter={handleAddFilter}
-						queryFilters={revenueFilters}
-						websiteId={websiteId}
-					/>
-				</div>
-			) : (
-				<div className="flex min-h-[320px] items-center justify-center p-4 sm:min-h-[400px]">
-					<EmptyState
-						action={{
-							label: hasInvalidCurrency
-								? "Fix currency"
-								: isConfigured
-									? "Check webhook settings"
-									: "Configure webhooks",
-							onClick: () => setSettingsOpen(true),
-						}}
-						description={
-							hasInvalidCurrency
-								? "Choose the currency used to filter and format revenue reports."
-								: isConfigured
-									? "Revenue will appear here once your payment provider sends webhook events."
-									: "Connect Stripe or Paddle to start tracking revenue and attribution."
-						}
-						icon={<CurrencyDollarIcon />}
-						title={
-							hasInvalidCurrency
-								? "Choose a valid currency"
-								: isConfigured
-									? "Waiting for transactions"
-									: "Set up revenue tracking"
-						}
-					/>
-				</div>
-			)}
+						{(isLoading || hasPaymentData) && (
+							<div className="grid grid-cols-1 gap-1.5 rounded-xl bg-secondary p-1.5 sm:grid-cols-2 lg:grid-cols-5">
+								<StatCard
+									description={paymentFailureObservationDescription(overview)}
+									displayMode="text"
+									icon={CreditCardIcon}
+									id="payment-failure-rate"
+									isLoading={isLoading}
+									title="Payment failure rate"
+									value={paymentFailureRateLabel(overview)}
+								/>
+								<StatCard
+									description={
+										overview?.top_payment_failure_reason
+											? `Top cause: ${paymentFailureReasonLabel(overview.top_payment_failure_reason)}`
+											: undefined
+									}
+									displayMode="text"
+									icon={CreditCardIcon}
+									id="failed-payments"
+									isLoading={isLoading}
+									title="Failed payments"
+									value={overview?.failed_payment_attempts ?? 0}
+								/>
+								<StatCard
+									displayMode="text"
+									icon={ArrowClockwiseIcon}
+									id="recovered-payments"
+									isLoading={isLoading}
+									title="Recovered payments"
+									value={overview?.recovered_payment_attempts ?? 0}
+								/>
+								<StatCard
+									description={
+										overview?.top_payment_cancellation_reason
+											? `Top reason: ${paymentFailureReasonLabel(overview.top_payment_cancellation_reason)}`
+											: undefined
+									}
+									displayMode="text"
+									icon={CreditCardIcon}
+									id="canceled-payments"
+									isLoading={isLoading}
+									title="Canceled payments"
+									value={overview?.canceled_payment_attempts ?? 0}
+								/>
+								<StatCard
+									displayMode="text"
+									icon={CurrencyDollarIcon}
+									id="failed-payment-amount"
+									isLoading={isLoading}
+									title="Failed amount"
+									value={formatRevenueCurrency(
+										overview?.failed_payment_amount ?? 0,
+										displayCurrency
+									)}
+								/>
+							</div>
+						)}
+
+						<Card>
+							<Card.Header className="flex-row items-center justify-between gap-3 py-3">
+								<div className="min-w-0 flex-1">
+									<Card.Title className="truncate text-sm">
+										Revenue Trends
+									</Card.Title>
+									<Card.Description className="line-clamp-2 text-pretty">
+										Revenue, transactions, customers, and refunds over time
+									</Card.Description>
+								</div>
+							</Card.Header>
+							<div className="overflow-x-auto">
+								<RevenueChart
+									currency={displayCurrency}
+									data={chartData}
+									height={isMobile ? 250 : 350}
+									isLoading={isLoading}
+									className="rounded-none border-0"
+								/>
+							</div>
+						</Card>
+
+						<RevenueAttributionTables
+							currency={displayCurrency}
+							dateRange={dateRange}
+							enabled={revenueQueryEnabled}
+							onAddFilter={handleAddFilter}
+							queryFilters={revenueFilters}
+							websiteId={websiteId}
+						/>
+					</div>
+				) : (
+					<div className="flex min-h-full items-center justify-center p-4 py-16">
+						<EmptyState
+							action={{
+								label: hasInvalidCurrency
+									? "Fix currency"
+									: isConfigured
+										? "Check webhook settings"
+										: "Configure webhooks",
+								onClick: () => setSettingsOpen(true),
+							}}
+							description={
+								hasInvalidCurrency
+									? "Choose the currency used to filter and format revenue reports."
+									: isConfigured
+										? "Revenue will appear here once your payment provider sends webhook events."
+										: "Connect Stripe or Paddle to start tracking revenue and attribution."
+							}
+							icon={<CurrencyDollarIcon />}
+							title={
+								hasInvalidCurrency
+									? "Choose a valid currency"
+									: isConfigured
+										? "Waiting for transactions"
+										: "Set up revenue tracking"
+							}
+						/>
+					</div>
+				)}
+			</div>
 
 			<RevenueSettingsSheet
 				onOpenChangeAction={setSettingsOpen}
 				open={settingsOpen}
 				websiteId={websiteId}
 			/>
-		</>
+		</div>
 	);
 }

--- a/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-settings-sheet.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/revenue/_components/revenue-settings-sheet.tsx
@@ -1,0 +1,590 @@
+"use client";
+
+import { publicConfig } from "@databuddy/env/public";
+import { normalizeCurrencyCode } from "@databuddy/shared/currency";
+import { STRIPE_WEBHOOK_EVENTS } from "@databuddy/shared/stripe-webhooks";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState, type ComponentType, type ReactNode } from "react";
+import { toast } from "sonner";
+import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { orpc } from "@/lib/orpc";
+import { Accordion, Sheet } from "@databuddy/ui/client";
+import { Button, EmptyState, Field, Input } from "@databuddy/ui";
+import {
+	ArrowClockwiseIcon,
+	ArrowSquareOutIcon,
+	CheckCircleIcon,
+	CheckIcon,
+	ClipboardIcon,
+	CreditCardIcon as StripeLogoIcon,
+	CurrencyDollarIcon,
+	EyeIcon,
+	EyeSlashIcon,
+	LinkIcon,
+	SpinnerIcon,
+	WarningCircleIcon,
+} from "@databuddy/ui/icons";
+
+const BASKET_URL = publicConfig.urls.basket;
+
+const PADDLE_REQUIRED_EVENTS = ["transaction.completed"];
+
+type ExpandedSection = "webhooks" | "stripe" | "paddle" | null;
+
+function SettingsSection({
+	icon: Icon,
+	title,
+	badge,
+	isOpen,
+	onOpenChange,
+	children,
+}: {
+	badge?: ReactNode;
+	children: ReactNode;
+	icon: ComponentType<{ className?: string; weight?: "duotone" }>;
+	isOpen: boolean;
+	onOpenChange: (open: boolean) => void;
+	title: string;
+}) {
+	return (
+		<div className="overflow-hidden rounded-md border border-border/60">
+			<Accordion onOpenChange={onOpenChange} open={isOpen}>
+				<Accordion.Trigger>
+					<Icon
+						className="size-4 shrink-0 text-muted-foreground"
+						weight="duotone"
+					/>
+					<span className="font-semibold text-sm">{title}</span>
+					{badge ? <span className="ml-auto">{badge}</span> : null}
+				</Accordion.Trigger>
+				<Accordion.Content>{children}</Accordion.Content>
+			</Accordion>
+		</div>
+	);
+}
+
+export function RevenueSettingsSheet({
+	websiteId,
+	open,
+	onOpenChangeAction,
+}: {
+	websiteId: string;
+	open: boolean;
+	onOpenChangeAction: (open: boolean) => void;
+}) {
+	const queryClient = useQueryClient();
+	const [stripeSecret, setStripeSecret] = useState("");
+	const [paddleSecret, setPaddleSecret] = useState("");
+	const [currencyDraft, setCurrencyDraft] = useState<string | null>(null);
+	const [showStripeSecret, setShowStripeSecret] = useState(false);
+	const [showPaddleSecret, setShowPaddleSecret] = useState(false);
+	const [expandedSection, setExpandedSection] =
+		useState<ExpandedSection>("webhooks");
+	const { isCopied: copiedStripeUrl, copyToClipboard: copyStripeUrl } =
+		useCopyToClipboard({
+			onCopy: () => toast.success("Webhook URL copied"),
+		});
+	const { isCopied: copiedPaddleUrl, copyToClipboard: copyPaddleUrl } =
+		useCopyToClipboard({
+			onCopy: () => toast.success("Webhook URL copied"),
+		});
+
+	const {
+		data: config,
+		isError: isConfigError,
+		isLoading,
+		refetch: refetchConfig,
+	} = useQuery({
+		queryKey: ["revenue-config", websiteId],
+		queryFn: () => orpc.revenue.get.call({ websiteId }),
+	});
+	const savedCurrency = normalizeCurrencyCode(config?.currency);
+	const configuredCurrency =
+		typeof config?.currency === "string"
+			? config.currency.trim().toUpperCase()
+			: "USD";
+	const currencyValue = currencyDraft ?? configuredCurrency;
+	const normalizedCurrency = normalizeCurrencyCode(currencyValue);
+	const currencyInvalid = normalizedCurrency === null;
+	const hasChanges =
+		!(isLoading || isConfigError) &&
+		Boolean(
+			stripeSecret ||
+				paddleSecret ||
+				(normalizedCurrency && normalizedCurrency !== savedCurrency)
+		);
+
+	const createWebhookMutation = useMutation({
+		mutationFn: () => {
+			if (!normalizedCurrency) {
+				throw new Error("Invalid revenue currency");
+			}
+			return orpc.revenue.upsert.call({
+				websiteId,
+				currency: normalizedCurrency,
+			});
+		},
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["revenue-config", websiteId],
+			});
+			toast.success("Webhook URLs generated");
+		},
+		onError: () => toast.error("Failed to generate webhook URL"),
+	});
+
+	const upsertMutation = useMutation({
+		mutationFn: (data: {
+			stripeWebhookSecret?: string;
+			paddleWebhookSecret?: string;
+			currency: string;
+		}) => orpc.revenue.upsert.call({ websiteId, ...data }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["revenue-config", websiteId],
+			});
+			setStripeSecret("");
+			setPaddleSecret("");
+			setCurrencyDraft(null);
+			toast.success("Configuration saved");
+		},
+		onError: () => toast.error("Failed to save"),
+	});
+
+	const regenerateMutation = useMutation({
+		mutationFn: () => orpc.revenue.regenerateHash.call({ websiteId }),
+		onSuccess: () => {
+			queryClient.invalidateQueries({
+				queryKey: ["revenue-config", websiteId],
+			});
+			toast.success("Webhook URLs regenerated");
+		},
+		onError: () => toast.error("Failed to regenerate"),
+	});
+
+	const handleSave = () => {
+		if (!normalizedCurrency) {
+			return;
+		}
+
+		const updates: {
+			stripeWebhookSecret?: string;
+			paddleWebhookSecret?: string;
+			currency: string;
+		} = { currency: normalizedCurrency };
+		if (stripeSecret) {
+			updates.stripeWebhookSecret = stripeSecret;
+		}
+		if (paddleSecret) {
+			updates.paddleWebhookSecret = paddleSecret;
+		}
+		upsertMutation.mutate(updates);
+	};
+
+	const webhookHash = config?.webhookHash;
+	const stripeUrl = webhookHash
+		? `${BASKET_URL}/webhooks/stripe/${webhookHash}`
+		: null;
+	const paddleUrl = webhookHash
+		? `${BASKET_URL}/webhooks/paddle/${webhookHash}`
+		: null;
+
+	return (
+		<Sheet onOpenChange={onOpenChangeAction} open={open}>
+			<Sheet.Content className="w-full sm:max-w-lg" side="right">
+				<Sheet.Header>
+					<div className="flex items-center gap-4">
+						<div className="flex size-11 items-center justify-center rounded border bg-secondary">
+							<CurrencyDollarIcon
+								className="size-5 text-primary"
+								weight="duotone"
+							/>
+						</div>
+						<div>
+							<Sheet.Title className="text-lg">Revenue Tracking</Sheet.Title>
+							<Sheet.Description>
+								Connect payment providers via webhooks
+							</Sheet.Description>
+						</div>
+					</div>
+				</Sheet.Header>
+
+				<Sheet.Form
+					onSubmit={(event) => {
+						event.preventDefault();
+						handleSave();
+					}}
+				>
+					<Sheet.Body className="space-y-5">
+						{isLoading ? (
+							<div className="flex items-center justify-center py-12">
+								<SpinnerIcon className="size-6 animate-spin text-muted-foreground" />
+							</div>
+						) : isConfigError ? (
+							<div className="flex min-h-[280px] items-center justify-center p-4">
+								<EmptyState
+									action={{
+										label: "Retry",
+										onClick: async () => {
+											await refetchConfig();
+										},
+									}}
+									description="We couldn't load revenue settings. Try again in a moment."
+									icon={<WarningCircleIcon />}
+									title="Couldn't load settings"
+									variant="error"
+								/>
+							</div>
+						) : (
+							<>
+								<Field error={currencyInvalid}>
+									<Field.Label>Currency</Field.Label>
+									<Input
+										autoCapitalize="characters"
+										className="font-mono uppercase"
+										maxLength={3}
+										onChange={(event) =>
+											setCurrencyDraft(event.target.value.toUpperCase())
+										}
+										placeholder="USD"
+										value={currencyValue}
+									/>
+									{currencyInvalid ? (
+										<Field.Error>
+											Enter a valid three-letter ISO currency code.
+										</Field.Error>
+									) : (
+										<Field.Description>
+											Only matching transactions are shown in revenue reports.
+										</Field.Description>
+									)}
+								</Field>
+
+								<div className="space-y-1">
+									<SettingsSection
+										badge={
+											webhookHash ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={LinkIcon}
+										isOpen={expandedSection === "webhooks"}
+										onOpenChange={(open) =>
+											setExpandedSection(open ? "webhooks" : null)
+										}
+										title="Webhook URLs"
+									>
+										{webhookHash ? (
+											<div className="space-y-4">
+												<div className="space-y-1.5">
+													<div className="flex items-center justify-between">
+														<p className="font-medium text-foreground text-xs">
+															Stripe
+														</p>
+														<a
+															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+															href="https://dashboard.stripe.com/webhooks/create"
+															rel="noopener noreferrer"
+															target="_blank"
+														>
+															Open dashboard
+															<ArrowSquareOutIcon className="size-3" />
+														</a>
+													</div>
+													<div className="flex items-center gap-2">
+														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
+															{stripeUrl}
+														</code>
+														<Button
+															aria-label="Copy Stripe webhook URL"
+															onClick={() =>
+																stripeUrl && copyStripeUrl(stripeUrl)
+															}
+															size="sm"
+															variant="ghost"
+														>
+															{copiedStripeUrl ? (
+																<CheckIcon className="size-4 text-success" />
+															) : (
+																<ClipboardIcon
+																	className="size-4"
+																	weight="duotone"
+																/>
+															)}
+														</Button>
+													</div>
+												</div>
+
+												<div className="space-y-1.5">
+													<div className="flex items-center justify-between">
+														<p className="font-medium text-foreground text-xs">
+															Paddle
+														</p>
+														<a
+															className="flex items-center gap-1 text-muted-foreground text-xs transition-colors hover:text-foreground"
+															href="https://vendors.paddle.com/notifications"
+															rel="noopener noreferrer"
+															target="_blank"
+														>
+															Open dashboard
+															<ArrowSquareOutIcon className="size-3" />
+														</a>
+													</div>
+													<div className="flex items-center gap-2">
+														<code className="flex-1 truncate rounded bg-secondary px-2.5 py-2 font-mono text-xs">
+															{paddleUrl}
+														</code>
+														<Button
+															aria-label="Copy Paddle webhook URL"
+															onClick={() =>
+																paddleUrl && copyPaddleUrl(paddleUrl)
+															}
+															size="sm"
+															variant="ghost"
+														>
+															{copiedPaddleUrl ? (
+																<CheckIcon className="size-4 text-success" />
+															) : (
+																<ClipboardIcon
+																	className="size-4"
+																	weight="duotone"
+																/>
+															)}
+														</Button>
+													</div>
+												</div>
+
+												<Button
+													className="h-auto w-full justify-center px-0 pt-2 text-muted-foreground text-xs"
+													disabled={regenerateMutation.isPending}
+													onClick={() => regenerateMutation.mutate()}
+													size="sm"
+													variant="ghost"
+												>
+													{regenerateMutation.isPending ? (
+														<SpinnerIcon className="size-3 animate-spin" />
+													) : (
+														<ArrowClockwiseIcon className="size-3" />
+													)}
+													Regenerate URLs
+												</Button>
+											</div>
+										) : (
+											<div>
+												<p className="mb-3 text-muted-foreground text-xs">
+													Generate URLs to receive payment events.
+												</p>
+												<Button
+													className="w-full"
+													disabled={currencyInvalid}
+													loading={createWebhookMutation.isPending}
+													onClick={() => createWebhookMutation.mutate()}
+													size="sm"
+													variant="secondary"
+												>
+													Generate Webhook URLs
+												</Button>
+											</div>
+										)}
+									</SettingsSection>
+
+									<SettingsSection
+										badge={
+											config?.stripeConfigured ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={StripeLogoIcon}
+										isOpen={expandedSection === "stripe"}
+										onOpenChange={(open) =>
+											setExpandedSection(open ? "stripe" : null)
+										}
+										title="Stripe"
+									>
+										<div className="space-y-4">
+											<div className="space-y-1.5">
+												<p className="font-medium text-foreground text-xs">
+													Signing secret
+												</p>
+												<div className="flex items-center gap-2">
+													<Input
+														className="flex-1 font-mono text-xs"
+														onChange={(e) => setStripeSecret(e.target.value)}
+														placeholder={
+															config?.stripeConfigured
+																? "••••••••"
+																: "whsec_..."
+														}
+														type={showStripeSecret ? "text" : "password"}
+														value={stripeSecret}
+													/>
+													<Button
+														aria-label={
+															showStripeSecret
+																? "Hide Stripe signing secret"
+																: "Show Stripe signing secret"
+														}
+														onClick={() =>
+															setShowStripeSecret(!showStripeSecret)
+														}
+														size="sm"
+														variant="ghost"
+													>
+														{showStripeSecret ? (
+															<EyeSlashIcon
+																className="size-4"
+																weight="duotone"
+															/>
+														) : (
+															<EyeIcon className="size-4" weight="duotone" />
+														)}
+													</Button>
+												</div>
+											</div>
+
+											<div className="space-y-2">
+												<p className="text-muted-foreground text-xs">
+													Required events
+												</p>
+												<div className="flex flex-wrap gap-1">
+													{STRIPE_WEBHOOK_EVENTS.required.map(({ event }) => (
+														<code
+															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
+															key={event}
+														>
+															{event}
+														</code>
+													))}
+												</div>
+											</div>
+
+											{STRIPE_WEBHOOK_EVENTS.optional.length > 0 && (
+												<div className="space-y-2">
+													<p className="text-muted-foreground text-xs">
+														Optional
+													</p>
+													<div className="flex flex-wrap gap-1">
+														{STRIPE_WEBHOOK_EVENTS.optional.map(({ event }) => (
+															<code
+																className="rounded bg-secondary px-1.5 py-0.5 font-mono text-[11px] text-muted-foreground"
+																key={event}
+															>
+																{event}
+															</code>
+														))}
+													</div>
+												</div>
+											)}
+										</div>
+									</SettingsSection>
+
+									<SettingsSection
+										badge={
+											config?.paddleConfigured ? (
+												<CheckCircleIcon
+													className="size-4 text-success"
+													weight="duotone"
+												/>
+											) : undefined
+										}
+										icon={CurrencyDollarIcon}
+										isOpen={expandedSection === "paddle"}
+										onOpenChange={(open) =>
+											setExpandedSection(open ? "paddle" : null)
+										}
+										title="Paddle"
+									>
+										<div className="space-y-4">
+											<div className="space-y-1.5">
+												<p className="font-medium text-foreground text-xs">
+													Signing secret
+												</p>
+												<div className="flex items-center gap-2">
+													<Input
+														className="flex-1 font-mono text-xs"
+														onChange={(e) => setPaddleSecret(e.target.value)}
+														placeholder={
+															config?.paddleConfigured
+																? "••••••••"
+																: "pdl_ntfset_..."
+														}
+														type={showPaddleSecret ? "text" : "password"}
+														value={paddleSecret}
+													/>
+													<Button
+														aria-label={
+															showPaddleSecret
+																? "Hide Paddle signing secret"
+																: "Show Paddle signing secret"
+														}
+														onClick={() =>
+															setShowPaddleSecret(!showPaddleSecret)
+														}
+														size="sm"
+														variant="ghost"
+													>
+														{showPaddleSecret ? (
+															<EyeSlashIcon
+																className="size-4"
+																weight="duotone"
+															/>
+														) : (
+															<EyeIcon className="size-4" weight="duotone" />
+														)}
+													</Button>
+												</div>
+											</div>
+
+											<div className="space-y-2">
+												<p className="text-muted-foreground text-xs">
+													Required events
+												</p>
+												<div className="flex flex-wrap gap-1">
+													{PADDLE_REQUIRED_EVENTS.map((event) => (
+														<code
+															className="rounded bg-primary/10 px-1.5 py-0.5 font-mono text-[11px] text-primary"
+															key={event}
+														>
+															{event}
+														</code>
+													))}
+												</div>
+											</div>
+										</div>
+									</SettingsSection>
+								</div>
+							</>
+						)}
+					</Sheet.Body>
+
+					<Sheet.Footer>
+						<Button
+							onClick={() => onOpenChangeAction(false)}
+							type="button"
+							variant="secondary"
+						>
+							Cancel
+						</Button>
+						<Button
+							className="min-w-24"
+							disabled={
+								isLoading || isConfigError || currencyInvalid || !hasChanges
+							}
+							loading={upsertMutation.isPending}
+							type="submit"
+						>
+							Save Changes
+						</Button>
+					</Sheet.Footer>
+				</Sheet.Form>
+				<Sheet.Close />
+			</Sheet.Content>
+		</Sheet>
+	);
+}

--- a/apps/dashboard/components/layout/navigation/navigation-config.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-config.tsx
@@ -31,6 +31,7 @@ import {
 	ReceiptIcon,
 	RobotIcon,
 	SignalIcon,
+	ShieldCheckIcon,
 	TargetIcon,
 	UserIcon,
 	UserSettingsIcon,
@@ -312,6 +313,11 @@ export const settingsNavigation: NavigationGroup[] = [
 				{ flag: "integrations" }
 			),
 			createNavItem("Members", UserIcon, "/organizations/members"),
+			createNavItem(
+				"Audit Log",
+				ShieldCheckIcon,
+				"/organizations/settings/audit"
+			),
 			createNavItem("Billing", CreditCardIcon, "/billing"),
 			createNavItem("Plans", CurrencyDollarIcon, "/billing/plans"),
 			createNavItem("Invoices", ReceiptIcon, "/billing/history"),

--- a/apps/dashboard/components/layout/navigation/navigation-config.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-config.tsx
@@ -136,8 +136,6 @@ export const websiteNavigation: NavigationGroup[] = [
 			createNavItem("Dashboard", ChartPieSliceIcon, "", { rootLevel: false }),
 			createNavItem("Realtime", SignalIcon, "/realtime", {
 				rootLevel: false,
-				flag: "realtime",
-				alpha: true,
 				hideFromDemo: true,
 			}),
 			createNavItem("Audience", UsersThreeIcon, "/audience", {

--- a/apps/dashboard/hooks/use-dynamic-query.ts
+++ b/apps/dashboard/hooks/use-dynamic-query.ts
@@ -190,7 +190,7 @@ export function useDynamicQuery<
 
 	return {
 		data: processedData,
-		isLoading: query.isLoading || query.isFetching || query.isPending,
+		isLoading: query.isLoading || query.isFetching,
 		isFetching: query.isFetching,
 		isError: query.isError,
 		error: query.error,
@@ -280,7 +280,7 @@ export function useBatchDynamicQuery(
 
 	return {
 		results: processedResults,
-		isLoading: query.isLoading || query.isFetching || query.isPending,
+		isLoading: query.isLoading || query.isFetching,
 		isError: query.isError,
 		error: query.error,
 		refetch: query.refetch,

--- a/apps/docs/content/docs/sdk/feature-flags.mdx
+++ b/apps/docs/content/docs/sdk/feature-flags.mdx
@@ -499,7 +499,11 @@ Direct rules and target group matches short-circuit evaluation as force on/off r
 
 ### Measure Flag Outcomes
 
-Treat flag metrics as two separate questions: who was exposed, and what changed afterward. The browser SDK emits `$flag_evaluated` for single-flag fetches when the tracker is available, but bulk-prefetched or cached reads may not emit a fresh exposure event. For experiments where exposure accounting must be complete, track one explicit exposure event when the meaningful flagged view appears.
+Treat flag metrics as two separate questions: who was evaluated, and what changed afterward. When the tracker is available, the browser SDK emits a deduplicated `$flag_evaluated` event when a flag is read through `useFlag`, `useFlags`, or the manager APIs. The Feature Flags dashboard uses those events to show observed visitors, identified visitors, evaluation count, and the last observed evaluation time.
+
+These dashboard numbers are directional estimates, not guaranteed complete or exact counts of people who used a feature. They only include browser evaluations that Databuddy observed, so blockers, consent or opt-out settings, event sampling, missing tracker coverage, server-side evaluations, and incomplete identity linkage can make the numbers lower than reality. The visitor count should be read as “observed visitors evaluated,” not “people who used the feature.” Passing `userId` to the flags provider and calling Databuddy `identify()` on the tracker lets those evaluations carry your profile ID.
+
+An evaluation is not proof that a feature was rendered or used, and server-side flag evaluations are not automatically sent as analytics events. For experiments where rendered exposure or product usage must be measured, track one explicit exposure event when the meaningful flagged view appears, then track the downstream outcome.
 
 <CodeBlock language="tsx">
   {`import { track } from "@databuddy/sdk";

--- a/packages/cache/src/drizzle.ts
+++ b/packages/cache/src/drizzle.ts
@@ -1,6 +1,17 @@
 import { getTableName, is, Table } from "drizzle-orm";
-import { Cache } from "drizzle-orm/cache/core";
+import { Cache, type MutationOption } from "drizzle-orm/cache/core";
 import type { CacheConfig } from "drizzle-orm/cache/core/types";
+
+export interface RedisCacheClient {
+	del(key: string): Promise<unknown>;
+	expire(key: string, seconds: number): Promise<unknown>;
+	get(key: string): Promise<string | null>;
+	sadd(key: string, member: string): Promise<unknown>;
+	set(key: string, value: string, mode?: "KEEPTTL"): Promise<unknown>;
+	setex(key: string, seconds: number, value: string): Promise<unknown>;
+	smembers(key: string): Promise<string[]>;
+	unlink(key: string): Promise<unknown>;
+}
 
 /**
  * Configuration options for creating a Redis-based Drizzle cache instance.
@@ -56,7 +67,7 @@ export interface RedisCacheConfig {
 	 * const redis = new Redis("redis://localhost:6379");
 	 * ```
 	 */
-	redis: any;
+	redis: RedisCacheClient;
 	/**
 	 * Cache strategy determines when queries are cached.
 	 *
@@ -139,7 +150,7 @@ export interface RedisCacheConfig {
  * ```
  */
 export class RedisDrizzleCache extends Cache {
-	private readonly redis: any;
+	private readonly redis: RedisCacheClient;
 	private readonly defaultTtl: number;
 	private readonly namespace: string;
 	private readonly _strategy: "explicit" | "all";
@@ -212,14 +223,15 @@ export class RedisDrizzleCache extends Cache {
 	 * - Returns `undefined` if JSON parsing fails
 	 * - Logs errors to console but doesn't throw
 	 */
-	override async get(key: string): Promise<any[] | undefined> {
+	override async get(key: string): Promise<unknown[] | undefined> {
 		const cacheKey = this.formatKey(key);
 		try {
 			const cached = await this.redis.get(cacheKey);
 			if (!cached) {
 				return;
 			}
-			return JSON.parse(cached) as any[];
+			const parsed: unknown = JSON.parse(cached);
+			return Array.isArray(parsed) ? parsed : undefined;
 		} catch (error) {
 			console.error(
 				`[RedisDrizzleCache] GET failed for key ${cacheKey}:`,
@@ -276,7 +288,7 @@ export class RedisDrizzleCache extends Cache {
 	 */
 	override async put(
 		key: string,
-		response: any,
+		response: unknown,
 		tables: string[],
 		_isTag: boolean,
 		config?: CacheConfig
@@ -359,10 +371,7 @@ export class RedisDrizzleCache extends Cache {
 	 * - Tag-based invalidation is supported but tags must be tracked separately
 	 * - Operations are performed in parallel for better performance
 	 */
-	override async onMutate(params: {
-		tags?: string | string[];
-		tables?: string | string[] | Table<any> | Table<any>[];
-	}): Promise<void> {
+	override async onMutate(params: MutationOption): Promise<void> {
 		const tagsArray = params.tags
 			? Array.isArray(params.tags)
 				? params.tags

--- a/packages/db/src/drizzle/schema/flags.test.ts
+++ b/packages/db/src/drizzle/schema/flags.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildFlagChangeSnapshot } from "./flags";
+
+describe("buildFlagChangeSnapshot", () => {
+	test("normalizes nullable flag fields for every writer", () => {
+		const snapshot = buildFlagChangeSnapshot({
+			defaultValue: false,
+			dependencies: null,
+			description: null,
+			environment: null,
+			key: "checkout-v2",
+			name: null,
+			persistAcrossAuth: false,
+			rolloutBy: null,
+			rolloutPercentage: null,
+			status: "active",
+			type: "boolean",
+			variants: null,
+		});
+
+		expect(snapshot).toEqual({
+			defaultValue: false,
+			dependencies: [],
+			description: null,
+			environment: null,
+			key: "checkout-v2",
+			name: null,
+			persistAcrossAuth: false,
+			rolloutBy: null,
+			rolloutPercentage: null,
+			status: "active",
+			type: "boolean",
+			variants: [],
+		});
+	});
+});

--- a/packages/db/src/drizzle/schema/flags.ts
+++ b/packages/db/src/drizzle/schema/flags.ts
@@ -148,6 +148,39 @@ export const flags = pgTable(
 	]
 );
 
+export function buildFlagChangeSnapshot(
+	flag: Pick<
+		typeof flags.$inferSelect,
+		| "defaultValue"
+		| "dependencies"
+		| "description"
+		| "environment"
+		| "key"
+		| "name"
+		| "persistAcrossAuth"
+		| "rolloutBy"
+		| "rolloutPercentage"
+		| "status"
+		| "type"
+		| "variants"
+	>
+): FlagChangeSnapshot {
+	return {
+		key: flag.key,
+		name: flag.name ?? null,
+		description: flag.description ?? null,
+		type: flag.type,
+		status: flag.status,
+		defaultValue: flag.defaultValue,
+		persistAcrossAuth: flag.persistAcrossAuth,
+		rolloutPercentage: flag.rolloutPercentage ?? null,
+		rolloutBy: flag.rolloutBy ?? null,
+		environment: flag.environment ?? null,
+		dependencies: flag.dependencies ?? [],
+		variants: flag.variants ?? [],
+	};
+}
+
 export const flagChangeEvents = pgTable(
 	"flag_change_events",
 	{

--- a/packages/rpc/src/lib/audit.ts
+++ b/packages/rpc/src/lib/audit.ts
@@ -3,11 +3,14 @@ import type {
 	AuditActor,
 	AuditRequestContext,
 } from "@databuddy/shared/audit";
+import { getTrustedClientIp } from "@databuddy/shared/utils/trusted-client-ip";
 import {
+	appendAuditEvent,
 	appendAuditEventInTransaction,
 	type AuditDatabase,
 	type AppendAuditEventInput,
 } from "@databuddy/services/audit";
+import { log } from "evlog";
 import type { Context } from "../orpc";
 
 export function getAuditActor(context: Context): AuditActor {
@@ -34,7 +37,9 @@ export function getAuditActor(context: Context): AuditActor {
 
 export function getAuditRequestContext(context: Context): AuditRequestContext {
 	return {
-		requestId: context.headers.get("x-request-id") ?? undefined,
+		ip: getTrustedClientIp(context.headers),
+		requestId:
+			context.requestId ?? context.headers.get("x-request-id") ?? undefined,
 		userAgent: context.headers.get("user-agent") ?? undefined,
 	};
 }
@@ -53,4 +58,28 @@ export async function appendRpcAuditEvent<
 		request: getAuditRequestContext(context),
 		source: "orpc",
 	});
+}
+
+export async function appendRpcAuditEventBestEffort<
+	TAction extends AuditActionDefinition,
+>(
+	context: Context,
+	organizationId: string,
+	input: Omit<AppendAuditEventInput<TAction>, "actor" | "request" | "source">
+): Promise<void> {
+	try {
+		await appendAuditEvent(context.db, organizationId, {
+			...input,
+			actor: getAuditActor(context),
+			request: getAuditRequestContext(context),
+			source: "orpc",
+		});
+	} catch (error) {
+		log.error({
+			service: "rpc",
+			component: "audit",
+			audit_error: error,
+			operation: input.operation,
+		});
+	}
 }

--- a/packages/rpc/src/lib/audit.ts
+++ b/packages/rpc/src/lib/audit.ts
@@ -44,6 +44,14 @@ export function getAuditRequestContext(context: Context): AuditRequestContext {
 	};
 }
 
+export function getAuditOrganizationId(context: Context): string | null {
+	return context.auditOrganizationId ?? context.organizationId;
+}
+
+export function setAuditOrganization(context: Context, organizationId: string) {
+	context.auditOrganizationId = organizationId;
+}
+
 export async function appendRpcAuditEvent<
 	TAction extends AuditActionDefinition,
 >(

--- a/packages/rpc/src/middleware/audit-mutation.test.ts
+++ b/packages/rpc/src/middleware/audit-mutation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { isAuditedMutationPath } from "./audit-mutation";
+
+describe("isAuditedMutationPath", () => {
+	test("recognizes privileged mutation verbs across routers", () => {
+		expect(isAuditedMutationPath("flags.create")).toBe(true);
+		expect(isAuditedMutationPath("statusPage.createIncident")).toBe(true);
+		expect(isAuditedMutationPath("organizations.updateEmailNotificationSettings")).toBe(true);
+	});
+
+	test("does not treat reads as mutations", () => {
+		expect(isAuditedMutationPath("flags.list")).toBe(false);
+		expect(isAuditedMutationPath("profiles.getHistory")).toBe(false);
+	});
+
+	test("leaves richer existing audit implementations in control", () => {
+		expect(isAuditedMutationPath("apikeys.create")).toBe(false);
+		expect(isAuditedMutationPath("websites.updateSettings")).toBe(false);
+	});
+
+	test("rejects malformed procedure paths", () => {
+		expect(isAuditedMutationPath("create")).toBe(false);
+		expect(isAuditedMutationPath("flags")).toBe(false);
+	});
+});

--- a/packages/rpc/src/middleware/audit-mutation.test.ts
+++ b/packages/rpc/src/middleware/audit-mutation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { getAuditOrganizationId, setAuditOrganization } from "../lib/audit";
 import { isAuditedMutationPath } from "./audit-mutation";
 
 describe("isAuditedMutationPath", () => {
@@ -21,5 +22,27 @@ describe("isAuditedMutationPath", () => {
 	test("rejects malformed procedure paths", () => {
 		expect(isAuditedMutationPath("create")).toBe(false);
 		expect(isAuditedMutationPath("flags")).toBe(false);
+	});
+});
+
+describe("audit organization targeting", () => {
+	test("uses an explicitly resolved target organization", () => {
+		const context = {
+			auditOrganizationId: undefined,
+			organizationId: "org-active",
+		} as Parameters<typeof setAuditOrganization>[0];
+
+		setAuditOrganization(context, "org-target");
+
+		expect(getAuditOrganizationId(context)).toBe("org-target");
+	});
+
+	test("falls back to the active organization", () => {
+		const context = {
+			auditOrganizationId: undefined,
+			organizationId: "org-active",
+		} as Parameters<typeof setAuditOrganization>[0];
+
+		expect(getAuditOrganizationId(context)).toBe("org-active");
 	});
 });

--- a/packages/rpc/src/middleware/audit-mutation.ts
+++ b/packages/rpc/src/middleware/audit-mutation.ts
@@ -1,7 +1,11 @@
 import { log } from "evlog";
 import { auditActions } from "@databuddy/shared/audit";
 import { appendAuditEvent } from "@databuddy/services/audit";
-import { getAuditActor, getAuditRequestContext } from "../lib/audit";
+import {
+	getAuditActor,
+	getAuditOrganizationId,
+	getAuditRequestContext,
+} from "../lib/audit";
 import type { Context } from "../orpc";
 
 const MUTATION_METHOD_PREFIXES = [
@@ -79,7 +83,7 @@ async function writeMutationAudit(
 	outcome: "denied" | "failure" | "success",
 	error?: unknown
 ): Promise<void> {
-	const organizationId = context.organizationId;
+	const organizationId = getAuditOrganizationId(context);
 	if (!(organizationId && (context.user || context.apiKey))) {
 		return;
 	}

--- a/packages/rpc/src/middleware/audit-mutation.ts
+++ b/packages/rpc/src/middleware/audit-mutation.ts
@@ -1,0 +1,128 @@
+import { log } from "evlog";
+import { auditActions } from "@databuddy/shared/audit";
+import { appendAuditEvent } from "@databuddy/services/audit";
+import { getAuditActor, getAuditRequestContext } from "../lib/audit";
+import type { Context } from "../orpc";
+
+const MUTATION_METHOD_PREFIXES = [
+	"accept",
+	"add",
+	"apply",
+	"archive",
+	"cancel",
+	"change",
+	"clear",
+	"configure",
+	"connect",
+	"create",
+	"delete",
+	"disconnect",
+	"edit",
+	"generate",
+	"install",
+	"mark",
+	"manual",
+	"pause",
+	"publish",
+	"redeem",
+	"remove",
+	"rename",
+	"regenerate",
+	"reorder",
+	"reset",
+	"reply",
+	"resolve",
+	"restore",
+	"resume",
+	"revoke",
+	"rotate",
+	"run",
+	"set",
+	"submit",
+	"test",
+	"toggle",
+	"transfer",
+	"uninstall",
+	"unpublish",
+	"update",
+	"upsert",
+] as const;
+
+const EXPLICIT_AUDIT_ROUTERS = new Set(["apikeys", "websites"]);
+
+export function isAuditedMutationPath(path: string): boolean {
+	const [router, method] = path.split(".");
+	if (!(router && method) || EXPLICIT_AUDIT_ROUTERS.has(router)) {
+		return false;
+	}
+
+	return MUTATION_METHOD_PREFIXES.some((prefix) => method.startsWith(prefix));
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) {
+		return;
+	}
+
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function getAuditOutcome(error: unknown): "denied" | "failure" {
+	const code = getErrorCode(error);
+	return code === "FORBIDDEN" ? "denied" : "failure";
+}
+
+async function writeMutationAudit(
+	context: Context,
+	path: string,
+	outcome: "denied" | "failure" | "success",
+	error?: unknown
+): Promise<void> {
+	const organizationId = context.organizationId;
+	if (!(organizationId && (context.user || context.apiKey))) {
+		return;
+	}
+
+	const errorCode = error ? getErrorCode(error) : undefined;
+	try {
+		await appendAuditEvent(context.db, organizationId, {
+			action: auditActions.RPC_MUTATION,
+			actor: getAuditActor(context),
+			metadata: errorCode ? { errorCode } : undefined,
+			operation: path,
+			outcome,
+			reason: errorCode,
+			request: getAuditRequestContext(context),
+			source: "orpc",
+			target: { id: organizationId },
+		});
+	} catch (auditError) {
+		log.error({
+			service: "rpc",
+			component: "audit_mutation",
+			audit_error: auditError,
+			operation: path,
+			outcome,
+		});
+	}
+}
+
+export async function runAuditedMutation<T>(
+	path: string,
+	context: Context,
+	fn: () => PromiseLike<T> | T
+): Promise<T> {
+	if (!isAuditedMutationPath(path)) {
+		return await fn();
+	}
+
+	try {
+		const result = await fn();
+		await writeMutationAudit(context, path, "success");
+		return result;
+	} catch (error) {
+		await writeMutationAudit(context, path, getAuditOutcome(error), error);
+		throw error;
+	}
+}

--- a/packages/rpc/src/orpc.ts
+++ b/packages/rpc/src/orpc.ts
@@ -117,6 +117,7 @@ export const createRPCContext = async (
 	return {
 		db,
 		auth,
+		auditOrganizationId: undefined as string | undefined,
 		session: session?.session,
 		user,
 		apiKey: apiKey ?? undefined,

--- a/packages/rpc/src/orpc.ts
+++ b/packages/rpc/src/orpc.ts
@@ -13,6 +13,7 @@ import {
 	setRpcProcedureType,
 } from "./lib/rpc-log-context";
 import { runTracked } from "./middleware/track-mutation";
+import { runAuditedMutation } from "./middleware/audit-mutation";
 import { type BillingOwner, getBillingOwner } from "./utils/billing";
 import { getOrganizationOwnerId } from "./utils/organization";
 
@@ -73,7 +74,7 @@ export function createServiceAuth(
 }
 
 export const createRPCContext = async (
-	opts: { headers: Headers },
+	opts: { headers: Headers; requestId?: string },
 	preResolved?: PreResolvedAuth
 ) => {
 	const [session, apiKey] = preResolved
@@ -169,11 +170,29 @@ export const sessionProcedure = protectedProcedure.use(
 );
 
 export const trackedProcedure = protectedProcedure.use(
-	({ context, next, path }) => runTracked(path.join("."), context, next)
+	({ context, next, path }) => {
+		const procedurePath = path.join(".");
+		return runTracked(procedurePath, context, () =>
+			runAuditedMutation(procedurePath, context, next)
+		);
+	}
 );
 
 export const trackedSessionProcedure = sessionProcedure.use(
-	({ context, next, path }) => runTracked(path.join("."), context, next)
+	({ context, next, path }) => {
+		const procedurePath = path.join(".");
+		return runTracked(procedurePath, context, () =>
+			runAuditedMutation(procedurePath, context, next)
+		);
+	}
+);
+
+export const auditedProcedure = protectedProcedure.use(
+	({ context, next, path }) => runAuditedMutation(path.join("."), context, next)
+);
+
+export const auditedSessionProcedure = sessionProcedure.use(
+	({ context, next, path }) => runAuditedMutation(path.join("."), context, next)
 );
 
 export { os };

--- a/packages/rpc/src/root.ts
+++ b/packages/rpc/src/root.ts
@@ -3,6 +3,7 @@ import { alarmsRouter } from "./routers/alarms";
 import { annotationsRouter } from "./routers/annotations";
 import { anomaliesRouter } from "./routers/anomalies";
 import { apikeysRouter } from "./routers/apikeys";
+import { auditRouter } from "./routers/audit";
 import { autocompleteRouter } from "./routers/autocomplete";
 import { billingRouter } from "./routers/billing";
 import { feedbackRouter } from "./routers/feedback";
@@ -28,6 +29,7 @@ export const appRouter = {
 	alarms: alarmsRouter,
 	anomalies: anomaliesRouter,
 	annotations: annotationsRouter,
+	audit: auditRouter,
 	websites: websitesRouter,
 	funnels: funnelsRouter,
 	goals: goalsRouter,

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -64,7 +64,7 @@ const chartContextSchema = z.object({
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
-	chartContext: z.unknown(),
+	chartContext: chartContextSchema,
 	chartType: z.string(),
 	color: z.string(),
 	createdAt: z.coerce.date(),

--- a/packages/rpc/src/routers/audit.ts
+++ b/packages/rpc/src/routers/audit.ts
@@ -1,0 +1,158 @@
+import {
+	auditActionNames,
+	auditActions,
+	auditOutcomes,
+} from "@databuddy/shared/audit";
+import {
+	decodeAuditCursor,
+	encodeAuditCursor,
+	getAuditEvent,
+	listAuditEvents,
+	MAX_AUDIT_PAGE_SIZE,
+	type AuditCursor,
+} from "@databuddy/services/audit";
+import { z } from "zod";
+import { rpcError } from "../errors";
+import { appendRpcAuditEventBestEffort } from "../lib/audit";
+import { sessionProcedure } from "../orpc";
+import { withWorkspace } from "../procedures/with-workspace";
+
+const auditEventSchema = z.object({
+	action: z.string(),
+	actorDisplayName: z.string().nullable(),
+	actorId: z.string(),
+	actorType: z.enum(["user", "api", "system", "agent"]),
+	changes: z.record(z.string(), z.unknown()),
+	createdAt: z.coerce.date(),
+	id: z.string(),
+	ip: z.string().nullable(),
+	metadata: z.record(z.string(), z.unknown()),
+	operation: z.string().nullable(),
+	organizationId: z.string(),
+	outcome: z.enum(["success", "failure", "denied"]),
+	reason: z.string().nullable(),
+	requestId: z.string().nullable(),
+	source: z.enum(["orpc", "better_auth", "public_api", "worker"]),
+	targetDisplayName: z.string().nullable(),
+	targetId: z.string(),
+	targetType: z.string(),
+	userAgent: z.string().nullable(),
+});
+
+const auditListInputSchema = z.object({
+	action: z.enum(auditActionNames).optional(),
+	actorId: z.string().min(1).optional(),
+	cursor: z.string().min(1).optional(),
+	limit: z.number().int().min(1).max(MAX_AUDIT_PAGE_SIZE).default(50),
+	organizationId: z.string().min(1).optional(),
+	outcome: z.enum(auditOutcomes).optional(),
+	targetId: z.string().min(1).optional(),
+});
+
+const auditListOutputSchema = z.object({
+	events: z.array(auditEventSchema),
+	hasMore: z.boolean(),
+	nextCursor: z.string().nullable(),
+});
+
+function getOrganizationId(
+	context: Parameters<typeof withWorkspace>[0],
+	organizationId?: string
+): string {
+	const resolved = organizationId ?? context.organizationId;
+	if (!resolved) {
+		throw rpcError.badRequest("Organization ID is required");
+	}
+	return resolved;
+}
+
+export const auditRouter = {
+	list: sessionProcedure
+		.route({
+			description:
+				"Lists tenant-scoped audit events for organization administrators and owners.",
+			method: "POST",
+			path: "/audit/list",
+			summary: "List audit events",
+			tags: ["Audit"],
+		})
+		.input(auditListInputSchema)
+		.output(auditListOutputSchema)
+		.handler(async ({ context, input }) => {
+			const organizationId = getOrganizationId(context, input.organizationId);
+			await withWorkspace(context, {
+				organizationId,
+				permissions: ["read"],
+				resource: "audit_log",
+			});
+
+			let cursor: AuditCursor | undefined;
+			if (input.cursor) {
+				const decodedCursor = decodeAuditCursor(input.cursor);
+				if (!decodedCursor) {
+					throw rpcError.badRequest("Invalid audit cursor");
+				}
+				cursor = decodedCursor;
+			}
+
+			const rows = await listAuditEvents(context.db, {
+				action: input.action,
+				actorId: input.actorId,
+				cursor,
+				limit: input.limit,
+				organizationId,
+				outcome: input.outcome,
+				targetId: input.targetId,
+			});
+			const events = rows.slice(0, input.limit);
+			const lastEvent = events.at(-1);
+
+			await appendRpcAuditEventBestEffort(context, organizationId, {
+				action: auditActions.AUDIT_LOG_VIEWED,
+				operation: "audit.list",
+				target: { id: organizationId },
+			});
+
+			return {
+				events,
+				hasMore: rows.length > input.limit,
+				nextCursor: lastEvent ? encodeAuditCursor(lastEvent) : null,
+			};
+		}),
+
+	get: sessionProcedure
+		.route({
+			description:
+				"Returns one tenant-scoped audit event for organization administrators and owners.",
+			method: "POST",
+			path: "/audit/get",
+			summary: "Get an audit event",
+			tags: ["Audit"],
+		})
+		.input(
+			z.object({
+				id: z.string().min(1),
+				organizationId: z.string().min(1).optional(),
+			})
+		)
+		.output(z.object({ event: auditEventSchema.nullable() }))
+		.handler(async ({ context, input }) => {
+			const organizationId = getOrganizationId(context, input.organizationId);
+			await withWorkspace(context, {
+				organizationId,
+				permissions: ["read"],
+				resource: "audit_log",
+			});
+
+			const event = await getAuditEvent(context.db, organizationId, input.id);
+			if (event) {
+				await appendRpcAuditEventBestEffort(context, organizationId, {
+					action: auditActions.AUDIT_LOG_EVENT_VIEWED,
+					operation: "audit.get",
+					target: { id: event.id },
+				});
+			}
+
+			return { event };
+		}),
+};

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -8,7 +8,9 @@ import {
 	withTransaction,
 } from "@databuddy/db";
 import {
+	buildFlagChangeSnapshot,
 	flagChangeEvents,
+	type TargetGroups,
 	flags,
 	flagsToTargetGroups,
 } from "@databuddy/db/schema";
@@ -235,7 +237,7 @@ const checkCircularDependency = async (
 
 interface FlagRelation {
 	flagsToTargetGroups: Array<{
-		targetGroup: { deletedAt: Date | null; [key: string]: unknown } | null;
+		targetGroup: TargetGroups | null;
 	}>;
 }
 
@@ -247,45 +249,46 @@ function flattenTargetGroups<T extends FlagRelation>(flag: T) {
 	return { ...rest, targetGroups };
 }
 
-function buildFlagChangeSnapshot(flag: {
-	defaultValue: boolean;
-	dependencies?: string[] | null;
-	description?: string | null;
-	environment?: string | null;
-	key: string;
-	name?: string | null;
-	persistAcrossAuth: boolean;
-	rolloutBy?: string | null;
-	rolloutPercentage?: number | null;
-	status: "active" | "inactive" | "archived";
-	type: "boolean" | "rollout" | "multivariant";
-	variants?: Array<{
-		description?: string;
-		key: string;
-		type: "string" | "number" | "json";
-		value: unknown;
-		weight?: number;
-	}> | null;
-}) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
-}
+const flagTargetGroupOutputSchema = z.object({
+	color: z.string(),
+	createdAt: z.coerce.date(),
+	createdBy: z.string(),
+	deletedAt: z.coerce.date().nullable(),
+	description: z.string().nullable(),
+	id: z.string(),
+	name: z.string(),
+	rules: z.array(userRuleSchema),
+	updatedAt: z.coerce.date(),
+	websiteId: z.string(),
+});
+
+const flagOutputSchema = z.object({
+	createdAt: z.coerce.date(),
+	createdBy: z.string(),
+	defaultValue: z.boolean(),
+	deletedAt: z.coerce.date().nullable(),
+	dependencies: z.array(z.string()).nullable(),
+	description: z.string().nullable(),
+	environment: z.string().nullable(),
+	id: z.string(),
+	key: z.string(),
+	name: z.string().nullable(),
+	organizationId: z.string().nullable(),
+	payload: z.record(z.string(), z.unknown()).nullable(),
+	persistAcrossAuth: z.boolean(),
+	rules: z.array(userRuleSchema).nullable(),
+	rolloutBy: z.string().nullable(),
+	rolloutPercentage: z.number().nullable(),
+	status: z.enum(["active", "inactive", "archived"]),
+	targetGroupIds: z.array(z.string()).nullable(),
+	targetGroups: z.array(flagTargetGroupOutputSchema).optional(),
+	type: z.enum(["boolean", "rollout", "multivariant"]),
+	updatedAt: z.coerce.date(),
+	variants: z.array(variantSchema).nullable(),
+	websiteId: z.string().nullable(),
+});
 
 const successOutputSchema = z.object({ success: z.literal(true) });
-
-const flagOutputSchema = z.record(z.string(), z.unknown());
 
 export const flagsRouter = {
 	list: publicProcedure

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -11,6 +11,7 @@ import { chQuery } from "@databuddy/db/clickhouse";
 import {
 	buildFlagChangeSnapshot,
 	flagChangeEvents,
+	type FlagUserRule,
 	type TargetGroups,
 	flags,
 	flagsToTargetGroups,
@@ -18,6 +19,7 @@ import {
 import { createDrizzleCache, redis } from "@databuddy/redis";
 import {
 	flagFormShape,
+	FLAG_STATS_WINDOW_DAYS,
 	userRuleSchema,
 	variantSchema,
 } from "@databuddy/shared/flags";
@@ -110,7 +112,7 @@ const listFlagsSchema = z
 
 const flagStatsSchema = z.object({
 	websiteId: z.string(),
-	days: z.number().int().min(1).max(90).default(30),
+	days: z.number().int().min(1).max(90).default(FLAG_STATS_WINDOW_DAYS),
 });
 
 const getFlagSchema = z
@@ -255,6 +257,13 @@ function flattenTargetGroups<T extends FlagRelation>(flag: T) {
 	return { ...rest, targetGroups };
 }
 
+const flagRuleOutputSchema = z.custom<FlagUserRule>(
+	(value) =>
+		Boolean(value && typeof value === "object" && !Array.isArray(value)),
+	"Expected a flag rule object"
+);
+const flagRulesOutputSchema = z.array(flagRuleOutputSchema);
+
 const flagTargetGroupOutputSchema = z.object({
 	color: z.string(),
 	createdAt: z.coerce.date(),
@@ -263,7 +272,7 @@ const flagTargetGroupOutputSchema = z.object({
 	description: z.string().nullable(),
 	id: z.string(),
 	name: z.string(),
-	rules: z.array(userRuleSchema),
+	rules: flagRulesOutputSchema,
 	updatedAt: z.coerce.date(),
 	websiteId: z.string(),
 });
@@ -282,7 +291,7 @@ const flagOutputSchema = z.object({
 	organizationId: z.string().nullable(),
 	payload: z.record(z.string(), z.unknown()).nullable(),
 	persistAcrossAuth: z.boolean(),
-	rules: z.array(userRuleSchema).nullable(),
+	rules: flagRulesOutputSchema.nullable(),
 	rolloutBy: z.string().nullable(),
 	rolloutPercentage: z.number().nullable(),
 	status: z.enum(["active", "inactive", "archived"]),
@@ -290,6 +299,7 @@ const flagOutputSchema = z.object({
 	targetGroups: z.array(flagTargetGroupOutputSchema).optional(),
 	type: z.enum(["boolean", "rollout", "multivariant"]),
 	updatedAt: z.coerce.date(),
+	userId: z.string().nullable(),
 	variants: z.array(variantSchema).nullable(),
 	websiteId: z.string().nullable(),
 });
@@ -373,10 +383,21 @@ export const flagsRouter = {
 		.handler(async ({ context, input }) => {
 			const workspace = await authorizeFlagRead(context, input);
 			requireAuthedFlagRead(workspace);
+			const scopedFlags = await context.db
+				.select({ key: flags.key })
+				.from(flags)
+				.where(
+					and(eq(flags.websiteId, input.websiteId), isNull(flags.deletedAt))
+				);
+			const flagKeys = [...new Set(scopedFlags.map((flag) => flag.key))];
+			if (flagKeys.length === 0) {
+				return [];
+			}
 
 			const startDate = new Date(
 				Date.now() - input.days * 24 * 60 * 60 * 1000
 			).toISOString();
+			const endDate = new Date().toISOString();
 			const rows = await chQuery<{
 				evaluated_users: number;
 				evaluation_count: number;
@@ -402,8 +423,9 @@ export const flagsRouter = {
 							)
 						)
 						AND timestamp >= parseDateTimeBestEffort({startDate:String})
-						AND JSONExtractString(properties, 'flag') != ''
-				)
+						AND timestamp < parseDateTimeBestEffort({endDate:String})
+						AND JSONExtractString(properties, 'flag') IN {flagKeys:Array(String)}
+					)
 				SELECT
 					flag_key,
 					max(timestamp) AS last_evaluated_at,
@@ -413,7 +435,7 @@ export const flagsRouter = {
 				FROM evaluations
 				GROUP BY flag_key
 				ORDER BY last_evaluated_at DESC`,
-				{ startDate, websiteId: input.websiteId },
+				{ endDate, flagKeys, startDate, websiteId: input.websiteId },
 				{ readonly: true }
 			);
 

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -7,6 +7,7 @@ import {
 	notDeleted,
 	withTransaction,
 } from "@databuddy/db";
+import { chQuery } from "@databuddy/db/clickhouse";
 import {
 	buildFlagChangeSnapshot,
 	flagChangeEvents,
@@ -106,6 +107,11 @@ const listFlagsSchema = z
 		status: z.enum(["active", "inactive", "archived"]).optional(),
 	})
 	.refine(requireScope, scopeRefinement);
+
+const flagStatsSchema = z.object({
+	websiteId: z.string(),
+	days: z.number().int().min(1).max(90).default(30),
+});
 
 const getFlagSchema = z
 	.object({ id: z.string(), ...flagScopeFields })
@@ -288,6 +294,14 @@ const flagOutputSchema = z.object({
 	websiteId: z.string().nullable(),
 });
 
+const flagStatsOutputSchema = z.object({
+	evaluatedUsers: z.number(),
+	evaluationCount: z.number(),
+	identifiedUsers: z.number(),
+	key: z.string(),
+	lastEvaluatedAt: z.coerce.date().nullable(),
+});
+
 const successOutputSchema = z.object({ success: z.literal(true) });
 
 export const flagsRouter = {
@@ -343,6 +357,75 @@ export const flagsRouter = {
 					return flagsList.map(flattenTargetGroups);
 				},
 			});
+		}),
+
+	stats: publicProcedure
+		.route({
+			description:
+				"Returns recent feature flag evaluation stats for a website. Requires scope read permission.",
+			method: "POST",
+			path: "/flags/stats",
+			summary: "Get flag evaluation stats",
+			tags: ["Flags"],
+		})
+		.input(flagStatsSchema)
+		.output(z.array(flagStatsOutputSchema))
+		.handler(async ({ context, input }) => {
+			const workspace = await authorizeFlagRead(context, input);
+			requireAuthedFlagRead(workspace);
+
+			const startDate = new Date(
+				Date.now() - input.days * 24 * 60 * 60 * 1000
+			).toISOString();
+			const rows = await chQuery<{
+				evaluated_users: number;
+				evaluation_count: number;
+				flag_key: string;
+				identified_users: number;
+				last_evaluated_at: string | null;
+			}>(
+				`WITH evaluations AS (
+					SELECT
+						JSONExtractString(properties, 'flag') AS flag_key,
+						timestamp,
+						profile_id,
+						ifNull(anonymous_id, '') AS anonymous_id,
+						if(empty(profile_id), ifNull(anonymous_id, ''), profile_id) AS visitor_id
+					FROM analytics.custom_events
+					PREWHERE event_name = '$flag_evaluated'
+					WHERE
+						(
+							owner_id = {websiteId:String}
+							OR (
+								website_id = {websiteId:String}
+								AND owner_id != {websiteId:String}
+							)
+						)
+						AND timestamp >= parseDateTimeBestEffort({startDate:String})
+						AND JSONExtractString(properties, 'flag') != ''
+				)
+				SELECT
+					flag_key,
+					max(timestamp) AS last_evaluated_at,
+					count() AS evaluation_count,
+					uniqCombined64If(visitor_id, visitor_id != '') AS evaluated_users,
+					uniqCombined64If(profile_id, profile_id != '') AS identified_users
+				FROM evaluations
+				GROUP BY flag_key
+				ORDER BY last_evaluated_at DESC`,
+				{ startDate, websiteId: input.websiteId },
+				{ readonly: true }
+			);
+
+			return rows.map((row) => ({
+				evaluatedUsers: Number(row.evaluated_users),
+				evaluationCount: Number(row.evaluation_count),
+				identifiedUsers: Number(row.identified_users),
+				key: row.flag_key,
+				lastEvaluatedAt: row.last_evaluated_at
+					? new Date(row.last_evaluated_at)
+					: null,
+			}));
 		}),
 
 	getById: publicProcedure

--- a/packages/rpc/src/routers/funnels.ts
+++ b/packages/rpc/src/routers/funnels.ts
@@ -31,7 +31,16 @@ const cache = funnelCache;
 
 const filterSchema = z.object({
 	field: z.string(),
-	operator: z.enum(["equals", "contains", "not_equals", "in", "not_in"]),
+	operator: z.enum([
+		"contains",
+		"ends_with",
+		"equals",
+		"in",
+		"not_contains",
+		"not_equals",
+		"not_in",
+		"starts_with",
+	]),
 	value: z.union([z.string(), z.array(z.string())]),
 });
 
@@ -63,12 +72,12 @@ const getEffectiveStartDate = (
 const funnelListOutputSchema = z.object({
 	createdAt: z.coerce.date(),
 	description: z.string().nullable(),
-	filters: z.unknown().nullable(),
+	filters: z.array(filterSchema).nullable(),
 	id: z.string(),
 	ignoreHistoricData: z.boolean(),
 	isActive: z.boolean(),
 	name: z.string(),
-	steps: z.unknown(),
+	steps: z.array(funnelStepSchema),
 	updatedAt: z.coerce.date(),
 });
 
@@ -77,12 +86,12 @@ const funnelOutputSchema = z.object({
 	createdBy: z.string(),
 	deletedAt: z.nullable(z.coerce.date()),
 	description: z.string().nullable(),
-	filters: z.unknown().nullable(),
+	filters: z.array(filterSchema).nullable(),
 	id: z.string(),
 	ignoreHistoricData: z.boolean(),
 	isActive: z.boolean(),
 	name: z.string(),
-	steps: z.unknown(),
+	steps: z.array(funnelStepSchema),
 	updatedAt: z.coerce.date(),
 	websiteId: z.string(),
 });

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -35,7 +35,7 @@ import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
 import { logger } from "../lib/logger";
-import { type Context, protectedProcedure } from "../orpc";
+import { auditedProcedure, type Context, protectedProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 import {
 	getNextInsightRunAt,
@@ -1176,7 +1176,7 @@ export const insightGenerationRouter = {
 			return getConfig(organizationId);
 		}),
 
-	upsertConfig: protectedProcedure
+	upsertConfig: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/upsertConfig",
@@ -1196,7 +1196,7 @@ export const insightGenerationRouter = {
 			);
 		}),
 
-	addSlackDelivery: protectedProcedure
+	addSlackDelivery: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/addSlackDelivery",
@@ -1268,7 +1268,7 @@ export const insightGenerationRouter = {
 			});
 		}),
 
-	removeSlackDelivery: protectedProcedure
+	removeSlackDelivery: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/removeSlackDelivery",
@@ -1299,7 +1299,7 @@ export const insightGenerationRouter = {
 			}));
 		}),
 
-	triggerRun: protectedProcedure
+	triggerRun: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/triggerRun",

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -34,6 +34,7 @@ import { ORPCError } from "@orpc/server";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
+import { setAuditOrganization } from "../lib/audit";
 import { logger } from "../lib/logger";
 import { auditedProcedure, type Context, protectedProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
@@ -382,6 +383,7 @@ async function resolveOrganization(
 	if (!organizationId) {
 		throw rpcError.badRequest("Organization ID is required");
 	}
+	setAuditOrganization(context, organizationId);
 	await withWorkspace(context, {
 		organizationId,
 		resource: "organization",

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -44,6 +44,7 @@ import { rpcError } from "../errors";
 import { invalidateGoalsCache } from "../lib/goals-cache";
 import { invalidateFunnelsCache } from "../lib/funnels-cache";
 import { logger } from "../lib/logger";
+import { setAuditOrganization } from "../lib/audit";
 import {
 	auditedProcedure,
 	auditedSessionProcedure,
@@ -507,6 +508,7 @@ export async function appendInvestigationReply(
 	if (!insight) {
 		throw rpcError.notFound("insight", parsed.insightId);
 	}
+	setAuditOrganization(context, insight.organizationId);
 
 	await withWorkspace(context, {
 		allowCrossOrg: true,
@@ -724,6 +726,7 @@ export async function applyInsightAction(input: {
 	if (!target) {
 		throw rpcError.notFound("insight", parsed.insightId);
 	}
+	setAuditOrganization(context, target.organizationId);
 
 	const [latestObservation] = await db
 		.select({
@@ -1661,6 +1664,7 @@ export const insightsRouter = {
 			if (!reply) {
 				throw rpcError.notFound("insight reply", input.replyId);
 			}
+			setAuditOrganization(context, reply.organizationId);
 			await withWorkspace(context, {
 				allowCrossOrg: true,
 				organizationId: reply.organizationId,

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -44,7 +44,12 @@ import { rpcError } from "../errors";
 import { invalidateGoalsCache } from "../lib/goals-cache";
 import { invalidateFunnelsCache } from "../lib/funnels-cache";
 import { logger } from "../lib/logger";
-import { type Context, protectedProcedure, sessionProcedure } from "../orpc";
+import {
+	auditedProcedure,
+	auditedSessionProcedure,
+	type Context,
+	protectedProcedure,
+} from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 
 const INSIGHT_TIMELINE_ROWS_PER_KIND = 50;
@@ -1576,7 +1581,7 @@ export const insightsRouter = {
 			};
 		}),
 
-	reply: protectedProcedure
+	reply: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/reply",
@@ -1594,7 +1599,7 @@ export const insightsRouter = {
 			return { reply };
 		}),
 
-	applyAction: protectedProcedure
+	applyAction: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/actions/apply",
@@ -1608,7 +1613,7 @@ export const insightsRouter = {
 		),
 
 	// Keep the old route for clients that have not migrated to applyAction yet.
-	applyGoalAction: protectedProcedure
+	applyGoalAction: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/actions/goal/apply",
@@ -1621,7 +1626,7 @@ export const insightsRouter = {
 			applyInsightAction({ context, ...input })
 		),
 
-	retryReply: sessionProcedure
+	retryReply: auditedSessionProcedure
 		.route({
 			method: "POST",
 			path: "/insights/reply/retry",

--- a/packages/rpc/src/routers/revenue.ts
+++ b/packages/rpc/src/routers/revenue.ts
@@ -3,7 +3,7 @@ import { eq } from "@databuddy/db";
 import { revenueConfig } from "@databuddy/db/schema";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { protectedProcedure, sessionProcedure } from "../orpc";
+import { auditedSessionProcedure, protectedProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 import { revenueUpsertInputSchema } from "./revenue.schemas";
 
@@ -63,7 +63,7 @@ export const revenueRouter = {
 			};
 		}),
 
-	upsert: sessionProcedure
+	upsert: auditedSessionProcedure
 		.route({
 			description:
 				"Creates or updates revenue config. Requires configure permission.",
@@ -140,7 +140,7 @@ export const revenueRouter = {
 			};
 		}),
 
-	regenerateHash: sessionProcedure
+	regenerateHash: auditedSessionProcedure
 		.route({
 			description: "Regenerates webhook hash. Requires configure permission.",
 			method: "POST",

--- a/packages/rpc/src/utils/flags.ts
+++ b/packages/rpc/src/utils/flags.ts
@@ -7,7 +7,11 @@ import {
 	isNull,
 	withTransaction,
 } from "@databuddy/db";
-import { flagChangeEvents, flags } from "@databuddy/db/schema";
+import {
+	buildFlagChangeSnapshot,
+	flagChangeEvents,
+	flags,
+} from "@databuddy/db/schema";
 import {
 	createDrizzleCache,
 	invalidateFlagReadCaches,
@@ -84,42 +88,6 @@ export const getScopeCondition = (
 	}
 	return eq(table.organizationId, "");
 };
-
-function buildFlagChangeSnapshot(flag: {
-	defaultValue: boolean;
-	dependencies?: string[] | null;
-	description?: string | null;
-	environment?: string | null;
-	key: string;
-	name?: string | null;
-	persistAcrossAuth: boolean;
-	rolloutBy?: string | null;
-	rolloutPercentage?: number | null;
-	status: "active" | "inactive" | "archived";
-	type: "boolean" | "rollout" | "multivariant";
-	variants?: Array<{
-		description?: string;
-		key: string;
-		type: "string" | "number" | "json";
-		value: unknown;
-		weight?: number;
-	}> | null;
-}) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
-}
 
 interface FlagUpdateDependencyCascadingParams {
 	changedBy?: string;

--- a/packages/sdk/src/core/flags/flags-manager.ts
+++ b/packages/sdk/src/core/flags/flags-manager.ts
@@ -93,6 +93,8 @@ export abstract class BaseFlagsManager implements FlagsManager {
 
 	protected onCacheUpdated(): void {}
 
+	protected onContextCleared(): void {}
+
 	protected onFlagEvaluated(_key: string, _result: FlagResult): void {}
 
 	protected async runInit(): Promise<void> {
@@ -481,6 +483,7 @@ export abstract class BaseFlagsManager implements FlagsManager {
 			if (isStale(entry) && !this.shouldSkipFetch()) {
 				this.revalidate(key, cacheKey, this.config.user);
 			}
+			this.onFlagEvaluated(key, entry.result);
 			return {
 				on: entry.result.enabled,
 				status: entry.result.reason === "ERROR" ? "error" : "ready",
@@ -516,6 +519,7 @@ export abstract class BaseFlagsManager implements FlagsManager {
 			if (isStale(entry) && !this.shouldSkipFetch()) {
 				this.revalidate(key, cacheKey, this.config.user);
 			}
+			this.onFlagEvaluated(key, entry.result);
 			return entry.result.value as T;
 		}
 
@@ -728,6 +732,7 @@ export abstract class BaseFlagsManager implements FlagsManager {
 		this.cache.clear();
 		this.storage?.clear();
 		this.lastError = null;
+		this.onContextCleared();
 	}
 
 	private requestGenerationIsCurrent(generation: number): boolean {
@@ -838,6 +843,10 @@ export class BrowserFlagsManager extends BaseFlagsManager {
 
 	protected override onCacheUpdated(): void {
 		this.persist();
+	}
+
+	protected override onContextCleared(): void {
+		this.trackedFlags.clear();
 	}
 
 	protected override onFlagEvaluated(key: string, result: FlagResult): void {

--- a/packages/sdk/src/react/flags/flags-provider.tsx
+++ b/packages/sdk/src/react/flags/flags-provider.tsx
@@ -110,21 +110,10 @@ export function FlagsProvider({ children, ...config }: FlagsProviderProps) {
 				);
 			},
 
-			isOn: (key: string): boolean => {
-				const result = store.flags[key];
-				if (result) {
-					return result.enabled;
-				}
-				return manager.isEnabled(key).on;
-			},
+			isOn: (key: string): boolean => manager.isEnabled(key).on,
 
-			getValue: <T,>(key: string, defaultValue?: T): T => {
-				const result = store.flags[key];
-				if (result) {
-					return result.value as T;
-				}
-				return manager.getValue(key, defaultValue);
-			},
+			getValue: <T,>(key: string, defaultValue?: T): T =>
+				manager.getValue(key, defaultValue),
 
 			fetchFlag: (key: string) => manager.getFlag(key),
 			fetchAllFlags: () => manager.fetchAllFlags(),

--- a/packages/sdk/tests/flags.spec.ts
+++ b/packages/sdk/tests/flags.spec.ts
@@ -216,6 +216,64 @@ test.describe("BrowserFlagsManager", () => {
 	});
 
 	test.describe("isEnabled (synchronous)", () => {
+		test("tracks cached evaluations from the synchronous path", async ({ page }) => {
+			const tracked = await page.evaluate(async () => {
+				const events: Array<{
+					name: string;
+					properties?: Record<string, unknown>;
+				}> = [];
+				window.databuddy = {
+					track: (name, properties) => events.push({ name, properties }),
+				} as typeof window.databuddy;
+
+				const manager = new window.__SDK__.BrowserFlagsManager({
+					config: { clientId: "test-id", autoFetch: false },
+				});
+				await manager.fetchAllFlags();
+				manager.isEnabled("feature-on");
+				manager.destroy();
+				return events;
+			});
+
+			expect(tracked).toEqual([
+				{
+					name: "$flag_evaluated",
+					properties: {
+						flag: "feature-on",
+						value: true,
+						variant: undefined,
+						enabled: true,
+					},
+				},
+			]);
+		});
+
+		test("tracks a new evaluation after the user context changes", async ({
+			page,
+		}) => {
+			const trackedCount = await page.evaluate(async () => {
+				let count = 0;
+				window.databuddy = {
+					track: () => {
+						count += 1;
+					},
+				} as typeof window.databuddy;
+
+				const manager = new window.__SDK__.BrowserFlagsManager({
+					config: { clientId: "test-id", autoFetch: false },
+				});
+				await manager.fetchAllFlags();
+				manager.isEnabled("feature-on");
+				manager.updateUser({ userId: "user-1" });
+				await new Promise((resolve) => setTimeout(resolve, 50));
+				manager.isEnabled("feature-on");
+				manager.destroy();
+				return count;
+			});
+
+			expect(trackedCount).toBe(2);
+		});
+
 		test("returns loading state for uncached flag", async ({ page }) => {
 			const state = await page.evaluate(() => {
 				const manager = new window.__SDK__.BrowserFlagsManager({

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -11,7 +11,8 @@
     "./websites": "./src/websites.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test src"
   },
   "dependencies": {
     "@databuddy/db": "workspace:*",

--- a/packages/services/src/audit.test.ts
+++ b/packages/services/src/audit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { auditActions } from "@databuddy/shared/audit";
 import {
 	appendAuditEventInTransaction,
+	replayAuditOutbox,
 	type AuditDatabase,
 } from "./audit";
 
@@ -23,5 +24,75 @@ describe("appendAuditEventInTransaction", () => {
 				target: { id: "key_123" },
 			})
 		).rejects.toThrow("audit ledger unavailable");
+	});
+});
+
+describe("replayAuditOutbox", () => {
+	const payload = {
+		action: "rpc.mutation",
+		actorId: "user_123",
+		actorType: "user" as const,
+		changes: {},
+		id: "event_123",
+		metadata: {},
+		organizationId: "org_123",
+		outcome: "success" as const,
+		source: "orpc" as const,
+		targetId: "org_123",
+		targetType: "organization",
+	};
+
+	test("replays durable rows and reports the result", async () => {
+		const operations: string[] = [];
+		const database = {
+			delete: () => ({
+				where: async () => {
+					operations.push("delete");
+				},
+			}),
+			insert: () => ({
+				values: () => ({
+					onConflictDoNothing: async () => {
+						operations.push("insert");
+					},
+				}),
+			}),
+			select: () => ({
+				from: () => ({
+					orderBy: () => ({
+						limit: async () => [
+							{ id: "outbox_123", payload, createdAt: new Date() },
+						],
+					}),
+				}),
+			}),
+		} as unknown as AuditDatabase;
+
+		expect(await replayAuditOutbox(database)).toEqual({ failed: 0, replayed: 1 });
+		expect(operations).toEqual(["insert", "delete"]);
+	});
+
+	test("keeps failed rows visible for the next replay", async () => {
+		const database = {
+			delete: () => ({ where: async () => undefined }),
+			insert: () => ({
+				values: () => ({
+					onConflictDoNothing: async () => {
+						throw new Error("ledger unavailable");
+					},
+				}),
+			}),
+			select: () => ({
+				from: () => ({
+					orderBy: () => ({
+						limit: async () => [
+							{ id: "outbox_123", payload, createdAt: new Date() },
+						],
+					}),
+				}),
+			}),
+		} as unknown as AuditDatabase;
+
+		expect(await replayAuditOutbox(database)).toEqual({ failed: 1, replayed: 0 });
 	});
 });

--- a/packages/services/src/audit.ts
+++ b/packages/services/src/audit.ts
@@ -111,13 +111,14 @@ export function appendAuditEventInTransaction<
 export async function replayAuditOutbox(
 	database: AuditDatabase,
 	limit = 100
-): Promise<number> {
+): Promise<{ failed: number; replayed: number }> {
 	const rows = await database
 		.select()
 		.from(auditOutboxEvents)
 		.orderBy(asc(auditOutboxEvents.createdAt))
 		.limit(Math.min(Math.max(limit, 1), 100));
 	let replayed = 0;
+	let failed = 0;
 	for (const row of rows) {
 		try {
 			await database
@@ -130,9 +131,10 @@ export async function replayAuditOutbox(
 			replayed += 1;
 		} catch {
 			// Leave the durable entry for the next bounded replay attempt.
+			failed += 1;
 		}
 	}
-	return replayed;
+	return { failed, replayed };
 }
 
 export async function appendAuditEvent<TAction extends AuditActionDefinition>(
@@ -174,8 +176,6 @@ export async function appendAuditEvent<TAction extends AuditActionDefinition>(
 		reason: input.reason,
 		target: { id: input.target.id },
 	});
-
-	replayAuditOutbox(database).catch(() => undefined);
 
 	return event;
 }
@@ -228,6 +228,8 @@ export interface ListAuditEventsInput {
 	targetId?: string;
 }
 
+export const MAX_AUDIT_PAGE_SIZE = 100;
+
 export async function listAuditEvents(
 	database: AuditDatabase,
 	input: ListAuditEventsInput
@@ -259,12 +261,13 @@ export async function listAuditEvents(
 		}
 	}
 
+	const limit = Math.min(Math.max(input.limit, 1), MAX_AUDIT_PAGE_SIZE);
 	return await database
 		.select()
 		.from(auditEvents)
 		.where(and(...conditions))
 		.orderBy(desc(auditEvents.createdAt), desc(auditEvents.id))
-		.limit(input.limit + 1);
+		.limit(limit + 1);
 }
 
 export async function getAuditEvent(

--- a/packages/shared/src/audit.ts
+++ b/packages/shared/src/audit.ts
@@ -58,6 +58,8 @@ function defineAction<
 export const auditActions = {
 	AUDIT_LOG_VIEWED: defineAction("audit_log.viewed", "audit_log"),
 	AUDIT_LOG_EVENT_VIEWED: defineAction("audit_log.event_viewed", "audit_log"),
+	RPC_MUTATION: defineAction("rpc.mutation", "organization"),
+	FLAG_CHANGED: defineAction("flag.changed", "flag"),
 	API_KEY_CREATED: defineAction("api_key.created", "api_key"),
 	API_KEY_UPDATED: defineAction("api_key.updated", "api_key"),
 	API_KEY_REVOKED: defineAction("api_key.revoked", "api_key"),

--- a/packages/shared/src/flags/index.ts
+++ b/packages/shared/src/flags/index.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+export const FLAG_STATS_WINDOW_DAYS = 30;
+
 export const userRuleSchema = z.object({
 	type: z.enum(["user_id", "email", "property"]),
 	operator: z.enum([

--- a/packages/test/src/context.ts
+++ b/packages/test/src/context.ts
@@ -57,6 +57,7 @@ export function context(overrides: ContextOverrides = {}): Context {
 		apiKey: overrides.apiKey,
 		getBilling: async () => undefined,
 		organizationId: overrides.organizationId ?? null,
+		auditOrganizationId: undefined,
 		headers: overrides.headers ?? new Headers(),
 		anonymousId: null,
 		sessionId: null,

--- a/packages/tracker/src/core/types.ts
+++ b/packages/tracker/src/core/types.ts
@@ -31,7 +31,7 @@ export type TrackerOptions = {
 	batchTimeout?: number;
 
 	// Filtering & masking
-	filter?: (event: any) => boolean;
+	filter?: (event: BaseEvent) => boolean;
 	skipPatterns?: string[];
 	maskPatterns?: string[];
 };
@@ -74,7 +74,7 @@ export type BaseEvent = {
 	sessionStartTime?: number;
 	timestamp: number;
 	type?: string;
-	[key: string]: any;
+	[key: string]: unknown;
 };
 
 export type WebVitalMetricName = "FCP" | "LCP" | "CLS" | "INP" | "TTFB" | "FPS";

--- a/packages/tracker/src/core/utils.ts
+++ b/packages/tracker/src/core/utils.ts
@@ -265,17 +265,17 @@ export function getTrackerConfig(): TrackerOptions {
 }
 
 export const logger = {
-	log: (...args: any[]) => {
+	log: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.log("[Databuddy]", ...args);
 		}
 	},
-	error: (...args: any[]) => {
+	error: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.error("[Databuddy]", ...args);
 		}
 	},
-	warn: (...args: any[]) => {
+	warn: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.warn("[Databuddy]", ...args);
 		}


### PR DESCRIPTION
## Summary
- keep the revenue empty state below the analytics toolbar
- give the state a consistent centered content area

## Validation
- bun run lint
- bun run check-types
- bun run test
- Dashboard Playwright CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centers and unifies revenue empty/error states, promotes a sturdier Realtime map, adds an Organization Audit Log, and surfaces feature flag activity by tracking SDK evaluations. Disabled queries no longer appear to load forever, and flag admin audit writes are now best‑effort so responses don’t break.

- Revenue: replaces chart, attribution tables, and settings empty/error views with a centered `EmptyState` plus Retry; extracts `revenue-settings-sheet.tsx`; chart empty view and legend/ticks polished; `useDynamicQuery`/`useBatchDynamicQuery` stop treating `isPending` as loading.
- Realtime: refactors the map for stability and accessibility (hit map and pixel grids, pointer pan/zoom, double‑click reset, DPR/resize awareness, stable tooltips), adds types to the page, and removes the alpha flag so Realtime appears in the sidebar for non‑demo sites.
- Audit: adds an Audit Log page under Organization Settings and an `audit` RPC router (list/get) with pagination; RPC contexts now include request ID and trusted IP; introduces audited‑mutation middleware that records `rpc.mutation` for privileged verbs; attributes audits to the target organization; durable outbox replays now report replayed/failed counts; hardens UI against fetch errors; adds tests across DB, RPC, and services.
- Feature Flags: adds a `flags.stats` RPC for observed activity over `FLAG_STATS_WINDOW_DAYS`; dashboard Flags list shows an Activity column with an accuracy tooltip and refresh re-fetches stats; preserves user‑scoped identity fields in `flags.list`; docs clarify these numbers are directional.
- SDK/Tracker: records `$flag_evaluated` for cached and synchronous flag reads in the browser manager; simplifies `FlagsProvider` sync reads; tightens tracker event types.
- API: simplifies admin flag audit failures to best effort; public flag admin endpoints append audits with request ID/IP without breaking responses.

- Review: verify revenue configured/empty/error/invalid‑currency states on narrow/wide screens and that Retry refetches; confirm no view stays stuck when a query is disabled; exercise Realtime hover/pan/zoom/reset/resize; visit Audit Log and ensure events appear (flags, revenue, insights) with request ID/IP and correct org; confirm Flags Activity populates, refreshes, and `flags.list` preserves user identity fields.

<sup>Written for commit 20d1fb0f7e626e789476d51221f24d29975fa272. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

