### PR TITLE
feat(audit): add organization audit visibility and mutation coverage

### DIFF
--- a/apps/api/src/audit/audit-outbox-replay.ts
+++ b/apps/api/src/audit/audit-outbox-replay.ts
@@ -21,7 +21,16 @@ export function startAuditOutboxReplayLoop(): AuditOutboxReplayLoop {
 			return active;
 		}
 		active = replayAuditOutbox(db)
-			.then(() => undefined)
+			.then(({ failed, replayed }) => {
+				if (replayed > 0 || failed > 0) {
+					log.info({
+						service: "api",
+						component: "audit_outbox_replay",
+						replayed,
+						failed,
+					});
+				}
+			})
 			.catch((error) => {
 				log.error({
 					service: "api",

--- a/apps/api/src/routes/public/flags.ts
+++ b/apps/api/src/routes/public/flags.ts
@@ -16,6 +16,7 @@ import {
 	withTransaction,
 } from "@databuddy/db";
 import {
+	buildFlagChangeSnapshot,
 	flagChangeEvents,
 	type FlagUserRule,
 	type FlagVariant,
@@ -25,7 +26,11 @@ import {
 import { cacheNamespaces, cacheTags, cacheable } from "@databuddy/redis";
 import { getRateLimitHeaders, ratelimit } from "@databuddy/redis/rate-limit";
 import { invalidateFlagCache } from "@databuddy/rpc/flags";
+import { appendAuditEvent } from "@databuddy/services/audit";
+import { auditActions } from "@databuddy/shared/audit";
+import { getTrustedClientIp } from "@databuddy/shared/utils/trusted-client-ip";
 import { randomUUIDv7 } from "bun";
+import { getRequestId } from "@/http/request-id";
 import { Elysia, t } from "elysia";
 import { useLogger } from "evlog/elysia";
 import { LRUCache } from "lru-cache";
@@ -668,6 +673,7 @@ interface FlagAdminSuccess {
 }
 
 interface FlagAdminFailure {
+	apiKey?: ApiKeyRow;
 	error: string;
 	ok: false;
 	status: 401 | 403;
@@ -701,9 +707,50 @@ async function resolveFlagAdmin(
 		hasWebsiteAccess = Boolean(website);
 	}
 	if (!(hasWebsiteAccess || hasOrgAccess)) {
-		return { ok: false, status: 403, error: "Forbidden" };
+		return { apiKey, ok: false, status: 403, error: "Forbidden" };
 	}
 	return { ok: true, apiKey };
+}
+
+async function recordPublicFlagAudit(input: {
+	action: "denied" | "failure" | "success";
+	apiKey?: ApiKeyRow;
+	operation: string;
+	request: Request;
+	reason?: string;
+	targetId: string;
+	targetName?: string;
+}): Promise<void> {
+	const organizationId = input.apiKey?.organizationId;
+	if (!(organizationId && input.apiKey)) {
+		return;
+	}
+
+	try {
+		await appendAuditEvent(db, organizationId, {
+			action: auditActions.FLAG_CHANGED,
+			actor: {
+				displayName: input.apiKey.name,
+				id: input.apiKey.id,
+				type: "api",
+			},
+			operation: input.operation,
+			outcome: input.action,
+			reason: input.reason,
+			request: {
+				ip: getTrustedClientIp(input.request.headers),
+				requestId: getRequestId(input.request),
+				userAgent: input.request.headers.get("user-agent") ?? undefined,
+			},
+			source: "public_api",
+			target: { displayName: input.targetName, id: input.targetId },
+		});
+	} catch (error) {
+		useLogger().error(
+			error instanceof Error ? error : new Error(String(error)),
+			{ flags: { audit: true, operation: input.operation } }
+		);
+	}
 }
 
 function invalidateMemCacheForClient(clientId: string) {
@@ -732,23 +779,6 @@ function resolveScope(
 		return { websiteId: null, organizationId: clientId };
 	}
 	return { websiteId: null, organizationId: null };
-}
-
-function buildFlagChangeSnapshot(flag: typeof flags.$inferSelect) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
 }
 
 interface BulkFlagInput extends UserContext {
@@ -1106,17 +1136,41 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: auth.error,
+						request,
+						targetId: body.clientId,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: "Forbidden",
+						request,
+						targetId: body.clientId,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
 
 				const scope = resolveScope(auth.apiKey, body.clientId);
 				if (!(scope.websiteId || scope.organizationId)) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.create",
+						reason: "Insufficient permissions",
+						request,
+						targetId: body.clientId,
+					});
 					set.status = 403;
 					return { error: "Insufficient permissions" };
 				}
@@ -1257,6 +1311,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					result.key
 				);
 				invalidateMemCacheForClient(body.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: existing ? "flags.restore" : "flags.create",
+					request,
+					targetId: result.id,
+					targetName: result.key,
+				});
 
 				return {
 					flag: {
@@ -1318,11 +1380,27 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, body.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.update",
+						reason: auth.error,
+						request,
+						targetId: params.id,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.update",
+						reason: "Forbidden",
+						request,
+						targetId: params.id,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
@@ -1397,6 +1475,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					updated.key
 				);
 				invalidateMemCacheForClient(body.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: "flags.update",
+					request,
+					targetId: updated.id,
+					targetName: updated.key,
+				});
 
 				return {
 					flag: {
@@ -1450,11 +1536,27 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 			try {
 				const auth = await resolveFlagAdmin(request.headers, query.clientId);
 				if (!auth.ok) {
+					await recordPublicFlagAudit({
+						action: auth.status === 403 ? "denied" : "failure",
+						apiKey: auth.apiKey,
+						operation: "flags.delete",
+						reason: auth.error,
+						request,
+						targetId: params.id,
+					});
 					set.status = auth.status;
 					return { error: auth.error };
 				}
 
 				if (!auth.apiKey.userId) {
+					await recordPublicFlagAudit({
+						action: "denied",
+						apiKey: auth.apiKey,
+						operation: "flags.delete",
+						reason: "Forbidden",
+						request,
+						targetId: params.id,
+					});
 					set.status = 403;
 					return { error: "Forbidden" };
 				}
@@ -1511,6 +1613,14 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 					flag.key
 				);
 				invalidateMemCacheForClient(query.clientId);
+				await recordPublicFlagAudit({
+					action: "success",
+					apiKey: auth.apiKey,
+					operation: "flags.delete",
+					request,
+					targetId: flag.id,
+					targetName: flag.key,
+				});
 
 				return { success: true };
 			} catch (error) {

--- a/apps/api/src/rpc/handlers.ts
+++ b/apps/api/src/rpc/handlers.ts
@@ -28,11 +28,17 @@ export const rpcHandler = new RPCHandler(appRouter, {
 
 export function createAuthenticatedOrpcContext(request: Request) {
 	const preResolvedAuth = getPreResolvedAuth(request.headers);
-	return createRPCContext({ headers: request.headers }, preResolvedAuth);
+	return createRPCContext(
+		{ headers: request.headers, requestId: getRequestId(request) },
+		preResolvedAuth
+	);
 }
 
 export function createAnonymousOrpcContext(request: Request) {
-	return createRPCContext({ headers: request.headers }, ANONYMOUS_AUTH);
+	return createRPCContext(
+		{ headers: request.headers, requestId: getRequestId(request) },
+		ANONYMOUS_AUTH
+	);
 }
 
 export function handleAuthenticatedOrpcRequest(

--- a/apps/dashboard/app/(main)/organizations/components/organization-provider.tsx
+++ b/apps/dashboard/app/(main)/organizations/components/organization-provider.tsx
@@ -13,6 +13,7 @@ import {
 	GlobeIcon,
 	PlugIcon,
 	UsersIcon,
+	ShieldCheckIcon,
 } from "@databuddy/ui/icons";
 import { Button, EmptyState, Skeleton } from "@databuddy/ui";
 
@@ -63,6 +64,12 @@ const PAGE_INFO_MAP: Record<string, PageInfo> = {
 		title: "Integrations",
 		description: "Connect external tools to this organization",
 		icon: PlugIcon,
+		requiresOrg: true,
+	},
+	"/organizations/settings/audit": {
+		title: "Audit Log",
+		description: "Review privileged activity in this organization",
+		icon: ShieldCheckIcon,
 		requiresOrg: true,
 	},
 	"/organizations/settings/websites": {

--- a/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
+++ b/apps/dashboard/app/(main)/organizations/settings/audit/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { Badge, Button, Card, EmptyState, Skeleton, Text } from "@databuddy/ui";
+import { ShieldCheckIcon } from "@databuddy/ui/icons";
+import { useOrganizations } from "@/hooks/use-organizations";
+import { orpc } from "@/lib/orpc";
+
+const outcomeVariant = {
+	denied: "warning",
+	failure: "destructive",
+	success: "success",
+} as const;
+
+function formatAction(action: string): string {
+	return action
+		.split(".")
+		.map((part) => part.replaceAll("_", " "))
+		.join(" / ");
+}
+
+function AuditSkeleton() {
+	return (
+		<div className="mx-auto max-w-4xl space-y-6 p-5">
+			<Card>
+				<Card.Header>
+					<Skeleton className="h-4 w-32" />
+					<Skeleton className="h-3 w-64" />
+				</Card.Header>
+				<Card.Content className="space-y-3">
+					{["a", "b", "c", "d"].map((key) => (
+						<div className="flex items-center gap-3" key={key}>
+							<Skeleton className="size-2 rounded-full" />
+							<Skeleton className="h-4 flex-1" />
+							<Skeleton className="h-4 w-32" />
+						</div>
+					))}
+				</Card.Content>
+			</Card>
+		</div>
+	);
+}
+
+export default function AuditLogPage() {
+	const { activeOrganization } = useOrganizations();
+	const [cursor, setCursor] = useState<string>();
+	const query = useQuery({
+		...orpc.audit.list.queryOptions({
+			input: {
+				limit: 50,
+				organizationId: activeOrganization?.id,
+				...(cursor ? { cursor } : {}),
+			},
+		}),
+		enabled: Boolean(activeOrganization?.id),
+	});
+
+	if (!activeOrganization || query.isLoading) {
+		return <AuditSkeleton />;
+	}
+
+	if (query.isError) {
+		return (
+			<div className="mx-auto max-w-4xl p-5">
+				<EmptyState
+					description="Audit history is only available to organization administrators and owners."
+					icon={<ShieldCheckIcon size={18} weight="duotone" />}
+					title="Audit log unavailable"
+					variant="minimal"
+				/>
+			</div>
+		);
+	}
+
+	const events = query.data?.events ?? [];
+
+	return (
+		<div className="mx-auto max-w-4xl space-y-6 p-5">
+			<Card>
+				<Card.Header className="flex-row items-start justify-between gap-4">
+					<div>
+						<Card.Title>Audit log</Card.Title>
+						<Card.Description>
+							Privileged activity recorded for {activeOrganization.name}.
+						</Card.Description>
+					</div>
+					<ShieldCheckIcon className="size-5 text-muted-foreground" />
+				</Card.Header>
+				<Card.Content className="p-0">
+					{events.length === 0 ? (
+						<EmptyState
+							description="New organization, access, flag, and workspace changes will appear here."
+							icon={<ShieldCheckIcon size={18} weight="duotone" />}
+							title="No audit events yet"
+							variant="minimal"
+						/>
+					) : (
+						<div className="divide-y">
+							{events.map((event) => (
+								<div
+									className="flex flex-col gap-2 px-5 py-4 sm:flex-row sm:items-center sm:justify-between"
+									key={event.id}
+								>
+									<div className="min-w-0">
+										<div className="flex flex-wrap items-center gap-2">
+											<Text className="font-medium capitalize" variant="label">
+												{formatAction(event.action)}
+											</Text>
+											<Badge size="sm" variant={outcomeVariant[event.outcome]}>
+												{event.outcome}
+											</Badge>
+										</div>
+										<Text
+											className="mt-1 truncate"
+											tone="muted"
+											variant="caption"
+										>
+											{event.actorDisplayName ?? event.actorId} · {event.source}
+										</Text>
+									</div>
+									<Text
+										className="shrink-0 tabular-nums"
+										tone="muted"
+										variant="caption"
+									>
+										{new Date(event.createdAt).toLocaleString()}
+									</Text>
+								</div>
+							))}
+						</div>
+					)}
+				</Card.Content>
+				{query.data?.hasMore && query.data.nextCursor && (
+					<Card.Footer className="justify-end">
+						<Button
+							onClick={() => setCursor(query.data?.nextCursor ?? undefined)}
+							size="sm"
+							variant="outline"
+						>
+							Load older events
+						</Button>
+					</Card.Footer>
+				)}
+			</Card>
+		</div>
+	);
+}

--- a/apps/dashboard/components/layout/navigation/navigation-config.tsx
+++ b/apps/dashboard/components/layout/navigation/navigation-config.tsx
@@ -31,6 +31,7 @@ import {
 	ReceiptIcon,
 	RobotIcon,
 	SignalIcon,
+	ShieldCheckIcon,
 	TargetIcon,
 	UserIcon,
 	UserSettingsIcon,
@@ -312,6 +313,11 @@ export const settingsNavigation: NavigationGroup[] = [
 				{ flag: "integrations" }
 			),
 			createNavItem("Members", UserIcon, "/organizations/members"),
+			createNavItem(
+				"Audit Log",
+				ShieldCheckIcon,
+				"/organizations/settings/audit"
+			),
 			createNavItem("Billing", CreditCardIcon, "/billing"),
 			createNavItem("Plans", CurrencyDollarIcon, "/billing/plans"),
 			createNavItem("Invoices", ReceiptIcon, "/billing/history"),

--- a/packages/cache/src/drizzle.ts
+++ b/packages/cache/src/drizzle.ts
@@ -1,6 +1,17 @@
 import { getTableName, is, Table } from "drizzle-orm";
-import { Cache } from "drizzle-orm/cache/core";
+import { Cache, type MutationOption } from "drizzle-orm/cache/core";
 import type { CacheConfig } from "drizzle-orm/cache/core/types";
+
+export interface RedisCacheClient {
+	del(key: string): Promise<unknown>;
+	expire(key: string, seconds: number): Promise<unknown>;
+	get(key: string): Promise<string | null>;
+	sadd(key: string, member: string): Promise<unknown>;
+	set(key: string, value: string, mode?: "KEEPTTL"): Promise<unknown>;
+	setex(key: string, seconds: number, value: string): Promise<unknown>;
+	smembers(key: string): Promise<string[]>;
+	unlink(key: string): Promise<unknown>;
+}
 
 /**
  * Configuration options for creating a Redis-based Drizzle cache instance.
@@ -56,7 +67,7 @@ export interface RedisCacheConfig {
 	 * const redis = new Redis("redis://localhost:6379");
 	 * ```
 	 */
-	redis: any;
+	redis: RedisCacheClient;
 	/**
 	 * Cache strategy determines when queries are cached.
 	 *
@@ -139,7 +150,7 @@ export interface RedisCacheConfig {
  * ```
  */
 export class RedisDrizzleCache extends Cache {
-	private readonly redis: any;
+	private readonly redis: RedisCacheClient;
 	private readonly defaultTtl: number;
 	private readonly namespace: string;
 	private readonly _strategy: "explicit" | "all";
@@ -212,14 +223,15 @@ export class RedisDrizzleCache extends Cache {
 	 * - Returns `undefined` if JSON parsing fails
 	 * - Logs errors to console but doesn't throw
 	 */
-	override async get(key: string): Promise<any[] | undefined> {
+	override async get(key: string): Promise<unknown[] | undefined> {
 		const cacheKey = this.formatKey(key);
 		try {
 			const cached = await this.redis.get(cacheKey);
 			if (!cached) {
 				return;
 			}
-			return JSON.parse(cached) as any[];
+			const parsed: unknown = JSON.parse(cached);
+			return Array.isArray(parsed) ? parsed : undefined;
 		} catch (error) {
 			console.error(
 				`[RedisDrizzleCache] GET failed for key ${cacheKey}:`,
@@ -276,7 +288,7 @@ export class RedisDrizzleCache extends Cache {
 	 */
 	override async put(
 		key: string,
-		response: any,
+		response: unknown,
 		tables: string[],
 		_isTag: boolean,
 		config?: CacheConfig
@@ -359,10 +371,7 @@ export class RedisDrizzleCache extends Cache {
 	 * - Tag-based invalidation is supported but tags must be tracked separately
 	 * - Operations are performed in parallel for better performance
 	 */
-	override async onMutate(params: {
-		tags?: string | string[];
-		tables?: string | string[] | Table<any> | Table<any>[];
-	}): Promise<void> {
+	override async onMutate(params: MutationOption): Promise<void> {
 		const tagsArray = params.tags
 			? Array.isArray(params.tags)
 				? params.tags

--- a/packages/db/src/drizzle/schema/flags.test.ts
+++ b/packages/db/src/drizzle/schema/flags.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { buildFlagChangeSnapshot } from "./flags";
+
+describe("buildFlagChangeSnapshot", () => {
+	test("normalizes nullable flag fields for every writer", () => {
+		const snapshot = buildFlagChangeSnapshot({
+			defaultValue: false,
+			dependencies: null,
+			description: null,
+			environment: null,
+			key: "checkout-v2",
+			name: null,
+			persistAcrossAuth: false,
+			rolloutBy: null,
+			rolloutPercentage: null,
+			status: "active",
+			type: "boolean",
+			variants: null,
+		});
+
+		expect(snapshot).toEqual({
+			defaultValue: false,
+			dependencies: [],
+			description: null,
+			environment: null,
+			key: "checkout-v2",
+			name: null,
+			persistAcrossAuth: false,
+			rolloutBy: null,
+			rolloutPercentage: null,
+			status: "active",
+			type: "boolean",
+			variants: [],
+		});
+	});
+});

--- a/packages/db/src/drizzle/schema/flags.ts
+++ b/packages/db/src/drizzle/schema/flags.ts
@@ -148,6 +148,39 @@ export const flags = pgTable(
 	]
 );
 
+export function buildFlagChangeSnapshot(
+	flag: Pick<
+		typeof flags.$inferSelect,
+		| "defaultValue"
+		| "dependencies"
+		| "description"
+		| "environment"
+		| "key"
+		| "name"
+		| "persistAcrossAuth"
+		| "rolloutBy"
+		| "rolloutPercentage"
+		| "status"
+		| "type"
+		| "variants"
+	>
+): FlagChangeSnapshot {
+	return {
+		key: flag.key,
+		name: flag.name ?? null,
+		description: flag.description ?? null,
+		type: flag.type,
+		status: flag.status,
+		defaultValue: flag.defaultValue,
+		persistAcrossAuth: flag.persistAcrossAuth,
+		rolloutPercentage: flag.rolloutPercentage ?? null,
+		rolloutBy: flag.rolloutBy ?? null,
+		environment: flag.environment ?? null,
+		dependencies: flag.dependencies ?? [],
+		variants: flag.variants ?? [],
+	};
+}
+
 export const flagChangeEvents = pgTable(
 	"flag_change_events",
 	{

--- a/packages/rpc/src/lib/audit.ts
+++ b/packages/rpc/src/lib/audit.ts
@@ -3,11 +3,14 @@ import type {
 	AuditActor,
 	AuditRequestContext,
 } from "@databuddy/shared/audit";
+import { getTrustedClientIp } from "@databuddy/shared/utils/trusted-client-ip";
 import {
+	appendAuditEvent,
 	appendAuditEventInTransaction,
 	type AuditDatabase,
 	type AppendAuditEventInput,
 } from "@databuddy/services/audit";
+import { log } from "evlog";
 import type { Context } from "../orpc";
 
 export function getAuditActor(context: Context): AuditActor {
@@ -34,7 +37,9 @@ export function getAuditActor(context: Context): AuditActor {
 
 export function getAuditRequestContext(context: Context): AuditRequestContext {
 	return {
-		requestId: context.headers.get("x-request-id") ?? undefined,
+		ip: getTrustedClientIp(context.headers),
+		requestId:
+			context.requestId ?? context.headers.get("x-request-id") ?? undefined,
 		userAgent: context.headers.get("user-agent") ?? undefined,
 	};
 }
@@ -53,4 +58,28 @@ export async function appendRpcAuditEvent<
 		request: getAuditRequestContext(context),
 		source: "orpc",
 	});
+}
+
+export async function appendRpcAuditEventBestEffort<
+	TAction extends AuditActionDefinition,
+>(
+	context: Context,
+	organizationId: string,
+	input: Omit<AppendAuditEventInput<TAction>, "actor" | "request" | "source">
+): Promise<void> {
+	try {
+		await appendAuditEvent(context.db, organizationId, {
+			...input,
+			actor: getAuditActor(context),
+			request: getAuditRequestContext(context),
+			source: "orpc",
+		});
+	} catch (error) {
+		log.error({
+			service: "rpc",
+			component: "audit",
+			audit_error: error,
+			operation: input.operation,
+		});
+	}
 }

--- a/packages/rpc/src/middleware/audit-mutation.test.ts
+++ b/packages/rpc/src/middleware/audit-mutation.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { isAuditedMutationPath } from "./audit-mutation";
+
+describe("isAuditedMutationPath", () => {
+	test("recognizes privileged mutation verbs across routers", () => {
+		expect(isAuditedMutationPath("flags.create")).toBe(true);
+		expect(isAuditedMutationPath("statusPage.createIncident")).toBe(true);
+		expect(isAuditedMutationPath("organizations.updateEmailNotificationSettings")).toBe(true);
+	});
+
+	test("does not treat reads as mutations", () => {
+		expect(isAuditedMutationPath("flags.list")).toBe(false);
+		expect(isAuditedMutationPath("profiles.getHistory")).toBe(false);
+	});
+
+	test("leaves richer existing audit implementations in control", () => {
+		expect(isAuditedMutationPath("apikeys.create")).toBe(false);
+		expect(isAuditedMutationPath("websites.updateSettings")).toBe(false);
+	});
+
+	test("rejects malformed procedure paths", () => {
+		expect(isAuditedMutationPath("create")).toBe(false);
+		expect(isAuditedMutationPath("flags")).toBe(false);
+	});
+});

--- a/packages/rpc/src/middleware/audit-mutation.ts
+++ b/packages/rpc/src/middleware/audit-mutation.ts
@@ -1,0 +1,128 @@
+import { log } from "evlog";
+import { auditActions } from "@databuddy/shared/audit";
+import { appendAuditEvent } from "@databuddy/services/audit";
+import { getAuditActor, getAuditRequestContext } from "../lib/audit";
+import type { Context } from "../orpc";
+
+const MUTATION_METHOD_PREFIXES = [
+	"accept",
+	"add",
+	"apply",
+	"archive",
+	"cancel",
+	"change",
+	"clear",
+	"configure",
+	"connect",
+	"create",
+	"delete",
+	"disconnect",
+	"edit",
+	"generate",
+	"install",
+	"mark",
+	"manual",
+	"pause",
+	"publish",
+	"redeem",
+	"remove",
+	"rename",
+	"regenerate",
+	"reorder",
+	"reset",
+	"reply",
+	"resolve",
+	"restore",
+	"resume",
+	"revoke",
+	"rotate",
+	"run",
+	"set",
+	"submit",
+	"test",
+	"toggle",
+	"transfer",
+	"uninstall",
+	"unpublish",
+	"update",
+	"upsert",
+] as const;
+
+const EXPLICIT_AUDIT_ROUTERS = new Set(["apikeys", "websites"]);
+
+export function isAuditedMutationPath(path: string): boolean {
+	const [router, method] = path.split(".");
+	if (!(router && method) || EXPLICIT_AUDIT_ROUTERS.has(router)) {
+		return false;
+	}
+
+	return MUTATION_METHOD_PREFIXES.some((prefix) => method.startsWith(prefix));
+}
+
+function getErrorCode(error: unknown): string | undefined {
+	if (typeof error !== "object" || error === null || !("code" in error)) {
+		return;
+	}
+
+	const code = (error as { code?: unknown }).code;
+	return typeof code === "string" ? code : undefined;
+}
+
+function getAuditOutcome(error: unknown): "denied" | "failure" {
+	const code = getErrorCode(error);
+	return code === "FORBIDDEN" ? "denied" : "failure";
+}
+
+async function writeMutationAudit(
+	context: Context,
+	path: string,
+	outcome: "denied" | "failure" | "success",
+	error?: unknown
+): Promise<void> {
+	const organizationId = context.organizationId;
+	if (!(organizationId && (context.user || context.apiKey))) {
+		return;
+	}
+
+	const errorCode = error ? getErrorCode(error) : undefined;
+	try {
+		await appendAuditEvent(context.db, organizationId, {
+			action: auditActions.RPC_MUTATION,
+			actor: getAuditActor(context),
+			metadata: errorCode ? { errorCode } : undefined,
+			operation: path,
+			outcome,
+			reason: errorCode,
+			request: getAuditRequestContext(context),
+			source: "orpc",
+			target: { id: organizationId },
+		});
+	} catch (auditError) {
+		log.error({
+			service: "rpc",
+			component: "audit_mutation",
+			audit_error: auditError,
+			operation: path,
+			outcome,
+		});
+	}
+}
+
+export async function runAuditedMutation<T>(
+	path: string,
+	context: Context,
+	fn: () => PromiseLike<T> | T
+): Promise<T> {
+	if (!isAuditedMutationPath(path)) {
+		return await fn();
+	}
+
+	try {
+		const result = await fn();
+		await writeMutationAudit(context, path, "success");
+		return result;
+	} catch (error) {
+		await writeMutationAudit(context, path, getAuditOutcome(error), error);
+		throw error;
+	}
+}

--- a/packages/rpc/src/orpc.ts
+++ b/packages/rpc/src/orpc.ts
@@ -13,6 +13,7 @@ import {
 	setRpcProcedureType,
 } from "./lib/rpc-log-context";
 import { runTracked } from "./middleware/track-mutation";
+import { runAuditedMutation } from "./middleware/audit-mutation";
 import { type BillingOwner, getBillingOwner } from "./utils/billing";
 import { getOrganizationOwnerId } from "./utils/organization";
 
@@ -73,7 +74,7 @@ export function createServiceAuth(
 }
 
 export const createRPCContext = async (
-	opts: { headers: Headers },
+	opts: { headers: Headers; requestId?: string },
 	preResolved?: PreResolvedAuth
 ) => {
 	const [session, apiKey] = preResolved
@@ -169,11 +170,29 @@ export const sessionProcedure = protectedProcedure.use(
 );
 
 export const trackedProcedure = protectedProcedure.use(
-	({ context, next, path }) => runTracked(path.join("."), context, next)
+	({ context, next, path }) => {
+		const procedurePath = path.join(".");
+		return runTracked(procedurePath, context, () =>
+			runAuditedMutation(procedurePath, context, next)
+		);
+	}
 );
 
 export const trackedSessionProcedure = sessionProcedure.use(
-	({ context, next, path }) => runTracked(path.join("."), context, next)
+	({ context, next, path }) => {
+		const procedurePath = path.join(".");
+		return runTracked(procedurePath, context, () =>
+			runAuditedMutation(procedurePath, context, next)
+		);
+	}
+);
+
+export const auditedProcedure = protectedProcedure.use(
+	({ context, next, path }) => runAuditedMutation(path.join("."), context, next)
+);
+
+export const auditedSessionProcedure = sessionProcedure.use(
+	({ context, next, path }) => runAuditedMutation(path.join("."), context, next)
 );
 
 export { os };

--- a/packages/rpc/src/root.ts
+++ b/packages/rpc/src/root.ts
@@ -3,6 +3,7 @@ import { alarmsRouter } from "./routers/alarms";
 import { annotationsRouter } from "./routers/annotations";
 import { anomaliesRouter } from "./routers/anomalies";
 import { apikeysRouter } from "./routers/apikeys";
+import { auditRouter } from "./routers/audit";
 import { autocompleteRouter } from "./routers/autocomplete";
 import { billingRouter } from "./routers/billing";
 import { feedbackRouter } from "./routers/feedback";
@@ -28,6 +29,7 @@ export const appRouter = {
 	alarms: alarmsRouter,
 	anomalies: anomaliesRouter,
 	annotations: annotationsRouter,
+	audit: auditRouter,
 	websites: websitesRouter,
 	funnels: funnelsRouter,
 	goals: goalsRouter,

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -64,7 +64,7 @@ const chartContextSchema = z.object({
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
-	chartContext: z.unknown(),
+	chartContext: chartContextSchema,
 	chartType: z.string(),
 	color: z.string(),
 	createdAt: z.coerce.date(),

--- a/packages/rpc/src/routers/audit.ts
+++ b/packages/rpc/src/routers/audit.ts
@@ -1,0 +1,158 @@
+import {
+	auditActionNames,
+	auditActions,
+	auditOutcomes,
+} from "@databuddy/shared/audit";
+import {
+	decodeAuditCursor,
+	encodeAuditCursor,
+	getAuditEvent,
+	listAuditEvents,
+	MAX_AUDIT_PAGE_SIZE,
+	type AuditCursor,
+} from "@databuddy/services/audit";
+import { z } from "zod";
+import { rpcError } from "../errors";
+import { appendRpcAuditEventBestEffort } from "../lib/audit";
+import { sessionProcedure } from "../orpc";
+import { withWorkspace } from "../procedures/with-workspace";
+
+const auditEventSchema = z.object({
+	action: z.string(),
+	actorDisplayName: z.string().nullable(),
+	actorId: z.string(),
+	actorType: z.enum(["user", "api", "system", "agent"]),
+	changes: z.record(z.string(), z.unknown()),
+	createdAt: z.coerce.date(),
+	id: z.string(),
+	ip: z.string().nullable(),
+	metadata: z.record(z.string(), z.unknown()),
+	operation: z.string().nullable(),
+	organizationId: z.string(),
+	outcome: z.enum(["success", "failure", "denied"]),
+	reason: z.string().nullable(),
+	requestId: z.string().nullable(),
+	source: z.enum(["orpc", "better_auth", "public_api", "worker"]),
+	targetDisplayName: z.string().nullable(),
+	targetId: z.string(),
+	targetType: z.string(),
+	userAgent: z.string().nullable(),
+});
+
+const auditListInputSchema = z.object({
+	action: z.enum(auditActionNames).optional(),
+	actorId: z.string().min(1).optional(),
+	cursor: z.string().min(1).optional(),
+	limit: z.number().int().min(1).max(MAX_AUDIT_PAGE_SIZE).default(50),
+	organizationId: z.string().min(1).optional(),
+	outcome: z.enum(auditOutcomes).optional(),
+	targetId: z.string().min(1).optional(),
+});
+
+const auditListOutputSchema = z.object({
+	events: z.array(auditEventSchema),
+	hasMore: z.boolean(),
+	nextCursor: z.string().nullable(),
+});
+
+function getOrganizationId(
+	context: Parameters<typeof withWorkspace>[0],
+	organizationId?: string
+): string {
+	const resolved = organizationId ?? context.organizationId;
+	if (!resolved) {
+		throw rpcError.badRequest("Organization ID is required");
+	}
+	return resolved;
+}
+
+export const auditRouter = {
+	list: sessionProcedure
+		.route({
+			description:
+				"Lists tenant-scoped audit events for organization administrators and owners.",
+			method: "POST",
+			path: "/audit/list",
+			summary: "List audit events",
+			tags: ["Audit"],
+		})
+		.input(auditListInputSchema)
+		.output(auditListOutputSchema)
+		.handler(async ({ context, input }) => {
+			const organizationId = getOrganizationId(context, input.organizationId);
+			await withWorkspace(context, {
+				organizationId,
+				permissions: ["read"],
+				resource: "audit_log",
+			});
+
+			let cursor: AuditCursor | undefined;
+			if (input.cursor) {
+				const decodedCursor = decodeAuditCursor(input.cursor);
+				if (!decodedCursor) {
+					throw rpcError.badRequest("Invalid audit cursor");
+				}
+				cursor = decodedCursor;
+			}
+
+			const rows = await listAuditEvents(context.db, {
+				action: input.action,
+				actorId: input.actorId,
+				cursor,
+				limit: input.limit,
+				organizationId,
+				outcome: input.outcome,
+				targetId: input.targetId,
+			});
+			const events = rows.slice(0, input.limit);
+			const lastEvent = events.at(-1);
+
+			await appendRpcAuditEventBestEffort(context, organizationId, {
+				action: auditActions.AUDIT_LOG_VIEWED,
+				operation: "audit.list",
+				target: { id: organizationId },
+			});
+
+			return {
+				events,
+				hasMore: rows.length > input.limit,
+				nextCursor: lastEvent ? encodeAuditCursor(lastEvent) : null,
+			};
+		}),
+
+	get: sessionProcedure
+		.route({
+			description:
+				"Returns one tenant-scoped audit event for organization administrators and owners.",
+			method: "POST",
+			path: "/audit/get",
+			summary: "Get an audit event",
+			tags: ["Audit"],
+		})
+		.input(
+			z.object({
+				id: z.string().min(1),
+				organizationId: z.string().min(1).optional(),
+			})
+		)
+		.output(z.object({ event: auditEventSchema.nullable() }))
+		.handler(async ({ context, input }) => {
+			const organizationId = getOrganizationId(context, input.organizationId);
+			await withWorkspace(context, {
+				organizationId,
+				permissions: ["read"],
+				resource: "audit_log",
+			});
+
+			const event = await getAuditEvent(context.db, organizationId, input.id);
+			if (event) {
+				await appendRpcAuditEventBestEffort(context, organizationId, {
+					action: auditActions.AUDIT_LOG_EVENT_VIEWED,
+					operation: "audit.get",
+					target: { id: event.id },
+				});
+			}
+
+			return { event };
+		}),
+};

--- a/packages/rpc/src/routers/flags.ts
+++ b/packages/rpc/src/routers/flags.ts
@@ -8,7 +8,9 @@ import {
 	withTransaction,
 } from "@databuddy/db";
 import {
+	buildFlagChangeSnapshot,
 	flagChangeEvents,
+	type TargetGroups,
 	flags,
 	flagsToTargetGroups,
 } from "@databuddy/db/schema";
@@ -235,7 +237,7 @@ const checkCircularDependency = async (
 
 interface FlagRelation {
 	flagsToTargetGroups: Array<{
-		targetGroup: { deletedAt: Date | null; [key: string]: unknown } | null;
+		targetGroup: TargetGroups | null;
 	}>;
 }
 
@@ -247,45 +249,46 @@ function flattenTargetGroups<T extends FlagRelation>(flag: T) {
 	return { ...rest, targetGroups };
 }
 
-function buildFlagChangeSnapshot(flag: {
-	defaultValue: boolean;
-	dependencies?: string[] | null;
-	description?: string | null;
-	environment?: string | null;
-	key: string;
-	name?: string | null;
-	persistAcrossAuth: boolean;
-	rolloutBy?: string | null;
-	rolloutPercentage?: number | null;
-	status: "active" | "inactive" | "archived";
-	type: "boolean" | "rollout" | "multivariant";
-	variants?: Array<{
-		description?: string;
-		key: string;
-		type: "string" | "number" | "json";
-		value: unknown;
-		weight?: number;
-	}> | null;
-}) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
-}
+const flagTargetGroupOutputSchema = z.object({
+	color: z.string(),
+	createdAt: z.coerce.date(),
+	createdBy: z.string(),
+	deletedAt: z.coerce.date().nullable(),
+	description: z.string().nullable(),
+	id: z.string(),
+	name: z.string(),
+	rules: z.array(userRuleSchema),
+	updatedAt: z.coerce.date(),
+	websiteId: z.string(),
+});
+
+const flagOutputSchema = z.object({
+	createdAt: z.coerce.date(),
+	createdBy: z.string(),
+	defaultValue: z.boolean(),
+	deletedAt: z.coerce.date().nullable(),
+	dependencies: z.array(z.string()).nullable(),
+	description: z.string().nullable(),
+	environment: z.string().nullable(),
+	id: z.string(),
+	key: z.string(),
+	name: z.string().nullable(),
+	organizationId: z.string().nullable(),
+	payload: z.record(z.string(), z.unknown()).nullable(),
+	persistAcrossAuth: z.boolean(),
+	rules: z.array(userRuleSchema).nullable(),
+	rolloutBy: z.string().nullable(),
+	rolloutPercentage: z.number().nullable(),
+	status: z.enum(["active", "inactive", "archived"]),
+	targetGroupIds: z.array(z.string()).nullable(),
+	targetGroups: z.array(flagTargetGroupOutputSchema).optional(),
+	type: z.enum(["boolean", "rollout", "multivariant"]),
+	updatedAt: z.coerce.date(),
+	variants: z.array(variantSchema).nullable(),
+	websiteId: z.string().nullable(),
+});
 
 const successOutputSchema = z.object({ success: z.literal(true) });
-
-const flagOutputSchema = z.record(z.string(), z.unknown());
 
 export const flagsRouter = {
 	list: publicProcedure

--- a/packages/rpc/src/routers/funnels.ts
+++ b/packages/rpc/src/routers/funnels.ts
@@ -31,7 +31,16 @@ const cache = funnelCache;
 
 const filterSchema = z.object({
 	field: z.string(),
-	operator: z.enum(["equals", "contains", "not_equals", "in", "not_in"]),
+	operator: z.enum([
+		"contains",
+		"ends_with",
+		"equals",
+		"in",
+		"not_contains",
+		"not_equals",
+		"not_in",
+		"starts_with",
+	]),
 	value: z.union([z.string(), z.array(z.string())]),
 });
 
@@ -63,12 +72,12 @@ const getEffectiveStartDate = (
 const funnelListOutputSchema = z.object({
 	createdAt: z.coerce.date(),
 	description: z.string().nullable(),
-	filters: z.unknown().nullable(),
+	filters: z.array(filterSchema).nullable(),
 	id: z.string(),
 	ignoreHistoricData: z.boolean(),
 	isActive: z.boolean(),
 	name: z.string(),
-	steps: z.unknown(),
+	steps: z.array(funnelStepSchema),
 	updatedAt: z.coerce.date(),
 });
 
@@ -77,12 +86,12 @@ const funnelOutputSchema = z.object({
 	createdBy: z.string(),
 	deletedAt: z.nullable(z.coerce.date()),
 	description: z.string().nullable(),
-	filters: z.unknown().nullable(),
+	filters: z.array(filterSchema).nullable(),
 	id: z.string(),
 	ignoreHistoricData: z.boolean(),
 	isActive: z.boolean(),
 	name: z.string(),
-	steps: z.unknown(),
+	steps: z.array(funnelStepSchema),
 	updatedAt: z.coerce.date(),
 	websiteId: z.string(),
 });

--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -35,7 +35,7 @@ import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
 import { logger } from "../lib/logger";
-import { type Context, protectedProcedure } from "../orpc";
+import { auditedProcedure, type Context, protectedProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 import {
 	getNextInsightRunAt,
@@ -1176,7 +1176,7 @@ export const insightGenerationRouter = {
 			return getConfig(organizationId);
 		}),
 
-	upsertConfig: protectedProcedure
+	upsertConfig: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/upsertConfig",
@@ -1196,7 +1196,7 @@ export const insightGenerationRouter = {
 			);
 		}),
 
-	addSlackDelivery: protectedProcedure
+	addSlackDelivery: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/addSlackDelivery",
@@ -1268,7 +1268,7 @@ export const insightGenerationRouter = {
 			});
 		}),
 
-	removeSlackDelivery: protectedProcedure
+	removeSlackDelivery: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/removeSlackDelivery",
@@ -1299,7 +1299,7 @@ export const insightGenerationRouter = {
 			}));
 		}),
 
-	triggerRun: protectedProcedure
+	triggerRun: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/generation/triggerRun",

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -44,7 +44,12 @@ import { rpcError } from "../errors";
 import { invalidateGoalsCache } from "../lib/goals-cache";
 import { invalidateFunnelsCache } from "../lib/funnels-cache";
 import { logger } from "../lib/logger";
-import { type Context, protectedProcedure, sessionProcedure } from "../orpc";
+import {
+	auditedProcedure,
+	auditedSessionProcedure,
+	type Context,
+	protectedProcedure,
+} from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 
 const INSIGHT_TIMELINE_ROWS_PER_KIND = 50;
@@ -1576,7 +1581,7 @@ export const insightsRouter = {
 			};
 		}),
 
-	reply: protectedProcedure
+	reply: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/reply",
@@ -1594,7 +1599,7 @@ export const insightsRouter = {
 			return { reply };
 		}),
 
-	applyAction: protectedProcedure
+	applyAction: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/actions/apply",
@@ -1608,7 +1613,7 @@ export const insightsRouter = {
 		),
 
 	// Keep the old route for clients that have not migrated to applyAction yet.
-	applyGoalAction: protectedProcedure
+	applyGoalAction: auditedProcedure
 		.route({
 			method: "POST",
 			path: "/insights/actions/goal/apply",
@@ -1621,7 +1626,7 @@ export const insightsRouter = {
 			applyInsightAction({ context, ...input })
 		),
 
-	retryReply: sessionProcedure
+	retryReply: auditedSessionProcedure
 		.route({
 			method: "POST",
 			path: "/insights/reply/retry",

--- a/packages/rpc/src/routers/revenue.ts
+++ b/packages/rpc/src/routers/revenue.ts
@@ -3,7 +3,7 @@ import { eq } from "@databuddy/db";
 import { revenueConfig } from "@databuddy/db/schema";
 import { z } from "zod";
 import { rpcError } from "../errors";
-import { protectedProcedure, sessionProcedure } from "../orpc";
+import { auditedSessionProcedure, protectedProcedure } from "../orpc";
 import { withWorkspace } from "../procedures/with-workspace";
 import { revenueUpsertInputSchema } from "./revenue.schemas";
 
@@ -63,7 +63,7 @@ export const revenueRouter = {
 			};
 		}),
 
-	upsert: sessionProcedure
+	upsert: auditedSessionProcedure
 		.route({
 			description:
 				"Creates or updates revenue config. Requires configure permission.",
@@ -140,7 +140,7 @@ export const revenueRouter = {
 			};
 		}),
 
-	regenerateHash: sessionProcedure
+	regenerateHash: auditedSessionProcedure
 		.route({
 			description: "Regenerates webhook hash. Requires configure permission.",
 			method: "POST",

--- a/packages/rpc/src/utils/flags.ts
+++ b/packages/rpc/src/utils/flags.ts
@@ -7,7 +7,11 @@ import {
 	isNull,
 	withTransaction,
 } from "@databuddy/db";
-import { flagChangeEvents, flags } from "@databuddy/db/schema";
+import {
+	buildFlagChangeSnapshot,
+	flagChangeEvents,
+	flags,
+} from "@databuddy/db/schema";
 import {
 	createDrizzleCache,
 	invalidateFlagReadCaches,
@@ -84,42 +88,6 @@ export const getScopeCondition = (
 	}
 	return eq(table.organizationId, "");
 };
-
-function buildFlagChangeSnapshot(flag: {
-	defaultValue: boolean;
-	dependencies?: string[] | null;
-	description?: string | null;
-	environment?: string | null;
-	key: string;
-	name?: string | null;
-	persistAcrossAuth: boolean;
-	rolloutBy?: string | null;
-	rolloutPercentage?: number | null;
-	status: "active" | "inactive" | "archived";
-	type: "boolean" | "rollout" | "multivariant";
-	variants?: Array<{
-		description?: string;
-		key: string;
-		type: "string" | "number" | "json";
-		value: unknown;
-		weight?: number;
-	}> | null;
-}) {
-	return {
-		key: flag.key,
-		name: flag.name ?? null,
-		description: flag.description ?? null,
-		type: flag.type,
-		status: flag.status,
-		defaultValue: flag.defaultValue,
-		persistAcrossAuth: flag.persistAcrossAuth,
-		rolloutPercentage: flag.rolloutPercentage ?? null,
-		rolloutBy: flag.rolloutBy ?? null,
-		environment: flag.environment ?? null,
-		dependencies: flag.dependencies ?? [],
-		variants: flag.variants ?? [],
-	};
-}
 
 interface FlagUpdateDependencyCascadingParams {
 	changedBy?: string;

--- a/packages/services/package.json
+++ b/packages/services/package.json
@@ -11,7 +11,8 @@
     "./websites": "./src/websites.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "test": "bun test src"
   },
   "dependencies": {
     "@databuddy/db": "workspace:*",

--- a/packages/services/src/audit.test.ts
+++ b/packages/services/src/audit.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { auditActions } from "@databuddy/shared/audit";
 import {
 	appendAuditEventInTransaction,
+	replayAuditOutbox,
 	type AuditDatabase,
 } from "./audit";
 
@@ -23,5 +24,75 @@ describe("appendAuditEventInTransaction", () => {
 				target: { id: "key_123" },
 			})
 		).rejects.toThrow("audit ledger unavailable");
+	});
+});
+
+describe("replayAuditOutbox", () => {
+	const payload = {
+		action: "rpc.mutation",
+		actorId: "user_123",
+		actorType: "user" as const,
+		changes: {},
+		id: "event_123",
+		metadata: {},
+		organizationId: "org_123",
+		outcome: "success" as const,
+		source: "orpc" as const,
+		targetId: "org_123",
+		targetType: "organization",
+	};
+
+	test("replays durable rows and reports the result", async () => {
+		const operations: string[] = [];
+		const database = {
+			delete: () => ({
+				where: async () => {
+					operations.push("delete");
+				},
+			}),
+			insert: () => ({
+				values: () => ({
+					onConflictDoNothing: async () => {
+						operations.push("insert");
+					},
+				}),
+			}),
+			select: () => ({
+				from: () => ({
+					orderBy: () => ({
+						limit: async () => [
+							{ id: "outbox_123", payload, createdAt: new Date() },
+						],
+					}),
+				}),
+			}),
+		} as unknown as AuditDatabase;
+
+		expect(await replayAuditOutbox(database)).toEqual({ failed: 0, replayed: 1 });
+		expect(operations).toEqual(["insert", "delete"]);
+	});
+
+	test("keeps failed rows visible for the next replay", async () => {
+		const database = {
+			delete: () => ({ where: async () => undefined }),
+			insert: () => ({
+				values: () => ({
+					onConflictDoNothing: async () => {
+						throw new Error("ledger unavailable");
+					},
+				}),
+			}),
+			select: () => ({
+				from: () => ({
+					orderBy: () => ({
+						limit: async () => [
+							{ id: "outbox_123", payload, createdAt: new Date() },
+						],
+					}),
+				}),
+			}),
+		} as unknown as AuditDatabase;
+
+		expect(await replayAuditOutbox(database)).toEqual({ failed: 1, replayed: 0 });
 	});
 });

--- a/packages/services/src/audit.ts
+++ b/packages/services/src/audit.ts
@@ -111,13 +111,14 @@ export function appendAuditEventInTransaction<
 export async function replayAuditOutbox(
 	database: AuditDatabase,
 	limit = 100
-): Promise<number> {
+): Promise<{ failed: number; replayed: number }> {
 	const rows = await database
 		.select()
 		.from(auditOutboxEvents)
 		.orderBy(asc(auditOutboxEvents.createdAt))
 		.limit(Math.min(Math.max(limit, 1), 100));
 	let replayed = 0;
+	let failed = 0;
 	for (const row of rows) {
 		try {
 			await database
@@ -130,9 +131,10 @@ export async function replayAuditOutbox(
 			replayed += 1;
 		} catch {
 			// Leave the durable entry for the next bounded replay attempt.
+			failed += 1;
 		}
 	}
-	return replayed;
+	return { failed, replayed };
 }
 
 export async function appendAuditEvent<TAction extends AuditActionDefinition>(
@@ -174,8 +176,6 @@ export async function appendAuditEvent<TAction extends AuditActionDefinition>(
 		reason: input.reason,
 		target: { id: input.target.id },
 	});
-
-	replayAuditOutbox(database).catch(() => undefined);
 
 	return event;
 }
@@ -228,6 +228,8 @@ export interface ListAuditEventsInput {
 	targetId?: string;
 }
 
+export const MAX_AUDIT_PAGE_SIZE = 100;
+
 export async function listAuditEvents(
 	database: AuditDatabase,
 	input: ListAuditEventsInput
@@ -259,12 +261,13 @@ export async function listAuditEvents(
 		}
 	}
 
+	const limit = Math.min(Math.max(input.limit, 1), MAX_AUDIT_PAGE_SIZE);
 	return await database
 		.select()
 		.from(auditEvents)
 		.where(and(...conditions))
 		.orderBy(desc(auditEvents.createdAt), desc(auditEvents.id))
-		.limit(input.limit + 1);
+		.limit(limit + 1);
 }
 
 export async function getAuditEvent(

--- a/packages/shared/src/audit.ts
+++ b/packages/shared/src/audit.ts
@@ -58,6 +58,8 @@ function defineAction<
 export const auditActions = {
 	AUDIT_LOG_VIEWED: defineAction("audit_log.viewed", "audit_log"),
 	AUDIT_LOG_EVENT_VIEWED: defineAction("audit_log.event_viewed", "audit_log"),
+	RPC_MUTATION: defineAction("rpc.mutation", "organization"),
+	FLAG_CHANGED: defineAction("flag.changed", "flag"),
 	API_KEY_CREATED: defineAction("api_key.created", "api_key"),
 	API_KEY_UPDATED: defineAction("api_key.updated", "api_key"),
 	API_KEY_REVOKED: defineAction("api_key.revoked", "api_key"),

--- a/packages/tracker/src/core/types.ts
+++ b/packages/tracker/src/core/types.ts
@@ -31,7 +31,7 @@ export type TrackerOptions = {
 	batchTimeout?: number;
 
 	// Filtering & masking
-	filter?: (event: any) => boolean;
+	filter?: (event: BaseEvent) => boolean;
 	skipPatterns?: string[];
 	maskPatterns?: string[];
 };
@@ -74,7 +74,7 @@ export type BaseEvent = {
 	sessionStartTime?: number;
 	timestamp: number;
 	type?: string;
-	[key: string]: any;
+	[key: string]: unknown;
 };
 
 export type WebVitalMetricName = "FCP" | "LCP" | "CLS" | "INP" | "TTFB" | "FPS";

--- a/packages/tracker/src/core/utils.ts
+++ b/packages/tracker/src/core/utils.ts
@@ -265,17 +265,17 @@ export function getTrackerConfig(): TrackerOptions {
 }
 
 export const logger = {
-	log: (...args: any[]) => {
+	log: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.log("[Databuddy]", ...args);
 		}
 	},
-	error: (...args: any[]) => {
+	error: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.error("[Databuddy]", ...args);
 		}
 	},
-	warn: (...args: any[]) => {
+	warn: (...args: unknown[]) => {
 		if (process.env.DATABUDDY_DEBUG) {
 			console.warn("[Databuddy]", ...args);
 		}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an organization audit log and automatic coverage of privileged mutations. Previously, ORPC mutations and public flag writes were not consistently logged; now we record success/denied/failure outcomes, and expose them in a new Audit Log page.

- Introduces `audit.list` and `audit.get` routes and a dashboard Audit Log at /organizations/settings/audit for org admins/owners.
- Auto-audits `orpc` mutations via middleware: captures actor, IP, requestId, outcome, and error code; excludes routers with explicit audit (`apikeys`, `websites`). Converts selected routes to `auditedProcedure`.
- Audits public flag create/update/delete attempts with API key actors and consolidates flag change snapshots via `@databuddy/db` to align writers.
- Changes audit outbox replay to return replayed/failed counts; the API replay loop logs results. Append no longer triggers immediate replay.
- Tightens RPC output schemas (annotations, funnels, flags) and propagates requestId/IP in contexts. Adds `auditActions.RPC_MUTATION` and `auditActions.FLAG_CHANGED`.
- Refines `packages/cache` Redis cache types (`RedisCacheClient`, `MutationOption`), JSON-safe cache get/put, and narrows tracker/core types.

**Rollout notes**
- Ensure the API audit outbox replay loop is running; no DB migrations required.
- If you supply a custom Redis client to `packages/cache`, implement the `RedisCacheClient` methods (get/set/setex/sadd/smembers/expire/del/unlink).

<sup>Written for commit 1fec2bf286a7dd2d76849dcaa41717af17948f3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

