### PR TITLE
perf(api): cut redundant Postgres lookups on the query hot path

### DIFF
--- a/apps/api/src/middleware/website-auth.ts
+++ b/apps/api/src/middleware/website-auth.ts
@@ -4,7 +4,7 @@ import {
 	isApiKeyPresent,
 } from "@databuddy/api-keys/resolve";
 import { auth } from "@databuddy/auth";
-import { db } from "@databuddy/db";
+import { getMemberRole } from "@databuddy/rpc/organization";
 import { Elysia } from "elysia";
 import { getResolvedAuth } from "../lib/auth-wide-event";
 import { getCachedWebsite, getTimezone } from "@databuddy/ai/lib/website-utils";
@@ -75,11 +75,10 @@ export function websiteAuth() {
 				apiKey = resolvedApiKey;
 			}
 
-			const website = websiteId ? await getCachedWebsite(websiteId) : undefined;
-
-			const timezone = session?.user
-				? await getTimezone(request, session)
-				: await getTimezone(request, null);
+			const [website, timezone] = await Promise.all([
+				websiteId ? getCachedWebsite(websiteId) : undefined,
+				getTimezone(request, session?.user ? session : null),
+			]);
 
 			return {
 				user: sessionUser,
@@ -151,14 +150,9 @@ async function checkWebsiteAuth(
 			});
 		}
 
-		const membership = await db.query.member.findFirst({
-			where: { userId: sessionUser.id, organizationId: website.organizationId },
-			columns: {
-				id: true,
-			},
-		});
+		const role = await getMemberRole(sessionUser.id, website.organizationId);
 
-		if (membership) {
+		if (role) {
 			return null;
 		}
 

--- a/apps/api/src/routes/query.ts
+++ b/apps/api/src/routes/query.ts
@@ -21,7 +21,10 @@ import { validateTimezone } from "@databuddy/validation";
 import { readBooleanEnv } from "@databuddy/env/boolean";
 import { getRateLimitHeaders, ratelimit } from "@databuddy/redis/rate-limit";
 import { getBillingOwner } from "@databuddy/rpc/billing";
-import { getOrganizationOwnerId } from "@databuddy/rpc/organization";
+import {
+	getMemberRole,
+	getOrganizationOwnerId,
+} from "@databuddy/rpc/organization";
 import {
 	type GatedFeatureId,
 	GATED_FEATURES,
@@ -319,6 +322,7 @@ type ProjectAccessResult =
 			success: true;
 			projectId: string;
 			projectType: ProjectType;
+			organizationId?: string | null;
 	  }
 	| {
 			success: false;
@@ -519,7 +523,7 @@ async function verifyWebsiteAccess(
 	ctx: AuthContext,
 	websiteId: string,
 	queryTypes: string[] = []
-): Promise<boolean> {
+): Promise<{ granted: boolean; organizationId: string | null }> {
 	mergeWideEvent({ access_check_type: "website", website_id: websiteId });
 
 	const website = await db.query.websites.findFirst({
@@ -527,14 +531,18 @@ async function verifyWebsiteAccess(
 		columns: { id: true, isPublic: true, organizationId: true },
 	});
 
+	const denied = { granted: false, organizationId: null };
+
 	if (!website) {
 		mergeWideEvent({ access_result: "not_found" });
-		return false;
+		return denied;
 	}
+
+	const { organizationId } = website;
 
 	if (website.isPublic && canReadQueryTypesPublicly(queryTypes)) {
 		mergeWideEvent({ access_result: "public_query" });
-		return true;
+		return { granted: true, organizationId };
 	}
 
 	if (!ctx.isAuthenticated) {
@@ -543,45 +551,42 @@ async function verifyWebsiteAccess(
 				? "public_overview_only"
 				: "unauthenticated",
 		});
-		return false;
+		return denied;
 	}
 
-	if (!website.organizationId) {
+	if (!organizationId) {
 		mergeWideEvent({ access_result: "no_organization" });
-		return false;
+		return denied;
 	}
 
 	if (ctx.apiKey) {
 		if (hasGlobalAccess(ctx.apiKey)) {
 			if (!ctx.apiKey.organizationId) {
 				mergeWideEvent({ access_result: "api_key_no_org" });
-				return false;
+				return denied;
 			}
-			const granted = website.organizationId === ctx.apiKey.organizationId;
+			const granted = organizationId === ctx.apiKey.organizationId;
 			mergeWideEvent({
 				access_result: granted ? "api_key_global" : "api_key_denied",
 			});
-			return granted;
+			return { granted, organizationId };
 		}
 
 		const granted = getAccessibleWebsiteIds(ctx.apiKey).includes(websiteId);
 		mergeWideEvent({
 			access_result: granted ? "api_key_scoped" : "api_key_denied",
 		});
-		return granted;
+		return { granted, organizationId };
 	}
 
 	if (ctx.user) {
-		const membership = await db.query.member.findFirst({
-			where: { userId: ctx.user.id, organizationId: website.organizationId },
-			columns: { id: true },
-		});
-		mergeWideEvent({ access_result: membership ? "member" : "not_member" });
-		return !!membership;
+		const role = await getMemberRole(ctx.user.id, organizationId);
+		mergeWideEvent({ access_result: role ? "member" : "not_member" });
+		return { granted: !!role, organizationId };
 	}
 
 	mergeWideEvent({ access_result: "denied" });
-	return false;
+	return denied;
 }
 
 async function verifyScheduleAccess(
@@ -606,12 +611,9 @@ async function verifyScheduleAccess(
 	}
 
 	if (ctx.user) {
-		const membership = await db.query.member.findFirst({
-			where: { userId: ctx.user.id, organizationId: schedule.organizationId },
-			columns: { id: true },
-		});
-		mergeWideEvent({ access_result: membership ? "member" : "not_member" });
-		return !!membership;
+		const role = await getMemberRole(ctx.user.id, schedule.organizationId);
+		mergeWideEvent({ access_result: role ? "member" : "not_member" });
+		return !!role;
 	}
 
 	if (ctx.apiKey) {
@@ -663,12 +665,9 @@ async function verifyLinkAccess(
 	}
 
 	if (ctx.user && link.organizationId) {
-		const membership = await db.query.member.findFirst({
-			where: { userId: ctx.user.id, organizationId: link.organizationId },
-			columns: { id: true },
-		});
-		mergeWideEvent({ access_result: membership ? "member" : "not_member" });
-		return !!membership;
+		const role = await getMemberRole(ctx.user.id, link.organizationId);
+		mergeWideEvent({ access_result: role ? "member" : "not_member" });
+		return !!role;
 	}
 
 	if (ctx.user) {
@@ -707,12 +706,9 @@ async function verifyOrganizationAccess(
 	}
 
 	if (ctx.user) {
-		const membership = await db.query.member.findFirst({
-			where: { userId: ctx.user.id, organizationId },
-			columns: { id: true },
-		});
-		mergeWideEvent({ access_result: membership ? "member" : "not_member" });
-		return !!membership;
+		const role = await getMemberRole(ctx.user.id, organizationId);
+		mergeWideEvent({ access_result: role ? "member" : "not_member" });
+		return !!role;
 	}
 
 	if (ctx.apiKey) {
@@ -772,8 +768,8 @@ async function resolveProjectAccess(
 	}
 
 	if (websiteId) {
-		const hasAccess = await verifyWebsiteAccess(ctx, websiteId, queryTypes);
-		if (!hasAccess) {
+		const access = await verifyWebsiteAccess(ctx, websiteId, queryTypes);
+		if (!access.granted) {
 			return {
 				success: false,
 				error: ctx.isAuthenticated
@@ -783,7 +779,12 @@ async function resolveProjectAccess(
 				status: ctx.isAuthenticated ? 403 : 401,
 			};
 		}
-		return { success: true, projectId: websiteId, projectType: "website" };
+		return {
+			success: true,
+			projectId: websiteId,
+			projectType: "website",
+			organizationId: access.organizationId,
+		};
 	}
 
 	const apiKeyOrgFallback =
@@ -1357,12 +1358,13 @@ export const query = new Elysia({ prefix: "/v1/query" })
 					return rateLimited;
 				}
 
+				const queryTypes = extractQueryTypes(body);
 				const accessResult = await resolveProjectAccess(ctx, {
 					websiteId: q.website_id,
 					scheduleId: q.schedule_id,
 					linkId: q.link_id,
 					organizationId: q.organization_id,
-					queryTypes: extractQueryTypes(body),
+					queryTypes,
 				});
 
 				if (!accessResult.success) {
@@ -1375,24 +1377,16 @@ export const query = new Elysia({ prefix: "/v1/query" })
 				}
 
 				if (accessResult.projectType === "website" && q.website_id) {
-					const queryTypes = extractQueryTypes(body);
-					const website = await db.query.websites.findFirst({
-						where: { id: q.website_id },
-						columns: { organizationId: true },
+					const gateFail = await enforceFeatureGatesForQueryTypes(queryTypes, {
+						organizationId: accessResult.organizationId ?? null,
 					});
-					if (website) {
-						const gateFail = await enforceFeatureGatesForQueryTypes(
-							queryTypes,
-							website
+					if (gateFail) {
+						return createErrorResponse(
+							gateFail.error,
+							"FEATURE_UNAVAILABLE",
+							402,
+							requestId
 						);
-						if (gateFail) {
-							return createErrorResponse(
-								gateFail.error,
-								"FEATURE_UNAVAILABLE",
-								402,
-								requestId
-							);
-						}
 					}
 				}
 

--- a/packages/ai/src/lib/website-utils.ts
+++ b/packages/ai/src/lib/website-utils.ts
@@ -205,10 +205,10 @@ async function deriveWithSession(request: Request) {
 		return { user: session.user, session, timezone: tz } as const;
 	}
 
-	const tz = session?.user
-		? await getTimezone(request, session)
-		: await getTimezone(request, null);
-	const site = await getCachedWebsite(websiteId);
+	const [tz, site] = await Promise.all([
+		getTimezone(request, session?.user ? session : null),
+		getCachedWebsite(websiteId),
+	]);
 
 	if (!site) {
 		throw jsonError(404, "Website not found", "NOT_FOUND");


### PR DESCRIPTION
Cut two redundant Postgres round trips and a serialized lookup from every authenticated `/v1/query` request.

<<< AI-assisted wording below (disclosure per AI_POLICY.md) >>>

# Problem

Every authenticated request to `/v1/query` checks organization membership with a raw `db.query.member.findFirst`, bypassing the cached `getMemberRole` helper (300s TTL, stale-while-revalidate) that the RPC auth layer already uses for the same decision in `withWorkspace`. When the request targets a website, the handler then re-fetches the website row for feature gating even though `verifyWebsiteAccess` loaded its `organizationId` moments earlier. The shared `websiteAuth()` middleware has the same uncached membership lookup, and both it and `deriveWithSession` await the independent website and timezone lookups sequentially.

# Fix

Reuse `getMemberRole` from `@databuddy/rpc/organization` for the membership checks in the query access helpers and `websiteAuth()`, matching the caching semantics `withWorkspace` already applies. Thread `organizationId` from `verifyWebsiteAccess` through `resolveProjectAccess` so feature gating no longer re-queries the website. Fetch the website and timezone with `Promise.all` in `websiteAuth()` and `deriveWithSession`, mirroring the existing pattern in `deriveWithApiKey`.

No auth decisions change; membership staleness on these paths now matches the existing `withWorkspace` behavior.

# Verification

- `bun run test` (full suite via lefthook pre-push, all green; apps/api 200/200)
- `bun run check-types` (full monorepo via lefthook pre-commit, clean)
- `bunx ultracite check` on the changed files (clean)
- The integration suite skips in my environment (no Docker test DB); it should run in CI

AI usage disclosure: this change was developed with AI assistance (Claude Code). There is no accepted issue linked yet; I am happy to file one describing the redundant lookups if maintainers prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts two redundant Postgres round trips and a serialized lookup from every authenticated `/v1/query` request. Old behavior did uncached member checks and re-fetched website rows; new behavior reuses cached membership via `getMemberRole`, threads `organizationId`, and parallelizes website/timezone fetches. Auth decisions are unchanged; membership staleness now matches `withWorkspace` (300s TTL, SWR).

- Replaces raw membership queries with `getMemberRole` from `@databuddy/rpc/organization` in query access helpers and `websiteAuth()`, matching `withWorkspace` caching.
- Changes `verifyWebsiteAccess` to return `{ granted, organizationId }`; updates call sites and has `resolveProjectAccess` carry `organizationId` to the handler to avoid a second website read for feature gating.
- Uses the carried `organizationId` for `enforceFeatureGatesForQueryTypes` when querying by website, removing another website fetch in the route handler.
- Parallelizes website and timezone retrieval with `Promise.all` in `websiteAuth()` and `deriveWithSession()`; mirrors `deriveWithApiKey`.
- No external API changes; status codes and errors unchanged.

<sup>Written for commit 0d2c57b035c3e76980325b5aadad41b17cf6a17c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

