### PR TITLE
perf: cut per-item round trips in goal analytics, slack integrations, and event delivery

### DIFF
--- a/apps/basket/src/lib/event-service.ts
+++ b/apps/basket/src/lib/event-service.ts
@@ -311,7 +311,7 @@ export function insertTrackEvent(
 			throw deliveryUnavailable(error);
 		}
 
-		await markDuplicateReservationDelivered(reservation);
+		markDuplicateReservationDelivered(reservation);
 	});
 }
 
@@ -401,7 +401,7 @@ export function insertOutgoingLink(
 			throw deliveryUnavailable(error);
 		}
 
-		await markDuplicateReservationDelivered(reservation);
+		markDuplicateReservationDelivered(reservation);
 	});
 }
 
@@ -477,7 +477,7 @@ async function deliverItems<T>(
 				);
 				throw error;
 			}
-			await Promise.allSettled(
+			Promise.allSettled(
 				group.map(({ reservation }) =>
 					markDuplicateReservationDelivered(reservation)
 				)

--- a/packages/rpc/src/routers/goals.ts
+++ b/packages/rpc/src/routers/goals.ts
@@ -493,6 +493,7 @@ export const goalsRouter = {
 				.orderBy(desc(goals.createdAt));
 
 			const requestFilters = input.filters ?? [];
+			const totalUsersCache = new Map<string, Promise<number>>();
 			const results = await Promise.all(
 				goalsList.map(async (goal): Promise<[string, GoalAnalyticsResult]> => {
 					const effectiveStartDate = getEffectiveStartDate(
@@ -513,13 +514,20 @@ export const goalsRouter = {
 					const filters = (goal.filters as Filter[]) || [];
 					const combinedFilters = [...requestFilters, ...filters];
 
-					try {
-						const totalUsers = await getTotalWebsiteUsers(
+					const totalUsersKey = `${effectiveStartDate}|${JSON.stringify(combinedFilters)}`;
+					let totalUsersPromise = totalUsersCache.get(totalUsersKey);
+					if (!totalUsersPromise) {
+						totalUsersPromise = getTotalWebsiteUsers(
 							input.websiteId,
 							effectiveStartDate,
 							endDate,
 							combinedFilters
 						);
+						totalUsersCache.set(totalUsersKey, totalUsersPromise);
+					}
+
+					try {
+						const totalUsers = await totalUsersPromise;
 						const analytics = await processGoalAnalytics(
 							steps,
 							combinedFilters,

--- a/packages/rpc/src/routers/integrations.ts
+++ b/packages/rpc/src/routers/integrations.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "@databuddy/db";
+import { and, desc, eq, inArray } from "@databuddy/db";
 import {
 	account,
 	slackChannelBindings,
@@ -148,34 +148,46 @@ export const integrationsRouter = {
 				throw error;
 			}
 
-			const slack = await Promise.all(
-				slackRows.map(async (integration) => {
-					let channelBindings: SlackChannelBindingRow[];
-					try {
-						channelBindings = await context.db
-							.select({
-								id: slackChannelBindings.id,
-								slackChannelId: slackChannelBindings.slackChannelId,
-								createdAt: slackChannelBindings.createdAt,
-								updatedAt: slackChannelBindings.updatedAt,
-							})
-							.from(slackChannelBindings)
-							.where(eq(slackChannelBindings.integrationId, integration.id))
-							.orderBy(desc(slackChannelBindings.updatedAt));
-					} catch (error) {
-						if (isMissingSlackSchemaError(error)) {
-							channelBindings = [];
+			const bindingsByIntegration = new Map<string, SlackChannelBindingRow[]>();
+			if (slackRows.length > 0) {
+				try {
+					const bindingRows = await context.db
+						.select({
+							id: slackChannelBindings.id,
+							slackChannelId: slackChannelBindings.slackChannelId,
+							createdAt: slackChannelBindings.createdAt,
+							updatedAt: slackChannelBindings.updatedAt,
+							integrationId: slackChannelBindings.integrationId,
+						})
+						.from(slackChannelBindings)
+						.where(
+							inArray(
+								slackChannelBindings.integrationId,
+								slackRows.map((row) => row.id)
+							)
+						)
+						.orderBy(desc(slackChannelBindings.updatedAt));
+
+					for (const { integrationId, ...binding } of bindingRows) {
+						const existing = bindingsByIntegration.get(integrationId);
+						if (existing) {
+							existing.push(binding);
 						} else {
-							throw error;
+							bindingsByIntegration.set(integrationId, [binding]);
 						}
 					}
+				} catch (error) {
+					if (!isMissingSlackSchemaError(error)) {
+						throw error;
+					}
+					bindingsByIntegration.clear();
+				}
+			}
 
-					return {
-						...integration,
-						channelBindings,
-					};
-				})
-			);
+			const slack = slackRows.map((integration) => ({
+				...integration,
+				channelBindings: bindingsByIntegration.get(integration.id) ?? [],
+			}));
 
 			return { slack };
 		}),


### PR DESCRIPTION
Collapse per-item database round trips on three hot paths: bulk goal analytics, the Slack integrations list, and the event delivery response path.

<<< AI-assisted wording below (disclosure per AI_POLICY.md) >>>

# Problem

`goals.bulkAnalytics` runs `getTotalWebsiteUsers` once per goal inside the per-goal `Promise.all`, even though goals that share a date range and have no per-goal filters produce byte-identical ClickHouse queries. A Goals page with N comparable goals pays N identical round trips for one number.

`integrations.listIntegrations` runs one `slackChannelBindings` query per Slack integration row, a classic N+1.

In basket, `markDuplicateReservationDelivered` is awaited after the Kafka/ClickHouse send at all three delivery sites in `event-service.ts`. The call is best effort by design: its body guards on the reservation fields, swallows every error via `captureError`, and nothing downstream reads its result. Awaiting it adds a blocking Redis `EVAL`, with up to a 750ms dedup deadline, to every event's client-facing response after the durable send has already succeeded.

# Fix

In `goals.ts`, share in-flight `getTotalWebsiteUsers` promises across goals through a per-request map keyed on the effective start date and combined filters. Concurrent goals with identical inputs await one query; the `await` stays inside the existing try so a failure still produces the existing per-goal error result.

In `integrations.ts`, fetch all channel bindings in a single `inArray` query and group them by integration id. The `isMissingSlackSchemaError` fallback to empty bindings and the per-integration `updatedAt` ordering are preserved, and the grouping key is stripped before rows reach the output.

In `event-service.ts`, stop awaiting `markDuplicateReservationDelivered` at the three delivery sites and let it complete off the response path. It cannot reject (verified through `security.ts` and the `record` tracing wrapper), so a floating call is safe.

# Verification

- `cd apps/basket && bunx vitest run` (604 passed, including `event-service.delivery.test.ts`)
- `cd packages/rpc && bun run test` (306 passed, 0 failed)
- `bun run check-types` (full monorepo, clean)
- `bunx ultracite check` on the changed files (clean)

AI usage disclosure: this change was developed with AI assistance (Claude Code). No accepted issue is linked yet; I am happy to file one if maintainers prefer.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts per-item round trips in goal analytics and Slack integrations, and removes a blocking step from the event delivery response path to reduce latency and database load. Previously: N identical queries per goals page, N+1 queries per Slack integration list, and the dedup-delivered marker awaited on the response path; now: shared queries, a batched fetch, and a fire-and-forget marker.

- `packages/rpc/src/routers/goals.ts`: Share in-flight `getTotalWebsiteUsers` promises per request using a key of effective start date + combined filters. Await stays inside the per-goal try/catch to keep existing error behavior; results unchanged with fewer queries.
- `packages/rpc/src/routers/integrations.ts`: Replace per-integration `slackChannelBindings` queries with one `inArray` query and group by `integrationId`. Preserve `isMissingSlackSchemaError` fallback to empty bindings and `updatedAt` ordering; strip the grouping key from output.
- `apps/basket/src/lib/event-service.ts`: Stop awaiting `markDuplicateReservationDelivered` in `insertTrackEvent`, `insertOutgoingLink`, and `deliverItems`. Calls remain best-effort and non-throwing; response latency no longer includes the Redis EVAL/dedup deadline after the durable send succeeds.

<sup>Written for commit a011404ce26faaad3bd916571b91b58d4f43a632. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

