### PR TITLE
fix(sdk): catch storage errors in getAnonymousId and getSessionId

### DIFF
--- a/.changeset/sdk-storage-error-fix.md
+++ b/.changeset/sdk-storage-error-fix.md
@@ -1,0 +1,5 @@
+---
+"@databuddy/sdk": patch
+---
+
+`getAnonymousId` and `getSessionId` now return `null` instead of throwing when `localStorage` or `sessionStorage` access raises a `DOMException`. Follows the same try/catch pattern already used by `getProfileId`. URL params continue to take priority without touching storage.

--- a/packages/sdk/src/core/tracker.ts
+++ b/packages/sdk/src/core/tracker.ts
@@ -160,7 +160,15 @@ export function getAnonymousId(urlParams?: URLSearchParams): string | null {
 	if (typeof window === "undefined") {
 		return null;
 	}
-	return urlParams?.get("anonId") || localStorage.getItem("did") || null;
+	const fromParams = urlParams?.get("anonId");
+	if (fromParams) {
+		return fromParams;
+	}
+	try {
+		return localStorage.getItem("did") || null;
+	} catch {
+		return null;
+	}
 }
 
 /** Get current session ID. Priority: URL params → sessionStorage. Resets after 30 min inactivity. */
@@ -168,9 +176,15 @@ export function getSessionId(urlParams?: URLSearchParams): string | null {
 	if (typeof window === "undefined") {
 		return null;
 	}
-	return (
-		urlParams?.get("sessionId") || sessionStorage.getItem("did_session") || null
-	);
+	const fromParams = urlParams?.get("sessionId");
+	if (fromParams) {
+		return fromParams;
+	}
+	try {
+		return sessionStorage.getItem("did_session") || null;
+	} catch {
+		return null;
+	}
 }
 
 /** Get both anonymous ID and session ID in one call. */

--- a/packages/sdk/tests/sdk-functions.spec.ts
+++ b/packages/sdk/tests/sdk-functions.spec.ts
@@ -289,17 +289,14 @@ test.describe("SDK Functions", () => {
 			page,
 		}) => {
 			const result = await page.evaluate(() => {
-				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function (key: string) {
-					if (this === localStorage) {
-						throw new DOMException("Access denied", "SecurityError");
-					}
-					return original.call(this, key);
+				const { getItem } = Storage.prototype;
+				localStorage.getItem = () => {
+					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
 					return window.__SDK__.getAnonymousId();
 				} finally {
-					Storage.prototype.getItem = original;
+					localStorage.getItem = getItem;
 				}
 			});
 			expect(result).toBeNull();
@@ -309,17 +306,14 @@ test.describe("SDK Functions", () => {
 			page,
 		}) => {
 			const result = await page.evaluate(() => {
-				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function (key: string) {
-					if (this === sessionStorage) {
-						throw new DOMException("Access denied", "SecurityError");
-					}
-					return original.call(this, key);
+				const { getItem } = Storage.prototype;
+				sessionStorage.getItem = () => {
+					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
 					return window.__SDK__.getSessionId();
 				} finally {
-					Storage.prototype.getItem = original;
+					sessionStorage.getItem = getItem;
 				}
 			});
 			expect(result).toBeNull();
@@ -330,7 +324,7 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function () {
+				Storage.prototype.getItem = () => {
 					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
@@ -348,17 +342,14 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				sessionStorage.setItem("did_session", "sess-ok");
-				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function (key: string) {
-					if (this === localStorage) {
-						throw new DOMException("Access denied", "SecurityError");
-					}
-					return original.call(this, key);
+				const { getItem } = Storage.prototype;
+				localStorage.getItem = () => {
+					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
 					return window.__SDK__.getTrackingIds();
 				} finally {
-					Storage.prototype.getItem = original;
+					localStorage.getItem = getItem;
 				}
 			});
 			expect(result.anonId).toBeNull();
@@ -370,17 +361,14 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				localStorage.setItem("did", "anon-ok");
-				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function (key: string) {
-					if (this === sessionStorage) {
-						throw new DOMException("Access denied", "SecurityError");
-					}
-					return original.call(this, key);
+				const { getItem } = Storage.prototype;
+				sessionStorage.getItem = () => {
+					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
 					return window.__SDK__.getTrackingIds();
 				} finally {
-					Storage.prototype.getItem = original;
+					sessionStorage.getItem = getItem;
 				}
 			});
 			expect(result.anonId).toBe("anon-ok");
@@ -392,7 +380,7 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function () {
+				Storage.prototype.getItem = () => {
 					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
@@ -409,17 +397,14 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				localStorage.setItem("did", "anon-partial");
-				const original = Storage.prototype.getItem;
-				Storage.prototype.getItem = function (key: string) {
-					if (this === sessionStorage) {
-						throw new DOMException("Access denied", "SecurityError");
-					}
-					return original.call(this, key);
+				const { getItem } = Storage.prototype;
+				sessionStorage.getItem = () => {
+					throw new DOMException("Access denied", "SecurityError");
 				};
 				try {
 					return window.__SDK__.getTrackingParams();
 				} finally {
-					Storage.prototype.getItem = original;
+					sessionStorage.getItem = getItem;
 				}
 			});
 			expect(result).toContain("anonId=anon-partial");
@@ -432,7 +417,7 @@ test.describe("SDK Functions", () => {
 			const result = await page.evaluate(() => {
 				const original = Storage.prototype.getItem;
 				let storageWasAccessed = false;
-				Storage.prototype.getItem = function () {
+				Storage.prototype.getItem = () => {
 					storageWasAccessed = true;
 					throw new DOMException("Access denied", "SecurityError");
 				};

--- a/packages/sdk/tests/sdk-functions.spec.ts
+++ b/packages/sdk/tests/sdk-functions.spec.ts
@@ -284,6 +284,171 @@ test.describe("SDK Functions", () => {
 		});
 	});
 
+	test.describe("tracking helpers — storage throws", () => {
+		test("getAnonymousId() returns null when localStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function (key: string) {
+					if (this === localStorage) {
+						throw new DOMException("Access denied", "SecurityError");
+					}
+					return original.call(this, key);
+				};
+				try {
+					return window.__SDK__.getAnonymousId();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result).toBeNull();
+		});
+
+		test("getSessionId() returns null when sessionStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function (key: string) {
+					if (this === sessionStorage) {
+						throw new DOMException("Access denied", "SecurityError");
+					}
+					return original.call(this, key);
+				};
+				try {
+					return window.__SDK__.getSessionId();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result).toBeNull();
+		});
+
+		test("getTrackingIds() returns both null when both storages throw", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function () {
+					throw new DOMException("Access denied", "SecurityError");
+				};
+				try {
+					return window.__SDK__.getTrackingIds();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result.anonId).toBeNull();
+			expect(result.sessionId).toBeNull();
+		});
+
+		test("getTrackingIds() returns sessionId when only localStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				sessionStorage.setItem("did_session", "sess-ok");
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function (key: string) {
+					if (this === localStorage) {
+						throw new DOMException("Access denied", "SecurityError");
+					}
+					return original.call(this, key);
+				};
+				try {
+					return window.__SDK__.getTrackingIds();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result.anonId).toBeNull();
+			expect(result.sessionId).toBe("sess-ok");
+		});
+
+		test("getTrackingIds() returns anonId when only sessionStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				localStorage.setItem("did", "anon-ok");
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function (key: string) {
+					if (this === sessionStorage) {
+						throw new DOMException("Access denied", "SecurityError");
+					}
+					return original.call(this, key);
+				};
+				try {
+					return window.__SDK__.getTrackingIds();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result.anonId).toBe("anon-ok");
+			expect(result.sessionId).toBeNull();
+		});
+
+		test("getTrackingParams() returns empty string when both storages throw", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function () {
+					throw new DOMException("Access denied", "SecurityError");
+				};
+				try {
+					return window.__SDK__.getTrackingParams();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result).toBe("");
+		});
+
+		test("getTrackingParams() returns partial string when only sessionStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				localStorage.setItem("did", "anon-partial");
+				const original = Storage.prototype.getItem;
+				Storage.prototype.getItem = function (key: string) {
+					if (this === sessionStorage) {
+						throw new DOMException("Access denied", "SecurityError");
+					}
+					return original.call(this, key);
+				};
+				try {
+					return window.__SDK__.getTrackingParams();
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result).toContain("anonId=anon-partial");
+			expect(result).not.toContain("sessionId");
+		});
+
+		test("URL param takes priority without touching storage when localStorage throws", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				const original = Storage.prototype.getItem;
+				let storageWasAccessed = false;
+				Storage.prototype.getItem = function () {
+					storageWasAccessed = true;
+					throw new DOMException("Access denied", "SecurityError");
+				};
+				const params = new URLSearchParams("anonId=anon-from-url");
+				try {
+					const id = window.__SDK__.getAnonymousId(params);
+					return { id, storageWasAccessed };
+				} finally {
+					Storage.prototype.getItem = original;
+				}
+			});
+			expect(result.id).toBe("anon-from-url");
+			expect(result.storageWasAccessed).toBe(false);
+		});
+	});
+
 	test.describe("getTracker", () => {
 		test("returns null when tracker is not loaded", async ({ page }) => {
 			const result = await page.evaluate(() => window.__SDK__.getTracker());


### PR DESCRIPTION
Fixes #638

## What

`getAnonymousId()` and `getSessionId()` both access `localStorage` and
`sessionStorage` with no error handling. Web Storage can throw a
`DOMException` (usually `SecurityError`) when storage is blocked by
browser privacy settings, sandboxed iframes, or Safari ITP — and when
that happens the exception propagates up through `getTrackingIds()` and
`getTrackingParams()` to every caller.

Reproduced it with the snippet from the issue — overriding
`Storage.prototype.getItem` to throw and calling `getAnonymousId()`
confirms it throws instead of returning null.

## Why it matters

Two real callsites get hurt by this. The contact form calls
`getTrackingIds()` *before* entering its try/catch, so a storage error
prevents the form from submitting entirely — not just drops the tracking
IDs. The Stripe metadata helper has no error handling at all.

## How

While reading through the codebase I noticed `getProfileId()` already
handles this — it wraps `localStorage.getItem()` in a try/catch and
returns null on failure. The fix for `getAnonymousId` and `getSessionId`
is the exact same pattern, just wasn't applied consistently.

Also made the URL-param short-circuit an explicit `if` guard so when a
param is present, storage is never touched at all (not just skipped via
JS truthiness). Matches what the issue asked for.

`getTrackingIds` and `getTrackingParams` are unchanged — they just
delegate and get the fix for free.

Added 8 Playwright tests covering: each helper returning null when its
storage throws, partial results when only one storage fails, empty string
from `getTrackingParams`, and URL param bypassing storage entirely.

## Tests

```
40 passed (sdk-functions.spec.ts, chromium)
5 passed (storage-edge-cases.spec.ts, chromium)
tsc --noEmit: 0 errors
```

---

**AI disclosure**: I used Claude to help with research and writing. I
reproduced the issue myself, traced the callsites, and spotted the
`getProfileId` pattern in the codebase as the solution. I sketched the
plan and rough pseudocode for the fix and tests — Claude helped complete
the implementation and fill in the test cases from that. I reviewed all
the generated code, ran type-check and the full E2E suite locally before
opening this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Web Storage errors from breaking tracking ID lookups in `@databuddy/sdk`. Previously, `getAnonymousId`/`getSessionId` threw when storage was blocked; now they return null, and URL params short-circuit without accessing storage so flows like form submissions keep working.

- Mirrors the `getProfileId` try/catch pattern; `getTrackingIds`/`getTrackingParams` are unchanged and inherit the safer behavior.
- Adds Playwright tests for storage-throw cases, partial results, empty params, and URL param short-circuit.
- Migration: If any caller relied on these helpers throwing, update it to handle null results instead.

<sup>Written for commit a713e0632dc7c21096492379350ca9a5db393b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

