### PR TITLE
docs: document minimum bun version requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,14 +18,14 @@ git clone https://github.com/databuddy-analytics/Databuddy.git
 cd databuddy
 ```
 
-2. Install dependencies (requires Bun ≥ 1.2.0 — run `bun --version` to check, upgrade at https://bun.sh if needed):
+2. Install dependencies (requires Bun 1.2.0+, check with `bun --version`):
 
 ```bash
 bun install
 ```
 
 > [!NOTE]
-> Bun ≥ 1.2.0 is only the minimum required for `catalog:` protocol support. The repo pins an exact version via the `packageManager` field in `package.json`, so contributors should use that version to avoid install conflicts (check it with `grep packageManager package.json`, or activate it via Corepack with `corepack prepare bun@<version> --activate`).
+> Bun 1.2.0 is the minimum for `catalog:` dependency support. The repo pins an exact version in the `packageManager` field of `package.json`; match it with `bun upgrade` or by installing that version from https://bun.sh.
 
 3. Set up environment variables:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,9 @@ cd databuddy
 bun install
 ```
 
+> [!NOTE]
+> Bun ≥ 1.2.0 is only the minimum required for `catalog:` protocol support. The repo pins an exact version via the `packageManager` field in `package.json`, so contributors should use that version to avoid install conflicts (check it with `grep packageManager package.json`, or activate it via Corepack with `corepack prepare bun@<version> --activate`).
+
 3. Set up environment variables:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ git clone https://github.com/databuddy-analytics/Databuddy.git
 cd databuddy
 ```
 
-2. Install dependencies:
+2. Install dependencies (requires Bun ≥ 1.2.0 — run `bun --version` to check, upgrade at https://bun.sh if needed):
 
 ```bash
 bun install

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "ultracite": "^7.6.1"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=20",
+    "bun": ">=1.2.0"
   },
   "overrides": {
     "protobufjs": ">=7.5.5",


### PR DESCRIPTION
The `catalog:` protocol used throughout `package.json` for shared dependencies requires Bun 1.2.0+. On older versions, `bun install` fails with a confusing error about "git clone" for `@types/bun`, which looks like a network problem but is actually just an unsupported feature.

Added `"bun": ">=1.2.0"` to the `engines` field in `package.json` and a one-line note to the install step in CONTRIBUTING.md.

Noticed this while setting up locally to work on #638.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies and enforces a minimum Bun version to support the `catalog:` protocol and prevent misleading install errors. Previously `bun install` on Bun <1.2.0 failed with a `git clone` error for `@types/bun`; now we require Bun ≥1.2.0 and document the exact Bun version pinned via `packageManager` to avoid install conflicts.

- Adds `"bun": ">=1.2.0"` to the `engines` field in `package.json`.
- Updates `CONTRIBUTING.md` to call out the minimum and the pinned Bun version (with Corepack activation guidance).

**Developer action**
- Upgrade Bun to ≥1.2.0 and verify with `bun --version`.
- Use the pinned Bun version from `packageManager` to install and run locally.

<sup>Written for commit 6fdaca901a660529117aaa90e023dee498acedca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

