### PR TITLE
chore(tooling): add Knip configuration to detect unused files and dependencies

### DIFF
--- a/.agents/skills/databuddy-internal/SKILL.md
+++ b/.agents/skills/databuddy-internal/SKILL.md
@@ -77,6 +77,7 @@ Keep additions **minimal**: one bullet, a new `rg` hint, or a routing note—eno
 - `packages/sdk`: published analytics SDK for React, Vue, and Node
 - `packages/tracker`: internal tracker script build and release package
 - `packages/encryption`, `packages/notifications`, `packages/cache`, `packages/redis`, `packages/services`, `packages/validation`, `packages/api-keys`: shared infra and domain packages
+- Knip is configured in root `knip.json` (run `bun run knip`); per-workspace test globs are required because the root `test:watch` (`bun test --watch ./apps`) script shadows the Bun plugin's per-workspace script parsing; `apps/cron` is ignored (standalone scripts, no package.json)
 
 Read [codebase-map.md](./references/codebase-map.md) when you need deeper routing guidance.
 

--- a/knip.json
+++ b/knip.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "./node_modules/knip/schema.json",
+  "workspaces": {
+    ".": {
+      "entry": ["scripts/**/*.ts"],
+      "ignore": ["apps/cron/**"],
+      "ignoreBinaries": ["where", "which", "up"]
+    },
+    "apps/dashboard": {
+      "entry": ["**/*.test.{ts,tsx}"],
+      "ignoreDependencies": ["topojson-specification"]
+    },
+    "apps/docs": {
+      "entry": ["source.config.ts", "content/**/*.mdx", "**/*.test.{ts,tsx}"]
+    },
+    "apps/insights": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "apps/links": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "apps/slack": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "apps/uptime": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "apps/video": {
+      "entry": ["remotion.config.ts", "src/index.ts"],
+      "ignoreBinaries": ["out/intelligence-platform.mp4"]
+    },
+    "packages/ai": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/api-keys": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/db": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/devtools": {
+      "entry": ["src/{core,react,vue}/index.ts"]
+    },
+    "packages/email": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/encryption": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/env": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/migrate": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/notifications": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/nuxt": {
+      "entry": [
+        "src/module.ts",
+        "src/runtime/**/*.ts",
+        "playground/**/*.{ts,vue}"
+      ]
+    },
+    "packages/redis": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/rpc": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/sdk": {
+      "entry": [
+        "src/{core,node,react,vue}/index.ts",
+        "test-entry.ts",
+        "tests/**/*.test.{ts,tsx}",
+        "tests/**/*.types.ts"
+      ]
+    },
+    "packages/services": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/shared": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    },
+    "packages/tracker": {
+      "entry": [
+        "src/{errors,index,vitals}.ts",
+        "test-server.ts",
+        "tests/unit/**/*.test.ts"
+      ]
+    },
+    "packages/ui": {
+      "ignoreDependencies": ["tailwindcss", "tw-animate-css"]
+    },
+    "packages/validation": {
+      "entry": ["**/*.test.{ts,tsx}"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "databuddy",
-  "module": "index.ts",
   "devDependencies": {
     "@babel/plugin-proposal-optional-chaining": "^7.21.0",
     "@babel/plugin-transform-react-jsx": "^7.28.6",
@@ -44,6 +43,7 @@
     "test:watch": "dotenv -- bun test --watch ./apps",
     "test:coverage": "dotenv -- bun test --coverage ./apps",
     "lint": "bunx ultracite check && bun run lint:policies",
+    "knip": "knip",
     "lint:policies": "bunx tsc --project scripts/tsconfig.json && bun test scripts/lint-policy.test.ts && bun scripts/lint-policy.ts",
     "format": "bunx ultracite fix",
     "check-types": "dotenv -- turbo run check-types",


### PR DESCRIPTION
### Description
Adds a workspace-aware [Knip](https://knip.dev) configuration (`knip.json`) so unused files, dependencies, exports, and catalog entries can be detected across all 11 apps and 23 packages. Knip was already pinned in root `devDependencies` but had no config or script, making it unusable.

### fixes #645 

What's included:
- **`knip.json`** — per-workspace entry points matching repo conventions:
  - Test-file globs per workspace (the root `test:watch` script shadows Knip's Bun plugin per-workspace parsing)
  - Fumadocs entries for `apps/docs` (`source.config.ts`, `content/**/*.mdx`)
  - Runtime/playground entries for `packages/nuxt` (resolved via string paths)
  - Source entries for dist-building published packages (`sdk`, `devtools`, `nuxt`, `tracker`)
  - `ignoreBinaries` for shell utilities in `setup.ts` and the mp4 output path in `apps/video`
  - `apps/cron/**` ignored (standalone ops scripts, not a real workspace)
- **Root script** — `"knip": "knip"` so it runs via `bun run knip`
- Removed bogus root `"module": "index.ts"` field (pointed at a nonexistent file)

First run surfaces real findings (111 unused files, 58 unused deps, 355 unused exports, 24 unused catalog entries) to be cleaned up or baselined in follow-ups. It also exposed a pre-existing broken export in `packages/email` (`./config` → missing `config.ts`).

### Slice

- Issue: #645 
- Scope / owning surface: root tooling config (`knip.json`, root `package.json`) + agent skill doc note
- Dependencies or overlapping PRs: None

<details>
<summary>Checklist</summary>

- [x] This branch started from current `staging` and does not include another unmerged PR unless it is named above.
- [x] This is one independently reviewable slice; unrelated cleanup or refactors are in separate PRs.
- [x] I checked open PRs for overlapping files, contracts, schemas, or deployment configuration and made any dependency explicit above.
- [x] This PR targets `staging`; after it closes, this branch will not be reused for another change.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds workspace-aware `knip` configuration and a root script to detect unused files, dependencies, and exports across all apps and packages. Previously `knip` was installed but unusable; now run it via `bun run knip`. Also removes the bogus root "module" field and adds a brief usage note to the internal SKILL guide. Satisfies #645.

- Adds `knip.json` with per-workspace entries, targeted ignores (e.g., apps/cron/**, apps/video mp4 output), and scoped `ignoreDependencies` for `apps/dashboard` (`topojson-specification`) and `packages/ui` (`tailwindcss`, `tw-animate-css`).
- Adds `"knip": "knip"` to the root `package.json`.

**Review**
- Run `bun run knip` and confirm the schema loads and workspaces resolve.
- Spot-check entries/ignores and dependency exceptions are narrowly scoped and intentional.
- Confirm removing the root `"module"` field has no build/runtime impact.

**Rollout**
- Tooling-only; no migrations. After merge, baseline findings with `bun run knip`.

<sup>Written for commit 45bb275f9df16b53728c7a26a2ff41a3e869938d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

