### PR TITLE
fix: close audit tenant attribution gap

### DIFF
--- a/packages/rpc/src/routers/insight-generation.ts
+++ b/packages/rpc/src/routers/insight-generation.ts
@@ -383,12 +383,12 @@ async function resolveOrganization(
 	if (!organizationId) {
 		throw rpcError.badRequest("Organization ID is required");
 	}
-	setAuditOrganization(context, organizationId);
 	await withWorkspace(context, {
 		organizationId,
 		resource: "organization",
 		permissions: [permission],
 	});
+	setAuditOrganization(context, organizationId);
 	return organizationId;
 }
 

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -508,14 +508,13 @@ export async function appendInvestigationReply(
 	if (!insight) {
 		throw rpcError.notFound("insight", parsed.insightId);
 	}
-	setAuditOrganization(context, insight.organizationId);
-
 	await withWorkspace(context, {
 		allowCrossOrg: true,
 		organizationId: insight.organizationId,
 		permissions: ["update"],
 		websiteId: insight.websiteId,
 	});
+	setAuditOrganization(context, insight.organizationId);
 
 	const author = replyAuthor(context, authorName);
 	const createdAt = new Date();
@@ -726,8 +725,6 @@ export async function applyInsightAction(input: {
 	if (!target) {
 		throw rpcError.notFound("insight", parsed.insightId);
 	}
-	setAuditOrganization(context, target.organizationId);
-
 	const [latestObservation] = await db
 		.select({
 			outcome: insightObservations.outcome,
@@ -763,6 +760,7 @@ export async function applyInsightAction(input: {
 		permissions: initialAction.operation === "delete" ? ["delete"] : ["update"],
 		websiteId: target.websiteId,
 	});
+	setAuditOrganization(context, target.organizationId);
 
 	const author = replyAuthor(context);
 	const completed = await db.transaction(async (tx) => {
@@ -1664,13 +1662,13 @@ export const insightsRouter = {
 			if (!reply) {
 				throw rpcError.notFound("insight reply", input.replyId);
 			}
-			setAuditOrganization(context, reply.organizationId);
 			await withWorkspace(context, {
 				allowCrossOrg: true,
 				organizationId: reply.organizationId,
 				permissions: ["update"],
 				websiteId: reply.websiteId,
 			});
+			setAuditOrganization(context, reply.organizationId);
 			const pendingStatus = await db.transaction(async (tx) => {
 				const insightCase = and(
 					eq(analyticsInsights.organizationId, reply.organizationId),

--- a/packages/sdk/src/core/flags/flags-manager.ts
+++ b/packages/sdk/src/core/flags/flags-manager.ts
@@ -850,7 +850,14 @@ export class BrowserFlagsManager extends BaseFlagsManager {
 	}
 
 	protected override onFlagEvaluated(key: string, result: FlagResult): void {
-		const dedupeKey = `${key}:${String(result.value)}`;
+		let valueKey: string;
+		try {
+			valueKey = JSON.stringify(result.value) ?? String(result.value);
+		} catch {
+			// A malformed custom value should not prevent telemetry.
+			valueKey = String(result.value);
+		}
+		const dedupeKey = `${key}:${result.variant ?? ""}:${valueKey}`;
 		if (this.trackedFlags.has(dedupeKey)) {
 			return;
 		}

--- a/packages/sdk/src/core/flags/flags-manager.ts
+++ b/packages/sdk/src/core/flags/flags-manager.ts
@@ -857,7 +857,9 @@ export class BrowserFlagsManager extends BaseFlagsManager {
 			// A malformed custom value should not prevent telemetry.
 			valueKey = String(result.value);
 		}
-		const dedupeKey = `${key}:${result.variant ?? ""}:${valueKey}`;
+		const dedupeKey = [key, result.variant ?? "", valueKey]
+			.map((part) => `${part.length}:${part}`)
+			.join("");
 		if (this.trackedFlags.has(dedupeKey)) {
 			return;
 		}


### PR DESCRIPTION
## Summary\n- scope insight audit targets only after workspace authorization succeeds\n- prevent denied cross-organization requests from poisoning audit logs\n- preserve flag variant and JSON value identity in SDK activity telemetry\n\n## Validation\n- bun run lint\n- bun run check-types\n- bun run test (3940 passed, 34 skipped, 0 failed)\n- insight-generation tests (13 passed)\n- SDK unit tests (79 passed)\n\nFollow-up to merged PR #627; these fixes are based on the post-merge security review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes insight audit targets only after workspace authorization and makes flag telemetry dedupe keys collision‑safe. This closes a tenant attribution gap and prevents accidental dedupe of distinct variant/JSON evaluations.

- RPC: In `packages/rpc` insight routes (`insight-generation`, `insights`), call `setAuditOrganization` only after `withWorkspace` succeeds. Old behavior set the audit org before auth; new behavior sets it post‑auth. Side effect: denied cross‑org requests no longer tag audit context, eliminating incorrect audit attributions.
- SDK: In `packages/sdk`, change the flag evaluation dedupe key to a length‑prefixed tuple of [key, variant, JSON(value)] with a safe JSON stringify fallback. Old behavior used `String(value)` and ignored `variant`; new behavior preserves variant/JSON identity and avoids delimiter collisions. Side effect: more granular and collision‑free activity events, even when values contain colons or complex JSON.

<sup>Written for commit 7c415dc4be37c468935a30bd54fd79f05d63d7ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

