### PR TITLE
fix(dashboard): align web vitals breakdown values

### DIFF
--- a/apps/dashboard/app/(main)/websites/[id]/_components/tabs/performance/_components/web-vitals-metric-cell.tsx
+++ b/apps/dashboard/app/(main)/websites/[id]/_components/tabs/performance/_components/web-vitals-metric-cell.tsx
@@ -65,15 +65,22 @@ export function WebVitalsMetricCell({
 	const formatted =
 		metric === "cls" ? value.toFixed(3) : formatPerformanceTime(value);
 	const { colorClass, isGood, isPoor } = getMetricStyles(value, metric);
-	const showIcon = isGood || isPoor;
 
 	return (
-		<div className="flex items-center gap-1">
+		<div className="flex items-center justify-end gap-1">
+			{isGood ? (
+				<CheckCircle
+					aria-hidden="true"
+					className="size-3.5 shrink-0 text-success"
+				/>
+			) : null}
+			{isPoor ? (
+				<Warning
+					aria-hidden="true"
+					className="size-3.5 shrink-0 text-destructive"
+				/>
+			) : null}
 			<span className={colorClass}>{formatted}</span>
-			{showIcon && isGood && (
-				<CheckCircle className="size-3.5 text-green-600" />
-			)}
-			{showIcon && isPoor && <Warning className="size-3.5 text-red-600" />}
 		</div>
 	);
 }

--- a/apps/dashboard/components/table/table-content.tsx
+++ b/apps/dashboard/components/table/table-content.tsx
@@ -40,7 +40,7 @@ const DEFAULT_CELL_STYLE = {
 
 const COMPACT_COLUMN_WIDTHS: Record<string, number> = {
 	clicks: 88,
-	cls: 76,
+	cls: 78,
 	current_time: 108,
 	customers: 100,
 	fcp: 88,


### PR DESCRIPTION
## Summary

Fixes value alignment in the Web Vitals breakdown table across Pages, Countries, Regions, Cities, and Browsers.

- Moves success and error icons before metric values so the numbers remain right-aligned.
- Prevents status icons from shrinking beside three-decimal CLS values.
- Increases the CLS column width from 76px to 78px to prevent clipping.

## Screenshots

### Pages

**Before**
<img width="1224" height="600" alt="before-pages" src="https://github.com/user-attachments/assets/cea22f64-b878-4ae1-99d8-f6599191f8ea" />

<!-- Upload before-pages.jpg here -->

**After**
<img width="1224" height="600" alt="after-pages" src="https://github.com/user-attachments/assets/c4e2b86e-2f02-41a3-9c57-5436dc7188ad" />

<!-- Upload after-pages.jpg here -->

### Countries

**Before**
<img width="1224" height="600" alt="before-countries" src="https://github.com/user-attachments/assets/f7c0b613-b335-47a1-8229-f61563e19776" />

<!-- Upload before-countries.jpg here -->

**After**
<img width="1224" height="600" alt="after-countries" src="https://github.com/user-attachments/assets/6dbef346-5967-47a8-908d-59d44ce1ca51" />

<!-- Upload after-countries.jpg here -->

### Regions

**Before**
<img width="1224" height="600" alt="before-regions" src="https://github.com/user-attachments/assets/bf8a4fe2-b3b4-40d3-9fe4-7b98ebf87786" />

<!-- Upload before-regions.jpg here -->

**After**
<img width="1224" height="600" alt="after-regions" src="https://github.com/user-attachments/assets/909d1e29-40f8-40fa-8015-80fca25e1b34" />


<!-- Upload after-regions.jpg here -->

### Cities

**Before**
<img width="1224" height="600" alt="before-cities" src="https://github.com/user-attachments/assets/a377563a-bbc5-452e-9f69-6a7750fa8d41" />


<!-- Upload before-cities.jpg here -->

**After**
<img width="1224" height="600" alt="after-cities" src="https://github.com/user-attachments/assets/1b6e6197-3b9f-4871-a5b0-e7cb3fc8e131" />


<!-- Upload after-cities.jpg here -->

### Browsers

**Before**
<img width="1224" height="600" alt="before-browsers" src="https://github.com/user-attachments/assets/04b9ff5b-23a2-4750-b149-1afa9391d0b8" />

<!-- Upload before-browsers.jpg here -->

**After**
<img width="1224" height="600" alt="after-browsers" src="https://github.com/user-attachments/assets/83994d0a-2145-4196-8738-77ee7eac7fc6" />


<!-- Upload after-browsers.jpg here -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Web Vitals breakdown values by moving status icons before metric numbers and widening the CLS column to avoid clipping. Previously numbers shifted when icons rendered and some three-decimal CLS values clipped; now numbers remain right-aligned, icons keep fixed size, and CLS has enough width.

**Review notes**
- Verify right alignment and no clipping across Pages, Countries, Regions, Cities, and Browsers tables.
- Confirm icons render before values, do not shrink, and are aria-hidden.
- `cls` compact column width increases from 76px to 78px; check table layout remains stable.

<sup>Written for commit e758c63839571a5178657e719b8ac4ad78af1930. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

