### PR TITLE
fix(dashboard): correct appearance chart selects

### DIFF
--- a/apps/dashboard/app/(main)/settings/appearance/_components/chart-type-option.tsx
+++ b/apps/dashboard/app/(main)/settings/appearance/_components/chart-type-option.tsx
@@ -1,0 +1,15 @@
+import type { ChartBarIcon } from "@databuddy/ui/icons";
+
+interface ChartTypeOptionProps {
+	icon: typeof ChartBarIcon;
+	label: string;
+}
+
+export function ChartTypeOption({ icon: Icon, label }: ChartTypeOptionProps) {
+	return (
+		<span className="flex items-center gap-2">
+			<Icon className="size-3.5 shrink-0" weight="duotone" />
+			{label}
+		</span>
+	);
+}

--- a/apps/dashboard/app/(main)/settings/appearance/page.tsx
+++ b/apps/dashboard/app/(main)/settings/appearance/page.tsx
@@ -34,6 +34,7 @@ import {
 } from "@databuddy/ui/icons";
 import { Select } from "@databuddy/ui/client";
 import { Card, Text, Tooltip } from "@databuddy/ui";
+import { ChartTypeOption } from "./_components/chart-type-option";
 
 const MOCK_CHART_DATA = [
 	{ date: "2024-01-01", value: 186 },
@@ -68,6 +69,16 @@ const STEP_TYPE_OPTIONS: { id: ChartCurveType; name: string }[] = [
 	{ id: "stepAfter", name: "Step After" },
 ];
 
+const CHART_TYPE_ITEMS = CHART_TYPE_OPTIONS.map(({ id, name }) => ({
+	label: name,
+	value: id,
+}));
+
+const STEP_TYPE_ITEMS = STEP_TYPE_OPTIONS.map(({ id, name }) => ({
+	label: name,
+	value: id,
+}));
+
 const DEFAULT_DATE_RANGE_OPTIONS: DefaultDateRangePreset[] = [
 	"24h",
 	"7d",
@@ -84,6 +95,11 @@ const LOCATION_ICONS: Record<ChartLocation, typeof ChartLineIcon> = {
 	"website-list": ChartLineIcon,
 	events: CursorClickIcon,
 };
+
+const CHART_LOCATION_ITEMS = CHART_LOCATIONS.map((value) => ({
+	label: CHART_LOCATION_LABELS[value],
+	value,
+}));
 
 export default function AppearanceSettingsPage() {
 	const { theme, setTheme } = useTheme();
@@ -191,6 +207,7 @@ export default function AppearanceSettingsPage() {
 								</Text>
 								{showGranular && (
 									<Select
+										items={CHART_LOCATION_ITEMS}
 										onValueChange={(v) =>
 											setPreviewLocation(v as ChartLocation)
 										}
@@ -239,6 +256,7 @@ export default function AppearanceSettingsPage() {
 								<Text variant="label">All Charts</Text>
 								<div className="flex items-center gap-2">
 									<Select
+										items={CHART_TYPE_ITEMS}
 										onValueChange={(v) =>
 											updateAllPreferences({
 												chartType: v as ChartSeriesKind,
@@ -250,14 +268,14 @@ export default function AppearanceSettingsPage() {
 										<Select.Content>
 											{CHART_TYPE_OPTIONS.map(({ id, name, icon: OptIcon }) => (
 												<Select.Item key={id} value={id}>
-													<OptIcon className="size-3.5" weight="duotone" />
-													{name}
+													<ChartTypeOption icon={OptIcon} label={name} />
 												</Select.Item>
 											))}
 										</Select.Content>
 									</Select>
 									<Select
 										disabled={isGlobalBar}
+										items={STEP_TYPE_ITEMS}
 										onValueChange={(v) =>
 											updateAllPreferences({
 												chartStepType: v as ChartCurveType,
@@ -355,6 +373,7 @@ export default function AppearanceSettingsPage() {
 												</button>
 												<div className="flex shrink-0 items-center gap-2">
 													<Select
+														items={CHART_TYPE_ITEMS}
 														onValueChange={(v) =>
 															updateLocationPreferences(location, {
 																chartType: v as ChartSeriesKind,
@@ -367,11 +386,10 @@ export default function AppearanceSettingsPage() {
 															{CHART_TYPE_OPTIONS.map(
 																({ id, name, icon: OptIcon }) => (
 																	<Select.Item key={id} value={id}>
-																		<OptIcon
-																			className="size-3.5"
-																			weight="duotone"
+																		<ChartTypeOption
+																			icon={OptIcon}
+																			label={name}
 																		/>
-																		{name}
 																	</Select.Item>
 																)
 															)}
@@ -379,6 +397,7 @@ export default function AppearanceSettingsPage() {
 													</Select>
 													<Select
 														disabled={isBar}
+														items={STEP_TYPE_ITEMS}
 														onValueChange={(v) =>
 															updateLocationPreferences(location, {
 																chartStepType: v as ChartCurveType,

--- a/packages/ui/src/components/select.tsx
+++ b/packages/ui/src/components/select.tsx
@@ -57,7 +57,9 @@ function Root(props: ComponentPropsWithoutRef<typeof BaseSelect.Root>) {
 	);
 
 	return (
-		<LabelRegistryCtx.Provider value={registry}>
+		<LabelRegistryCtx.Provider
+			value={props.items === undefined ? registry : null}
+		>
 			<BaseSelect.Root {...props} />
 		</LabelRegistryCtx.Provider>
 	);


### PR DESCRIPTION
## Summary

- Show readable chart and style labels in Appearance settings.
- Keep chart option icons and labels on one row.
- Preserve existing Select behavior when `items` are not provided.

## Before screenshots
<img width="1512" height="714" alt="image" src="https://github.com/user-attachments/assets/0dd208fd-06c9-4dca-a8e2-37dc59f657aa" />
<img width="1512" height="714" alt="image" src="https://github.com/user-attachments/assets/6897e06c-4016-4570-b771-862e78d19457" />

<!-- Upload before screenshots here. -->

## After screenshots
<img width="1512" height="714" alt="image" src="https://github.com/user-attachments/assets/49cdd970-1228-4014-adea-0c02a23d83d1" />
<img width="1512" height="714" alt="image" src="https://github.com/user-attachments/assets/3e84492d-2ff5-4c45-a10a-cb39fbbb3143" />

<!-- Upload after screenshots here. -->

## Checks

- `bun run lint`
- `bun run check-types`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Appearance chart selects to show readable labels and keep icon + label on one line, improving clarity. Previously, options wrapped and trigger labels could be unclear; now selects use `items` with explicit labels, and `Select` preserves old behavior when `items` is omitted.

- Dashboard: Pass `items` to chart type, step type, and location `Select`s and render options with a new `ChartTypeOption` that shows icon and label on one row.
- UI `Select`: Provide the label registry only when `items` is undefined, avoiding conflicting labels when `items` is used; existing consumers without `items` are unaffected.

<sup>Written for commit 918b3feadd217a506334f996e42c3d148f07bb42. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

