### PR TITLE
fix(ai): allow public audience queries

### DIFF
--- a/packages/ai/src/query/builders/index.ts
+++ b/packages/ai/src/query/builders/index.ts
@@ -62,6 +62,12 @@ export const PUBLIC_QUERY_TYPES = new Set<string>([
 	"region",
 	"city",
 
+	// Public audience tab
+	"timezone",
+	"language",
+	"browser_versions",
+	"screen_resolution",
+
 	// Public product analytics tabs
 	"custom_events",
 	"custom_event_properties",

--- a/packages/ai/src/query/builders/public-access.test.ts
+++ b/packages/ai/src/query/builders/public-access.test.ts
@@ -26,6 +26,13 @@ const PUBLIC_OVERVIEW_QUERY_TYPES = [
 	"country",
 ] as const;
 
+const PUBLIC_AUDIENCE_QUERY_TYPES = [
+	"timezone",
+	"language",
+	"browser_versions",
+	"screen_resolution",
+] as const;
+
 const PUBLIC_EVENTS_QUERY_TYPES = [
 	"custom_events",
 	"custom_events_summary",
@@ -65,6 +72,7 @@ describe("query builder publicAccess", () => {
 	it("marks public dashboard query families as public-readable", () => {
 		const publicTypes = [
 			...PUBLIC_OVERVIEW_QUERY_TYPES,
+			...PUBLIC_AUDIENCE_QUERY_TYPES,
 			...PUBLIC_EVENTS_QUERY_TYPES,
 			...PUBLIC_ERROR_QUERY_TYPES,
 			...PUBLIC_VITALS_QUERY_TYPES,


### PR DESCRIPTION
### Description

Fixes the public demo Audience tab failing with a 401 error.

The Audience tab requests `timezone`, `language`, `browser_versions`, and `screen_resolution` together with other public query types. These query types were missing from `PUBLIC_QUERY_TYPES`, causing the entire unauthenticated query batch to be rejected.

This change adds those query types to the public allowlist and adds test coverage for the public Audience queries.

### Slice

- Issue: #650
- Scope / owning surface: Public demo Audience queries
- Dependencies or overlapping PRs: None

<details>
<summary>Checklist</summary>

- [x] This branch started from current `main` and does not include another unmerged PR unless it is named above.
- [x] This is one independently reviewable slice; unrelated cleanup or refactors are in separate PRs.
- [x] Checked open PRs for overlapping files, contracts, schemas, or deployment configuration and made any dependency explicit.
- [x] Added tests for the new public Audience query types.
- [x] Verified the fix with unit tests and type checking.
- [x] Verified the unauthenticated `/demo/<website-id>/audience` flow in the browser.
</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows unauthenticated Audience queries in the public demo by allowlisting missing types. Previously, batching Audience queries with timezone, language, browser_versions, and screen_resolution triggered a 401; these types are now public-readable so /demo/<website-id>/audience loads as expected. Addresses #650.

- Review notes
  - Adds timezone, language, browser_versions, and screen_resolution to PUBLIC_QUERY_TYPES in `packages/ai/src/query/builders/index.ts`.
  - Extends public access tests to cover Audience queries in `packages/ai/src/query/builders/public-access.test.ts`.

<sup>Written for commit 79f2d1e9d386c1a0ef857cec5d73d647c7862864. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

