### PR TITLE
fix(validation): restore MCP analytics date range contract

### DIFF
--- a/packages/validation/src/schemas/analytics.test.ts
+++ b/packages/validation/src/schemas/analytics.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { analyticsEventSchema } from "./analytics";
+import {
+	analyticsDateRangeSchema,
+	analyticsEventSchema,
+	getDefaultAnalyticsDateRange,
+} from "./analytics";
+
+describe("analyticsDateRangeSchema", () => {
+	it("uses an inclusive seven-calendar-day default range", () => {
+		expect(
+			getDefaultAnalyticsDateRange(new Date("2026-04-11T12:00:00.000Z"))
+		).toEqual({ startDate: "2026-04-05", endDate: "2026-04-11" });
+	});
+
+	it("accepts a complete, ordered ISO date range or no explicit range", () => {
+		expect(
+			analyticsDateRangeSchema.safeParse({
+				startDate: "2026-02-01",
+				endDate: "2026-02-28",
+			}).success
+		).toBe(true);
+		expect(analyticsDateRangeSchema.safeParse({}).success).toBe(true);
+	});
+
+	it("rejects invalid, partial, and reversed date ranges", () => {
+		for (const range of [
+			{ startDate: "2026-02-30", endDate: "2026-03-01" },
+			{ startDate: "2026-02-01" },
+			{ endDate: "2026-02-01" },
+			{ startDate: "2026-03-02", endDate: "2026-03-01" },
+		]) {
+			expect(analyticsDateRangeSchema.safeParse(range).success).toBe(false);
+		}
+	});
+});
 
 const validEvent = {
 	eventId: "test-id",

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -7,6 +7,46 @@ import {
 } from "../regexes";
 import { profileIdSchema } from "./identity";
 
+function dateRangeIssue(input: {
+	endDate?: string;
+	startDate?: string;
+}): string | null {
+	if (Boolean(input.startDate) !== Boolean(input.endDate)) {
+		return "Provide both startDate and endDate, or omit both to use the default range.";
+	}
+	if (input.startDate && input.endDate && input.startDate > input.endDate) {
+		return "endDate must be on or after startDate.";
+	}
+	return null;
+}
+
+/** The same inclusive seven-calendar-day window as the `last_7d` preset. */
+export function getDefaultAnalyticsDateRange(now = new Date()) {
+	const start = new Date(now);
+	start.setUTCDate(start.getUTCDate() - 6);
+	return {
+		startDate: start.toISOString().slice(0, 10),
+		endDate: now.toISOString().slice(0, 10),
+	};
+}
+
+/** Date-only analytics inputs must be complete, valid, and ordered. */
+export const analyticsDateRangeSchema = z
+	.object({
+		startDate: z.iso.date().optional(),
+		endDate: z.iso.date().optional(),
+	})
+	.superRefine((input, context) => {
+		const message = dateRangeIssue(input);
+		if (message) {
+			context.addIssue({
+				code: "custom",
+				message,
+				path: ["endDate"],
+			});
+		}
+	});
+
 const resolutionSchema = z
 	.string()
 	.regex(RESOLUTION_REGEX, "Must be in the format 'WIDTHxHEIGHT'")


### PR DESCRIPTION
## Summary
- add the shared analytics date-range schema consumed by the MCP tool contract
- reject invalid, partial, and reversed ranges consistently
- cover the default seven-calendar-day window and validation behavior

## Scope
This is the foundation slice for the staging MCP cleanup. It intentionally excludes the separate annotations, action, discovery, and documentation changes. No database or production changes.

## Verification
- full pre-commit typecheck: 35 tasks passed
- full pre-push test suite: 3,903 passed, 34 skipped, 0 failed
- focused validation tests: 13 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the MCP analytics date range contract and enforces strict validation in `packages/validation`. Previously partial or reversed ranges could pass; now callers must provide complete, ordered ISO dates or rely on an inclusive seven-day default window.

- Adds analytics date range schema and default helper in packages/validation/src/schemas/analytics.ts; validation requires both `startDate` and `endDate` together, ISO `YYYY-MM-DD`, and `endDate >= startDate`; default equals the `last_7d` preset (start = now-6, end = now).
- Adds focused tests covering default behavior and rejection of invalid, partial, and reversed ranges; no database or production changes.

Migration

- Send both `startDate` and `endDate` (YYYY-MM-DD), or omit both to use the default range; partial input is invalid.

<sup>Written for commit 79190bf2d49de7e1aec9d368a3103618aab6af38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Follow-up
The date-range propagation slice is intentionally stacked on this foundation in [#658](https://github.com/databuddy-analytics/Databuddy/pull/658).

The independent annotation contract slice is also stacked on this foundation in [#659](https://github.com/databuddy-analytics/Databuddy/pull/659).

The MCP tool-surface slice is stacked after the contract work in [#660](https://github.com/databuddy-analytics/Databuddy/pull/660).

The discovery/API/docs cleanup is stacked after these contract slices in [#661](https://github.com/databuddy-analytics/Databuddy/pull/661).