### PR TITLE
fix(mcp): enforce analytics date ranges end to end

### DIFF
--- a/packages/ai/src/ai/mcp/tool-contracts.ts
+++ b/packages/ai/src/ai/mcp/tool-contracts.ts
@@ -1,19 +1,36 @@
 import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
+import {
+	type DatePreset,
+	MCP_DATE_PRESETS,
+	resolveDatePreset,
+} from "../../lib/date-presets";
 import { McpToolError, type McpHandlerContext } from "./define-tool";
 
 const DateOnlySchema = z.iso.date();
 
 export const McpDateRangeSchema = z
 	.object({
+		preset: z
+			.enum(MCP_DATE_PRESETS as [DatePreset, ...DatePreset[]])
+			.optional()
+			.describe("Date preset such as last_7d. Alternative to from/to."),
 		from: DateOnlySchema.optional().describe(
-			"Start date YYYY-MM-DD (defaults to 30 days ago)"
+			"Start date YYYY-MM-DD. Use with to; alternative to preset."
 		),
 		to: DateOnlySchema.optional().describe(
-			"End date YYYY-MM-DD (defaults to today)"
+			"End date YYYY-MM-DD. Use with from; alternative to preset."
 		),
 	})
 	.superRefine((input, context) => {
+		if (input.preset && (input.from || input.to)) {
+			context.addIssue({
+				code: "custom",
+				message: "Use either preset or from/to, not both.",
+				path: ["preset"],
+			});
+			return;
+		}
 		const result = analyticsDateRangeSchema.safeParse({
 			startDate: input.from,
 			endDate: input.to,
@@ -28,6 +45,18 @@ export const McpDateRangeSchema = z
 			}
 		}
 	});
+
+export function resolveMcpDateRange(input: {
+	from?: string;
+	preset?: DatePreset;
+	to?: string;
+}): { from?: string; to?: string } {
+	if (input.preset) {
+		const { from, to } = resolveDatePreset(input.preset, "UTC");
+		return { from, to };
+	}
+	return { from: input.from, to: input.to };
+}
 
 export const WebsiteSelectorSchema = {
 	websiteId: z.string().optional().describe("Website ID from list_websites"),

--- a/packages/ai/src/ai/tools/date-range.test.ts
+++ b/packages/ai/src/ai/tools/date-range.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createFunnelTools } from "./funnels";
+import { createGoalTools } from "./goals";
+
+const analyticsRanges = [
+	{ idField: "funnelId", schema: createFunnelTools().get_funnel_analytics.inputSchema },
+	{
+		idField: "funnelId",
+		schema: createFunnelTools().get_funnel_analytics_by_referrer.inputSchema,
+	},
+	{ idField: "goalId", schema: createGoalTools().get_goal_analytics.inputSchema },
+];
+
+describe("agent tool date ranges", () => {
+	test("rejects invalid, partial, and reversed analytics ranges", () => {
+		for (const { idField, schema } of analyticsRanges) {
+			for (const input of [
+				{ [idField]: "definition-1", startDate: "2026-02-30", endDate: "2026-03-01" },
+				{ [idField]: "definition-1", startDate: "2026-03-01" },
+				{ [idField]: "definition-1", startDate: "2026-03-02", endDate: "2026-03-01" },
+			]) {
+				expect(schema.safeParse(input).success).toBe(false);
+			}
+		}
+	});
+
+});

--- a/packages/ai/src/ai/tools/funnels.ts
+++ b/packages/ai/src/ai/tools/funnels.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -9,6 +9,11 @@ import {
 } from "./utils";
 
 const logger = createToolLogger("Funnels Tools");
+
+const funnelAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	funnelId: z.string(),
+	websiteId: z.string().optional(),
+});
 
 export function createFunnelTools() {
 	const listFunnelsTool = tool({
@@ -41,12 +46,7 @@ export function createFunnelTools() {
 	const getFunnelAnalyticsTool = tool({
 		description:
 			"Funnel step conversion and drop-offs for a chosen date range. Do not repeat an exact overall measurement already supplied by the caller.",
-		inputSchema: z.object({
-			funnelId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: funnelAnalyticsInputSchema,
 		execute: async (
 			{ funnelId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -54,17 +54,6 @@ export function createFunnelTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalytics",
@@ -89,12 +78,7 @@ export function createFunnelTools() {
 	const getFunnelAnalyticsByReferrerTool = tool({
 		description:
 			"Funnel analytics broken down by referrer/source. Shows which sources convert best.",
-		inputSchema: z.object({
-			funnelId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: funnelAnalyticsInputSchema,
 		execute: async (
 			{ funnelId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -102,17 +86,6 @@ export function createFunnelTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalyticsByReferrer",

--- a/packages/ai/src/ai/tools/goals.ts
+++ b/packages/ai/src/ai/tools/goals.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -15,6 +15,10 @@ const goalFilterSchema = z.object({
 	field: z.string(),
 	operator: z.enum(["equals", "contains", "not_equals", "in", "not_in"]),
 	value: z.union([z.string(), z.array(z.string())]),
+});
+const goalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	goalId: z.string(),
+	websiteId: z.string().optional(),
 });
 const createGoalInputSchema = z.object({
 	websiteId: z.string(),
@@ -62,12 +66,7 @@ export function createGoalTools() {
 	const getGoalAnalyticsTool = tool({
 		description:
 			"Goal analytics for a chosen date range: conversion rate, users entered, and users completed. Do not repeat an exact measurement already supplied by the caller.",
-		inputSchema: z.object({
-			goalId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: goalAnalyticsInputSchema,
 		execute: async (
 			{ goalId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -75,17 +74,6 @@ export function createGoalTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"goals",
 					"getAnalytics",

--- a/packages/rpc/src/routers/autocomplete.ts
+++ b/packages/rpc/src/routers/autocomplete.ts
@@ -1,5 +1,9 @@
 import { chQuery } from "@databuddy/db/clickhouse";
 import { createDrizzleCache, redis } from "@databuddy/redis";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { z } from "zod";
 import { rpcError } from "../errors";
 import { logger } from "../lib/logger";
@@ -11,13 +15,9 @@ const drizzleCache = createDrizzleCache({ redis, namespace: "autocomplete" });
 
 const CACHE_TTL = 1800;
 
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
+const autocompleteInputSchema = analyticsDateRangeSchema.safeExtend({
+	websiteId: z.string(),
+});
 
 const getAutocompleteQuery = () => `
 	SELECT 'customEvents' as category, event_name as value
@@ -154,13 +154,7 @@ export const autocompleteRouter = {
 			summary: "Get autocomplete",
 			tags: ["Autocomplete"],
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(autocompleteInputSchema)
 		.output(autocompleteOutputSchema)
 		.handler(async ({ context, input }) => {
 			const workspace = await withPublicWorkspace(context, {
@@ -171,7 +165,7 @@ export const autocompleteRouter = {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			return drizzleCache.withCache({
 				key: scopedCacheKey(

--- a/packages/rpc/src/routers/funnels.ts
+++ b/packages/rpc/src/routers/funnels.ts
@@ -1,6 +1,10 @@
 import { and, desc, eq, isNull, sql } from "@databuddy/db";
 import { funnelDefinitions } from "@databuddy/db/schema";
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
@@ -46,13 +50,13 @@ const filterSchema = z.object({
 
 type Filter = z.infer<typeof filterSchema>;
 
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
+const funnelAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	funnelId: z.string(),
+	websiteId: z.string(),
+});
+const funnelAnalyticsByLinkInputSchema = funnelAnalyticsInputSchema.safeExtend({
+	linkId: z.string(),
+});
 
 const getEffectiveStartDate = (
 	requestedStartDate: string,
@@ -438,21 +442,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsInputSchema)
 		.output(funnelAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()
@@ -507,21 +504,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics by referrer",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsInputSchema)
 		.output(funnelAnalyticsByReferrerOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()
@@ -576,22 +566,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics by link",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				linkId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsByLinkInputSchema)
 		.output(funnelAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()

--- a/packages/rpc/src/routers/goals.ts
+++ b/packages/rpc/src/routers/goals.ts
@@ -2,6 +2,10 @@ import { and, desc, eq, inArray, isNull } from "@databuddy/db";
 import { goals } from "@databuddy/db/schema";
 import { createDrizzleCache, redis } from "@databuddy/redis";
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
@@ -41,6 +45,17 @@ const filterSchema = z.object({
 });
 
 type Filter = z.infer<typeof filterSchema>;
+
+const goalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	filters: z.array(filterSchema).optional(),
+	goalId: z.string(),
+	websiteId: z.string(),
+});
+const bulkGoalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	filters: z.array(filterSchema).optional(),
+	goalIds: z.array(z.string()).min(1),
+	websiteId: z.string(),
+});
 
 const goalOutputSchema = z.object({
 	id: z.string(),
@@ -116,14 +131,6 @@ const goalAnalyticsResultSchema = z.discriminatedUnion("ok", [
 ]);
 
 type GoalAnalyticsResult = z.infer<typeof goalAnalyticsResultSchema>;
-
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
 
 const getEffectiveStartDate = (
 	requestedStartDate: string,
@@ -376,22 +383,14 @@ export const goalsRouter = {
 			description:
 				"Returns conversion analytics for a single goal. Requires website read permission.",
 		})
-		.input(
-			z.object({
-				goalId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-				filters: z.array(filterSchema).optional(),
-			})
-		)
+		.input(goalAnalyticsInputSchema)
 		.output(goalAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [goal] = await context.db
 				.select()
@@ -463,22 +462,14 @@ export const goalsRouter = {
 			description:
 				"Returns conversion analytics for multiple goals. Requires website read permission.",
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				goalIds: z.array(z.string()).min(1),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-				filters: z.array(filterSchema).optional(),
-			})
-		)
+		.input(bulkGoalAnalyticsInputSchema)
 		.output(z.record(z.string(), goalAnalyticsResultSchema))
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const goalsList = await context.db
 				.select()

--- a/packages/validation/src/schemas/analytics.test.ts
+++ b/packages/validation/src/schemas/analytics.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { analyticsEventSchema } from "./analytics";
+import {
+	analyticsDateRangeSchema,
+	analyticsEventSchema,
+	getDefaultAnalyticsDateRange,
+} from "./analytics";
+
+describe("analyticsDateRangeSchema", () => {
+	it("uses an inclusive seven-calendar-day default range", () => {
+		expect(
+			getDefaultAnalyticsDateRange(new Date("2026-04-11T12:00:00.000Z"))
+		).toEqual({ startDate: "2026-04-05", endDate: "2026-04-11" });
+	});
+
+	it("accepts a complete, ordered ISO date range or no explicit range", () => {
+		expect(
+			analyticsDateRangeSchema.safeParse({
+				startDate: "2026-02-01",
+				endDate: "2026-02-28",
+			}).success
+		).toBe(true);
+		expect(analyticsDateRangeSchema.safeParse({}).success).toBe(true);
+	});
+
+	it("rejects invalid, partial, and reversed date ranges", () => {
+		for (const range of [
+			{ startDate: "2026-02-30", endDate: "2026-03-01" },
+			{ startDate: "2026-02-01" },
+			{ endDate: "2026-02-01" },
+			{ startDate: "2026-03-02", endDate: "2026-03-01" },
+		]) {
+			expect(analyticsDateRangeSchema.safeParse(range).success).toBe(false);
+		}
+	});
+});
 
 const validEvent = {
 	eventId: "test-id",

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -7,6 +7,46 @@ import {
 } from "../regexes";
 import { profileIdSchema } from "./identity";
 
+function dateRangeIssue(input: {
+	endDate?: string;
+	startDate?: string;
+}): string | null {
+	if (Boolean(input.startDate) !== Boolean(input.endDate)) {
+		return "Provide both startDate and endDate, or omit both to use the default range.";
+	}
+	if (input.startDate && input.endDate && input.startDate > input.endDate) {
+		return "endDate must be on or after startDate.";
+	}
+	return null;
+}
+
+/** The same inclusive seven-calendar-day window as the `last_7d` preset. */
+export function getDefaultAnalyticsDateRange(now = new Date()) {
+	const start = new Date(now);
+	start.setUTCDate(start.getUTCDate() - 6);
+	return {
+		startDate: start.toISOString().slice(0, 10),
+		endDate: now.toISOString().slice(0, 10),
+	};
+}
+
+/** Date-only analytics inputs must be complete, valid, and ordered. */
+export const analyticsDateRangeSchema = z
+	.object({
+		startDate: z.iso.date().optional(),
+		endDate: z.iso.date().optional(),
+	})
+	.superRefine((input, context) => {
+		const message = dateRangeIssue(input);
+		if (message) {
+			context.addIssue({
+				code: "custom",
+				message,
+				path: ["endDate"],
+			});
+		}
+	});
+
 const resolutionSchema = z
 	.string()
 	.regex(RESOLUTION_REGEX, "Must be in the format 'WIDTHxHEIGHT'")


### PR DESCRIPTION
## Summary
- carry the shared date-range contract through MCP, agent, and RPC analytics tools
- reject invalid, partial, and reversed ranges instead of silently changing them
- preserve the existing default range behavior and add focused agent-tool coverage

## Dependency
Depends on #657 (the shared validation foundation). This branch intentionally contains that foundation as its first commit; review the second commit as the follow-up slice.

## Scope
No database or production changes. Annotation, discovery, authentication, and documentation cleanup remain separate slices.

## Verification
- focused date-range test: 1 passed
- full pre-commit typecheck: 35 tasks passed
- full pre-push test suite: 3,904 passed, 34 skipped, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a strict analytics date-range contract across MCP, agent tools, and RPC. Previously, tools accepted partial/invalid/reversed ranges and sometimes silently corrected them; now they reject invalid inputs and use a shared inclusive last‑7‑day default.

- Validation: Adds `analyticsDateRangeSchema` and `getDefaultAnalyticsDateRange` in `@databuddy/validation`. The schema requires complete ISO date-only `startDate`/`endDate` with `endDate` on or after `startDate`; the default is an inclusive seven-calendar-day window.
- MCP: Extends `McpDateRangeSchema` with an optional `preset` and enforces “preset or from/to” exclusivity. `resolveMcpDateRange` maps a preset to `from`/`to` via `resolveDatePreset` (UTC).
- Agent tools: `funnels` and `goals` inputs use the shared schema via `safeExtend`; removed ad hoc `dayjs` checks.
- RPC: `autocomplete`, `funnels`, and `goals` routers adopt the shared input schema and `getDefaultAnalyticsDateRange`, preserving default behavior when no range is provided.
- Migration: Clients must supply both `startDate` and `endDate` or omit both; partial ranges now error. In MCP, do not send `preset` together with `from`/`to`.

<sup>Written for commit d6e45eafb5b96897846551aa92ed5dc35a5e3157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/658?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

