### PR TITLE
fix(annotations): centralize ordered coordinate validation

### DIFF
--- a/packages/ai/src/ai/tools/annotations.ts
+++ b/packages/ai/src/ai/tools/annotations.ts
@@ -1,5 +1,8 @@
 import { tool } from "ai";
-import { annotationCoordinateSchema } from "@databuddy/validation";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -26,29 +29,10 @@ interface AnnotationRecord {
 
 const chartTypeSchema = z.enum(["metrics"]);
 
-const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
-
 const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
 	websiteId: z.string(),
 	chartType: chartTypeSchema,
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 	yValue: z.number().optional(),
 	text: z.string().min(1).max(500),
 	tags: z.array(z.string()).optional(),
@@ -60,7 +44,7 @@ const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
 const listAnnotationsInputSchema = z.object({
 	websiteId: z.string(),
 	chartType: chartTypeSchema,
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 });
 const updateAnnotationInputSchema = createAnnotationInputSchema
 	.pick({

--- a/packages/ai/src/ai/tools/annotations.ts
+++ b/packages/ai/src/ai/tools/annotations.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { annotationCoordinateSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -25,7 +25,6 @@ interface AnnotationRecord {
 }
 
 const chartTypeSchema = z.enum(["metrics"]);
-const annotationTypeSchema = z.enum(["point", "line", "range"]);
 
 const chartContextSchema = z.object({
 	dateRange: z.object({
@@ -46,31 +45,17 @@ const chartContextSchema = z.object({
 	tabId: z.string().optional(),
 });
 
-const isoDateSchema = z.string().refine((value) => dayjs(value).isValid(), {
-	message:
-		"Must be a valid ISO 8601 date string (e.g., '2024-01-15T10:30:00Z').",
+const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
+	websiteId: z.string(),
+	chartType: chartTypeSchema,
+	chartContext: chartContextSchema,
+	yValue: z.number().optional(),
+	text: z.string().min(1).max(500),
+	tags: z.array(z.string()).optional(),
+	color: z.string().optional(),
+	isPublic: z.boolean().optional(),
+	confirmed: z.boolean().describe("false=preview, true=apply"),
 });
-
-const createAnnotationInputSchema = z
-	.object({
-		websiteId: z.string(),
-		chartType: chartTypeSchema,
-		chartContext: chartContextSchema,
-		annotationType: annotationTypeSchema,
-		xValue: isoDateSchema,
-		xEndValue: isoDateSchema.optional(),
-		yValue: z.number().optional(),
-		text: z.string().min(1).max(500),
-		tags: z.array(z.string()).optional(),
-		color: z.string().optional(),
-		isPublic: z.boolean().optional(),
-		confirmed: z.boolean().describe("false=preview, true=apply"),
-	})
-	.refine((input) => input.annotationType !== "range" || input.xEndValue, {
-		message:
-			"Range annotations require an xEndValue to define the end of the time period.",
-		path: ["xEndValue"],
-	});
 
 const listAnnotationsInputSchema = z.object({
 	websiteId: z.string(),

--- a/packages/rpc/src/routers/annotation-schema.ts
+++ b/packages/rpc/src/routers/annotation-schema.ts
@@ -1,30 +1,14 @@
-import { annotationCoordinateSchema } from "@databuddy/validation";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "@databuddy/validation";
 import { z } from "zod";
-
-export const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
 
 export const createAnnotationInputSchema =
 	annotationCoordinateSchema.safeExtend({
 		websiteId: z.string(),
 		chartType: z.enum(["metrics"]),
-		chartContext: chartContextSchema,
+		chartContext: annotationChartContextSchema,
 		yValue: z.number().optional(),
 		text: z.string().min(1).max(500),
 		tags: z.array(z.string()).optional(),

--- a/packages/rpc/src/routers/annotation-schema.ts
+++ b/packages/rpc/src/routers/annotation-schema.ts
@@ -1,0 +1,33 @@
+import { annotationCoordinateSchema } from "@databuddy/validation";
+import { z } from "zod";
+
+export const chartContextSchema = z.object({
+	dateRange: z.object({
+		start_date: z.string(),
+		end_date: z.string(),
+		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
+	}),
+	filters: z
+		.array(
+			z.object({
+				field: z.string(),
+				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
+				value: z.string(),
+			})
+		)
+		.optional(),
+	metrics: z.array(z.string()).optional(),
+	tabId: z.string().optional(),
+});
+
+export const createAnnotationInputSchema =
+	annotationCoordinateSchema.safeExtend({
+		websiteId: z.string(),
+		chartType: z.enum(["metrics"]),
+		chartContext: chartContextSchema,
+		yValue: z.number().optional(),
+		text: z.string().min(1).max(500),
+		tags: z.array(z.string()).optional(),
+		color: z.string().optional(),
+		isPublic: z.boolean().default(false),
+	});

--- a/packages/rpc/src/routers/annotations.test.ts
+++ b/packages/rpc/src/routers/annotations.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { createAnnotationInputSchema } from "./annotation-schema";
+
+const annotation = {
+	websiteId: "website-1",
+	chartType: "metrics" as const,
+	chartContext: {
+		dateRange: {
+			start_date: "2026-03-01",
+			end_date: "2026-03-02",
+			granularity: "daily" as const,
+		},
+	},
+	annotationType: "point" as const,
+	xValue: "2026-03-01",
+	text: "Release",
+};
+
+describe("createAnnotationInputSchema", () => {
+	test("rejects malformed annotation dates and incomplete ranges", () => {
+		for (const input of [
+			{ ...annotation, xValue: "not-a-date" },
+			{ ...annotation, xEndValue: "not-a-date" },
+			{ ...annotation, annotationType: "range" as const },
+		]) {
+			expect(createAnnotationInputSchema.safeParse(input).success).toBe(false);
+		}
+	});
+});

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -7,6 +7,10 @@ import {
 } from "@databuddy/redis";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
+import {
+	chartContextSchema,
+	createAnnotationInputSchema,
+} from "./annotation-schema";
 import { rpcError } from "../errors";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, publicProcedure, trackedProcedure } from "../orpc";
@@ -42,25 +46,6 @@ async function invalidateAnnotationCaches(websiteId: string): Promise<void> {
 		invalidateAgentContextSnapshotsForWebsite(websiteId),
 	]);
 }
-
-const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
@@ -248,21 +233,7 @@ export const annotationsRouter = {
 			summary: "Create annotation",
 			tags: ["Annotations"],
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				chartType: z.enum(["metrics"]),
-				chartContext: chartContextSchema,
-				annotationType: z.enum(["point", "line", "range"]),
-				xValue: z.string(),
-				xEndValue: z.string().optional(),
-				yValue: z.number().optional(),
-				text: z.string().min(1).max(500),
-				tags: z.array(z.string()).optional(),
-				color: z.string().optional(),
-				isPublic: z.boolean().default(false),
-			})
-		)
+		.input(createAnnotationInputSchema)
 		.output(annotationOutputSchema)
 		.handler(async ({ context, input }) => {
 			setTrackProperties({ type: input.annotationType });

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -6,11 +6,9 @@ import {
 	redis,
 } from "@databuddy/redis";
 import { randomUUIDv7 } from "bun";
+import { annotationChartContextSchema } from "@databuddy/validation";
 import { z } from "zod";
-import {
-	chartContextSchema,
-	createAnnotationInputSchema,
-} from "./annotation-schema";
+import { createAnnotationInputSchema } from "./annotation-schema";
 import { rpcError } from "../errors";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, publicProcedure, trackedProcedure } from "../orpc";
@@ -49,7 +47,7 @@ async function invalidateAnnotationCaches(websiteId: string): Promise<void> {
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 	chartType: z.string(),
 	color: z.string(),
 	createdAt: z.coerce.date(),
@@ -91,7 +89,7 @@ export const annotationsRouter = {
 			z.object({
 				websiteId: z.string(),
 				chartType: z.enum(["metrics"]),
-				chartContext: chartContextSchema,
+				chartContext: annotationChartContextSchema,
 			})
 		)
 		.output(z.array(annotationOutputSchema))

--- a/packages/validation/src/schemas/analytics.test.ts
+++ b/packages/validation/src/schemas/analytics.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { analyticsEventSchema } from "./analytics";
+import {
+	analyticsDateRangeSchema,
+	analyticsEventSchema,
+	getDefaultAnalyticsDateRange,
+} from "./analytics";
+
+describe("analyticsDateRangeSchema", () => {
+	it("uses an inclusive seven-calendar-day default range", () => {
+		expect(
+			getDefaultAnalyticsDateRange(new Date("2026-04-11T12:00:00.000Z"))
+		).toEqual({ startDate: "2026-04-05", endDate: "2026-04-11" });
+	});
+
+	it("accepts a complete, ordered ISO date range or no explicit range", () => {
+		expect(
+			analyticsDateRangeSchema.safeParse({
+				startDate: "2026-02-01",
+				endDate: "2026-02-28",
+			}).success
+		).toBe(true);
+		expect(analyticsDateRangeSchema.safeParse({}).success).toBe(true);
+	});
+
+	it("rejects invalid, partial, and reversed date ranges", () => {
+		for (const range of [
+			{ startDate: "2026-02-30", endDate: "2026-03-01" },
+			{ startDate: "2026-02-01" },
+			{ endDate: "2026-02-01" },
+			{ startDate: "2026-03-02", endDate: "2026-03-01" },
+		]) {
+			expect(analyticsDateRangeSchema.safeParse(range).success).toBe(false);
+		}
+	});
+});
 
 const validEvent = {
 	eventId: "test-id",

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -7,6 +7,46 @@ import {
 } from "../regexes";
 import { profileIdSchema } from "./identity";
 
+function dateRangeIssue(input: {
+	endDate?: string;
+	startDate?: string;
+}): string | null {
+	if (Boolean(input.startDate) !== Boolean(input.endDate)) {
+		return "Provide both startDate and endDate, or omit both to use the default range.";
+	}
+	if (input.startDate && input.endDate && input.startDate > input.endDate) {
+		return "endDate must be on or after startDate.";
+	}
+	return null;
+}
+
+/** The same inclusive seven-calendar-day window as the `last_7d` preset. */
+export function getDefaultAnalyticsDateRange(now = new Date()) {
+	const start = new Date(now);
+	start.setUTCDate(start.getUTCDate() - 6);
+	return {
+		startDate: start.toISOString().slice(0, 10),
+		endDate: now.toISOString().slice(0, 10),
+	};
+}
+
+/** Date-only analytics inputs must be complete, valid, and ordered. */
+export const analyticsDateRangeSchema = z
+	.object({
+		startDate: z.iso.date().optional(),
+		endDate: z.iso.date().optional(),
+	})
+	.superRefine((input, context) => {
+		const message = dateRangeIssue(input);
+		if (message) {
+			context.addIssue({
+				code: "custom",
+				message,
+				path: ["endDate"],
+			});
+		}
+	});
+
 const resolutionSchema = z
 	.string()
 	.regex(RESOLUTION_REGEX, "Must be in the format 'WIDTHxHEIGHT'")

--- a/packages/validation/src/schemas/annotations.test.ts
+++ b/packages/validation/src/schemas/annotations.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { annotationCoordinateSchema } from "./annotations";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "./annotations";
 
 describe("annotationCoordinateSchema", () => {
 	test("accepts ISO dates and ordered ISO timestamps", () => {
@@ -13,6 +16,21 @@ describe("annotationCoordinateSchema", () => {
 		]) {
 			expect(annotationCoordinateSchema.safeParse(input).success).toBe(true);
 		}
+	});
+
+	test("shares one chart-context shape across annotation callers", () => {
+		expect(
+			annotationChartContextSchema.safeParse({
+				dateRange: {
+					start_date: "2026-03-01",
+					end_date: "2026-03-02",
+					granularity: "daily",
+				},
+			}).success
+		).toBe(true);
+		expect(annotationChartContextSchema.safeParse({ dateRange: {} }).success).toBe(
+			false
+		);
 	});
 
 	test("rejects malformed, reversed, and incomplete coordinates", () => {

--- a/packages/validation/src/schemas/annotations.test.ts
+++ b/packages/validation/src/schemas/annotations.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { annotationCoordinateSchema } from "./annotations";
+
+describe("annotationCoordinateSchema", () => {
+	test("accepts ISO dates and ordered ISO timestamps", () => {
+		for (const input of [
+			{ annotationType: "point", xValue: "2026-03-01" },
+			{
+				annotationType: "range",
+				xValue: "2026-03-01T10:00:00Z",
+				xEndValue: "2026-03-01T12:00:00+00:00",
+			},
+		]) {
+			expect(annotationCoordinateSchema.safeParse(input).success).toBe(true);
+		}
+	});
+
+	test("rejects malformed, reversed, and incomplete coordinates", () => {
+		for (const input of [
+			{ annotationType: "point", xValue: "not-a-date" },
+			{
+				annotationType: "point",
+				xValue: "2026-03-01",
+				xEndValue: "not-a-date",
+			},
+			{
+				annotationType: "range",
+				xValue: "2026-03-02",
+				xEndValue: "2026-03-01",
+			},
+			{ annotationType: "range", xValue: "2026-03-01" },
+		]) {
+			expect(annotationCoordinateSchema.safeParse(input).success).toBe(false);
+		}
+	});
+});

--- a/packages/validation/src/schemas/annotations.ts
+++ b/packages/validation/src/schemas/annotations.ts
@@ -1,15 +1,34 @@
 import z from "zod";
 
-export const annotationTimestampSchema = z.union([
+export const isoDateOrOffsetDateTimeSchema = z.union([
 	z.iso.date(),
 	z.iso.datetime({ offset: true }),
 ]);
 
+export const annotationChartContextSchema = z.object({
+	dateRange: z.object({
+		start_date: z.string(),
+		end_date: z.string(),
+		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
+	}),
+	filters: z
+		.array(
+			z.object({
+				field: z.string(),
+				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
+				value: z.string(),
+			})
+		)
+		.optional(),
+	metrics: z.array(z.string()).optional(),
+	tabId: z.string().optional(),
+});
+
 export const annotationCoordinateSchema = z
 	.object({
 		annotationType: z.enum(["point", "line", "range"]),
-		xValue: annotationTimestampSchema,
-		xEndValue: annotationTimestampSchema.optional(),
+		xValue: isoDateOrOffsetDateTimeSchema,
+		xEndValue: isoDateOrOffsetDateTimeSchema.optional(),
 	})
 	.superRefine((input, context) => {
 		if (input.annotationType === "range" && !input.xEndValue) {

--- a/packages/validation/src/schemas/annotations.ts
+++ b/packages/validation/src/schemas/annotations.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+
+export const annotationTimestampSchema = z.union([
+	z.iso.date(),
+	z.iso.datetime({ offset: true }),
+]);
+
+export const annotationCoordinateSchema = z
+	.object({
+		annotationType: z.enum(["point", "line", "range"]),
+		xValue: annotationTimestampSchema,
+		xEndValue: annotationTimestampSchema.optional(),
+	})
+	.superRefine((input, context) => {
+		if (input.annotationType === "range" && !input.xEndValue) {
+			context.addIssue({
+				code: "custom",
+				message:
+					"Range annotations require an xEndValue to define the end of the time period.",
+				path: ["xEndValue"],
+			});
+		}
+		if (input.xEndValue && new Date(input.xEndValue) < new Date(input.xValue)) {
+			context.addIssue({
+				code: "custom",
+				message: "xEndValue must be on or after xValue.",
+				path: ["xEndValue"],
+			});
+		}
+	});

--- a/packages/validation/src/schemas/index.ts
+++ b/packages/validation/src/schemas/index.ts
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/performance/noBarrelFile: It's witerawwy just a bawel file*/
 export * from "./analytics";
+export * from "./annotations";
 export * from "./batch";
 export * from "./custom-events";
 export * from "./errors";


### PR DESCRIPTION
## Summary
- centralize annotation timestamp and range-coordinate validation in the shared validation package
- reuse the same contract in the annotation RPC input and agent tool
- add focused coverage for malformed, incomplete, and reversed coordinates

## Dependency
Depends on #657 because `origin/staging` currently has the MCP date-range import before its shared export exists. The foundation commit is included first in this branch; review the annotation commit separately.

## Scope
No database or production changes. MCP registration and discovery/auth cleanup remain separate slices.

## Verification
- validation annotation tests: 2 passed
- RPC annotation schema test: 1 passed
- agent tools tests: 50 passed
- full pre-commit typecheck: 35 tasks passed
- full pre-push test suite: 3,903 passed, 34 skipped, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes annotation coordinate and chart-context validation in `@databuddy/validation` to remove divergent, lenient parsing across layers. Old behavior: each caller defined its own shapes and date checks; new behavior: shared schemas enforce ISO-only coordinates, require xEndValue for ranges, reject reversed coordinates, and unify chart context.

- Review: RPC and AI now use `annotationCoordinateSchema` and `annotationChartContextSchema`; adds a `createAnnotationInputSchema` in rpc for compose-and-reuse; adds focused tests for malformed, incomplete, and reversed coordinates and analytics ranges.
- Rollout/Migration: API clients must send ISO 8601 dates or offset datetimes; range annotations must include an ordered xEndValue; chartContext must match the shared shape. No database or production configuration changes.

<sup>Written for commit 67025ecd0e426854c07523681c6719853e41a0db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

