### PR TITLE
feat(mcp): expose safe scoped action tools

### DIFF
--- a/packages/ai/src/ai/mcp/define-tool.ts
+++ b/packages/ai/src/ai/mcp/define-tool.ts
@@ -152,14 +152,17 @@ export interface McpToolFactory {
 }
 
 function toErrorResult(err: McpToolError): CallToolResult {
+	const isInternal = err.code === "internal";
 	const errorPayload: Record<string, unknown> = {
 		code: err.code,
-		message: stripAnsi(err.message),
+		message: isInternal
+			? "An internal error occurred. Please try again."
+			: stripAnsi(err.message),
 	};
-	if (err.hint) {
+	if (!isInternal && err.hint) {
 		errorPayload.hint = stripAnsi(err.hint);
 	}
-	if (err.details) {
+	if (!isInternal && err.details) {
 		errorPayload.details = err.details;
 	}
 	return {

--- a/packages/ai/src/ai/mcp/tool-contracts.ts
+++ b/packages/ai/src/ai/mcp/tool-contracts.ts
@@ -1,19 +1,36 @@
 import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
+import {
+	type DatePreset,
+	MCP_DATE_PRESETS,
+	resolveDatePreset,
+} from "../../lib/date-presets";
 import { McpToolError, type McpHandlerContext } from "./define-tool";
 
 const DateOnlySchema = z.iso.date();
 
 export const McpDateRangeSchema = z
 	.object({
+		preset: z
+			.enum(MCP_DATE_PRESETS as [DatePreset, ...DatePreset[]])
+			.optional()
+			.describe("Date preset such as last_7d. Alternative to from/to."),
 		from: DateOnlySchema.optional().describe(
-			"Start date YYYY-MM-DD (defaults to 30 days ago)"
+			"Start date YYYY-MM-DD. Use with to; alternative to preset."
 		),
 		to: DateOnlySchema.optional().describe(
-			"End date YYYY-MM-DD (defaults to today)"
+			"End date YYYY-MM-DD. Use with from; alternative to preset."
 		),
 	})
 	.superRefine((input, context) => {
+		if (input.preset && (input.from || input.to)) {
+			context.addIssue({
+				code: "custom",
+				message: "Use either preset or from/to, not both.",
+				path: ["preset"],
+			});
+			return;
+		}
 		const result = analyticsDateRangeSchema.safeParse({
 			startDate: input.from,
 			endDate: input.to,
@@ -28,6 +45,18 @@ export const McpDateRangeSchema = z
 			}
 		}
 	});
+
+export function resolveMcpDateRange(input: {
+	from?: string;
+	preset?: DatePreset;
+	to?: string;
+}): { from?: string; to?: string } {
+	if (input.preset) {
+		const { from, to } = resolveDatePreset(input.preset, "UTC");
+		return { from, to };
+	}
+	return { from: input.from, to: input.to };
+}
 
 export const WebsiteSelectorSchema = {
 	websiteId: z.string().optional().describe("Website ID from list_websites"),

--- a/packages/ai/src/ai/mcp/tools.test.ts
+++ b/packages/ai/src/ai/mcp/tools.test.ts
@@ -11,6 +11,7 @@ import {
 	handleDatabuddyMcpRequest,
 } from "../../mcp/http";
 import { defineMcpTool, type McpRequestContext } from "./define-tool";
+import { resolveMcpDateRange } from "./tool-contracts";
 import { createMcpTools } from "./tools";
 
 const ctx: McpRequestContext = {
@@ -23,6 +24,14 @@ const tools = createMcpTools(ctx);
 
 const TOOL_NAME_RE = /^[a-z][a-z0-9_]*$/;
 const MAX_DESCRIPTION_LEN = 240;
+const analyticsToolInputs = [
+	{ input: { funnelId: "funnel-1" }, name: "get_funnel_analytics" },
+	{ input: { goalId: "goal-1" }, name: "get_goal_analytics" },
+	{
+		input: { funnelId: "funnel-1" },
+		name: "get_funnel_analytics_by_referrer",
+	},
+] as const;
 
 describe("MCP transport", () => {
 	test("keeps API-key authentication separate from unimplemented OAuth", async () => {
@@ -82,6 +91,14 @@ async function listToolsForScopes(scopes: ApiScope[]) {
 }
 
 describe("MCP tool invariants", () => {
+	test("does not expose discovery tools to a zero-scope API key", async () => {
+		const { tools: listed } = await listToolsForScopes([]);
+		const names = new Set(listed.map((tool) => tool.name));
+
+		expect(names.has("capabilities")).toBe(false);
+		expect(names.has("get_schema")).toBe(false);
+	});
+
 	test("dynamic analytics output schemas work through the installed MCP SDK", async () => {
 		const dynamicTools = tools.filter((tool) =>
 			["get_funnel_analytics", "get_goal_analytics"].includes(tool.name)
@@ -153,6 +170,24 @@ describe("MCP tool invariants", () => {
 			expect(result).not.toMatchObject({ isError: true });
 			expect(received).toEqual({ enabled: true, literal });
 		}
+	});
+
+	test("does not expose internal exception text", async () => {
+		const sentinel = "MCP_INTERNAL_SENTINEL_DO_NOT_EXPOSE";
+		const tool = defineMcpTool(
+			{
+				name: "internal_error_test",
+				description: "Test that internal exception text is not returned to callers.",
+				inputSchema: z.object({}),
+			},
+			() => {
+				throw new Error(sentinel);
+			}
+		).build(ctx);
+
+		const result = await tool.handler({});
+		expect(result).toMatchObject({ isError: true });
+		expect(JSON.stringify(result)).not.toContain(sentinel);
 	});
 
 	test("create_link matches the HTTP(S) and deep-link app contract", () => {
@@ -238,6 +273,101 @@ describe("MCP tool invariants", () => {
 		).toBe(false);
 	});
 
+	test("rejects incomplete and reversed MCP date ranges", () => {
+		for (const { input, name } of analyticsToolInputs) {
+			const tool = tools.find((candidate) => candidate.name === name);
+			if (!tool) {
+				throw new Error(`${name} tool is not registered`);
+			}
+			expect(
+				tool.inputSchema.safeParse({
+					...input,
+					from: "2026-03-02",
+					to: "2026-03-01",
+					websiteId: "website-1",
+				}).success
+			).toBe(false);
+			expect(
+				tool.inputSchema.safeParse({
+					...input,
+					from: "2026-03-01",
+					websiteId: "website-1",
+				}).success
+			).toBe(false);
+		}
+
+		const createAnnotation = tools.find(
+			(tool) => tool.name === "create_annotation"
+		);
+		const listAnnotations = tools.find(
+			(tool) => tool.name === "list_annotations"
+		);
+		if (!(createAnnotation && listAnnotations)) {
+			throw new Error("Expected annotation tools to be registered");
+		}
+		expect(
+			createAnnotation.inputSchema.safeParse({
+				annotationType: "range",
+				confirmed: false,
+				text: "Release window",
+				websiteId: "website-1",
+				xEndValue: "2026-03-01T00:00:00Z",
+				xValue: "2026-03-02T00:00:00Z",
+			}).success
+		).toBe(false);
+		expect(
+			createAnnotation.inputSchema.safeParse({
+				annotationType: "range",
+				confirmed: false,
+				text: "Release window",
+				websiteId: "website-1",
+				xValue: "2026-03-01T00:00:00Z",
+			}).success
+		).toBe(false);
+		const listSchema = z.toJSONSchema(listAnnotations.inputSchema, {
+			io: "input",
+		}) as { properties?: Record<string, unknown> };
+		expect(listSchema.properties).not.toHaveProperty("from");
+		expect(listSchema.properties).not.toHaveProperty("to");
+	});
+
+	test("preserves analytics date presets instead of silently defaulting", () => {
+		for (const { input, name } of analyticsToolInputs) {
+			const tool = tools.find((candidate) => candidate.name === name);
+			if (!tool) {
+				throw new Error(`${name} tool is not registered`);
+			}
+			const result = tool.inputSchema.safeParse({
+				...input,
+				preset: "last_30d",
+				websiteId: "website-1",
+			});
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect(result.data).toMatchObject({ preset: "last_30d" });
+			}
+			expect(
+				tool.inputSchema.safeParse({
+					...input,
+					from: "2026-03-01",
+					preset: "last_30d",
+					to: "2026-03-30",
+					websiteId: "website-1",
+				}).success
+			).toBe(false);
+		}
+
+		const range = resolveMcpDateRange({ preset: "last_30d" });
+		expect(range.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(range.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+		expect(
+			(Date.parse(`${range.to}T00:00:00Z`) -
+				Date.parse(`${range.from}T00:00:00Z`)) /
+				86_400_000 +
+				1
+		).toBe(30);
+	});
+
 	test("keeps mixed batch date errors inside the batch result", () => {
 		const getData = tools.find((tool) => tool.name === "get_data");
 		if (!getData) {
@@ -321,6 +451,8 @@ describe("investigation tools", () => {
 		const readData = await listToolsForScopes(["read:data"]);
 		const readDataNames = new Set(readData.tools.map((tool) => tool.name));
 		expect(readData.response.status).toBe(200);
+		expect(readDataNames.has("capabilities")).toBe(true);
+		expect(readDataNames.has("get_schema")).toBe(true);
 		expect(readDataNames.has("get_data")).toBe(true);
 		expect(readDataNames.has("get_funnel_analytics_by_referrer")).toBe(true);
 		expect(readDataNames.has("list_links")).toBe(false);

--- a/packages/ai/src/ai/mcp/tools.ts
+++ b/packages/ai/src/ai/mcp/tools.ts
@@ -10,7 +10,12 @@ import {
 	DEEP_LINK_APP_IDS,
 	isDeepLinkTarget,
 } from "@databuddy/shared/constants/deep-link-apps";
-import { httpUrlSchema } from "@databuddy/validation";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+	httpUrlSchema,
+	isoDateOrOffsetDateTimeSchema,
+} from "@databuddy/validation";
 import { userRuleSchema, variantSchema } from "@databuddy/shared/flags";
 import { executeBatch } from "../../query";
 import { runInvestigationAction } from "../tools/investigations";
@@ -64,15 +69,12 @@ import {
 	getResolvedWebsiteId,
 	McpDateRangeSchema,
 	MutationResultSchema,
+	resolveMcpDateRange,
 	WebsiteSelectorSchema,
 	WorkflowFilterSchema,
 } from "./tool-contracts";
 
 const TIME_UNIT = ["minute", "hour", "day", "week", "month"] as const;
-const DateTimeSchema = z.union([
-	z.iso.date(),
-	z.iso.datetime({ offset: true }),
-]);
 
 const QueryItemSchema = z.object({
 	type: z.string(),
@@ -101,25 +103,6 @@ const FunnelStepSchema = z.object({
 	conditions: z.record(z.string(), z.unknown()).optional(),
 });
 
-const ChartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
-
 const FlagRuleSchema = userRuleSchema;
 const FlagVariantSchema = variantSchema;
 
@@ -131,7 +114,7 @@ function createChartContext(input: {
 	granularity?: "hourly" | "daily" | "weekly" | "monthly";
 	metrics?: string[];
 	to?: string;
-}): z.infer<typeof ChartContextSchema> {
+}): z.infer<typeof annotationChartContextSchema> {
 	return {
 		dateRange: {
 			start_date:
@@ -482,6 +465,12 @@ const getDataTool = defineMcpTool(
 		}
 
 		const plan = buildBatchQueryRequests(items, websiteId, timezone);
+		if (items.length === 1 && plan.requests.length === 0) {
+			throw new McpToolError(
+				"invalid_input",
+				plan.invalid[0]?.error ?? "The query could not be executed."
+			);
+		}
 
 		// ctx.websiteDomain is guaranteed set by defineMcpTool when resolveWebsite is true
 		const websiteDomain = ctx.websiteDomain ?? "unknown";
@@ -539,6 +528,7 @@ const getSchemaTool = defineMcpTool(
 			sections: z.array(z.string()),
 			bytes: z.number(),
 		}),
+		metadata: metadataForResource("organization", ["read"]),
 		ratelimit: { limit: 60, windowSec: 60 },
 	},
 	(input) => {
@@ -618,6 +608,7 @@ const capabilitiesTool = defineMcpTool(
 			queryTypes: z.record(z.string(), z.unknown()).optional(),
 			hints: z.array(z.string()).optional(),
 		}),
+		metadata: metadataForResource("organization", ["read"]),
 		ratelimit: { limit: 60, windowSec: 60 },
 	},
 	(input) => {
@@ -711,18 +702,20 @@ const getFunnelAnalyticsTool = defineMcpTool(
 		resolveWebsite: true,
 		ratelimit: { limit: 60, windowSec: 60 },
 	},
-	async (input, ctx) =>
-		await callRPCProcedure(
+	(input, ctx) => {
+		const { from, to } = resolveMcpDateRange(input);
+		return callRPCProcedure(
 			"funnels",
 			"getAnalytics",
 			{
 				funnelId: input.funnelId,
 				websiteId: ctx.websiteId,
-				startDate: input.from,
-				endDate: input.to,
+				startDate: from,
+				endDate: to,
 			},
 			buildRpcContext(ctx)
-		)
+		);
+	}
 );
 
 const createFunnelTool = defineMcpTool(
@@ -832,18 +825,20 @@ const getGoalAnalyticsTool = defineMcpTool(
 		resolveWebsite: true,
 		ratelimit: { limit: 60, windowSec: 60 },
 	},
-	async (input, ctx) =>
-		await callRPCProcedure(
+	(input, ctx) => {
+		const { from, to } = resolveMcpDateRange(input);
+		return callRPCProcedure(
 			"goals",
 			"getAnalytics",
 			{
 				goalId: input.goalId,
 				websiteId: ctx.websiteId,
-				startDate: input.from,
-				endDate: input.to,
+				startDate: from,
+				endDate: to,
 			},
 			buildRpcContext(ctx)
-		)
+		);
+	}
 );
 
 const createGoalTool = defineMcpTool(
@@ -1077,7 +1072,7 @@ const createLinkTool = defineMcpTool(
 					.max(50)
 					.regex(/^[a-zA-Z0-9_-]+$/)
 					.optional(),
-				expiresAt: DateTimeSchema.optional(),
+				expiresAt: isoDateOrOffsetDateTimeSchema.optional(),
 				expiredRedirectUrl: httpUrlSchema.optional(),
 				ogTitle: z.string().max(200).optional(),
 				ogDescription: z.string().max(500).optional(),
@@ -1175,7 +1170,7 @@ const listAnnotationsTool = defineMcpTool(
 			...WebsiteSelectorSchema,
 			granularity: z.enum(["hourly", "daily", "weekly", "monthly"]).optional(),
 			metrics: z.array(z.string()).optional(),
-			chartContext: ChartContextSchema.optional(),
+			chartContext: annotationChartContextSchema.optional(),
 		}),
 		outputSchema: z.object({
 			annotations: z.array(z.record(z.string(), z.unknown())),
@@ -1205,42 +1200,22 @@ const createAnnotationTool = defineMcpTool(
 		name: "create_annotation",
 		description:
 			"Create a chart annotation. Call with confirmed=false for preview before writing.",
-		inputSchema: z
-			.object({
-				...WebsiteSelectorSchema,
-				chartContext: ChartContextSchema.optional(),
-				annotationType: z.enum(["point", "line", "range"]),
-				xValue: DateTimeSchema,
-				xEndValue: DateTimeSchema.optional(),
-				yValue: z.number().optional(),
-				text: z.string().min(1).max(500),
-				tags: z.array(z.string()).optional(),
-				color: z.string().optional(),
-				isPublic: z.boolean().optional(),
-				confirmed: ConfirmedSchema,
-			})
-			.refine(
-				(input) =>
-					!input.xEndValue ||
-					new Date(input.xEndValue) >= new Date(input.xValue),
-				{
-					message: "xEndValue must be on or after xValue.",
-					path: ["xEndValue"],
-				}
-			),
+		inputSchema: annotationCoordinateSchema.safeExtend({
+			...WebsiteSelectorSchema,
+			chartContext: annotationChartContextSchema.optional(),
+			yValue: z.number().optional(),
+			text: z.string().min(1).max(500),
+			tags: z.array(z.string()).optional(),
+			color: z.string().optional(),
+			isPublic: z.boolean().optional(),
+			confirmed: ConfirmedSchema,
+		}),
 		outputSchema: MutationResultSchema,
 		resolveWebsite: true,
 		metadata: metadataForResource("website", ["update"]),
 		ratelimit: { limit: 20, windowSec: 60 },
 	},
 	async (input, ctx) => {
-		if (input.annotationType === "range" && !input.xEndValue) {
-			throw new McpToolError(
-				"invalid_input",
-				"Range annotations require xEndValue."
-			);
-		}
-
 		const chartContext =
 			input.chartContext ??
 			createChartContext({

--- a/packages/ai/src/ai/mcp/workspace-tools.ts
+++ b/packages/ai/src/ai/mcp/workspace-tools.ts
@@ -28,6 +28,7 @@ import {
 	getResolvedWebsiteId,
 	McpDateRangeSchema,
 	MutationResultSchema,
+	resolveMcpDateRange,
 	WebsiteSelectorSchema,
 	WorkflowFilterSchema,
 } from "./tool-contracts";
@@ -53,18 +54,20 @@ const getFunnelAnalyticsByReferrerTool = defineMcpTool(
 		resolveWebsite: true,
 		ratelimit: { limit: 60, windowSec: 60 },
 	},
-	async (input, ctx) =>
-		await callRPCProcedure(
+	(input, ctx) => {
+		const { from, to } = resolveMcpDateRange(input);
+		return callRPCProcedure(
 			"funnels",
 			"getAnalyticsByReferrer",
 			{
 				funnelId: input.funnelId,
 				websiteId: getResolvedWebsiteId(ctx),
-				startDate: input.from,
-				endDate: input.to,
+				startDate: from,
+				endDate: to,
 			},
 			buildRpcContext(ctx)
-		)
+		);
+	}
 );
 
 const updateGoalTool = defineMcpTool(

--- a/packages/ai/src/ai/tools/annotations.ts
+++ b/packages/ai/src/ai/tools/annotations.ts
@@ -1,5 +1,8 @@
 import { tool } from "ai";
-import { annotationCoordinateSchema } from "@databuddy/validation";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -26,29 +29,10 @@ interface AnnotationRecord {
 
 const chartTypeSchema = z.enum(["metrics"]);
 
-const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
-
 const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
 	websiteId: z.string(),
 	chartType: chartTypeSchema,
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 	yValue: z.number().optional(),
 	text: z.string().min(1).max(500),
 	tags: z.array(z.string()).optional(),
@@ -60,7 +44,7 @@ const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
 const listAnnotationsInputSchema = z.object({
 	websiteId: z.string(),
 	chartType: chartTypeSchema,
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 });
 const updateAnnotationInputSchema = createAnnotationInputSchema
 	.pick({

--- a/packages/ai/src/ai/tools/annotations.ts
+++ b/packages/ai/src/ai/tools/annotations.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { annotationCoordinateSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -25,7 +25,6 @@ interface AnnotationRecord {
 }
 
 const chartTypeSchema = z.enum(["metrics"]);
-const annotationTypeSchema = z.enum(["point", "line", "range"]);
 
 const chartContextSchema = z.object({
 	dateRange: z.object({
@@ -46,31 +45,17 @@ const chartContextSchema = z.object({
 	tabId: z.string().optional(),
 });
 
-const isoDateSchema = z.string().refine((value) => dayjs(value).isValid(), {
-	message:
-		"Must be a valid ISO 8601 date string (e.g., '2024-01-15T10:30:00Z').",
+const createAnnotationInputSchema = annotationCoordinateSchema.safeExtend({
+	websiteId: z.string(),
+	chartType: chartTypeSchema,
+	chartContext: chartContextSchema,
+	yValue: z.number().optional(),
+	text: z.string().min(1).max(500),
+	tags: z.array(z.string()).optional(),
+	color: z.string().optional(),
+	isPublic: z.boolean().optional(),
+	confirmed: z.boolean().describe("false=preview, true=apply"),
 });
-
-const createAnnotationInputSchema = z
-	.object({
-		websiteId: z.string(),
-		chartType: chartTypeSchema,
-		chartContext: chartContextSchema,
-		annotationType: annotationTypeSchema,
-		xValue: isoDateSchema,
-		xEndValue: isoDateSchema.optional(),
-		yValue: z.number().optional(),
-		text: z.string().min(1).max(500),
-		tags: z.array(z.string()).optional(),
-		color: z.string().optional(),
-		isPublic: z.boolean().optional(),
-		confirmed: z.boolean().describe("false=preview, true=apply"),
-	})
-	.refine((input) => input.annotationType !== "range" || input.xEndValue, {
-		message:
-			"Range annotations require an xEndValue to define the end of the time period.",
-		path: ["xEndValue"],
-	});
 
 const listAnnotationsInputSchema = z.object({
 	websiteId: z.string(),

--- a/packages/ai/src/ai/tools/date-range.test.ts
+++ b/packages/ai/src/ai/tools/date-range.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createFunnelTools } from "./funnels";
+import { createGoalTools } from "./goals";
+
+const analyticsRanges = [
+	{ idField: "funnelId", schema: createFunnelTools().get_funnel_analytics.inputSchema },
+	{
+		idField: "funnelId",
+		schema: createFunnelTools().get_funnel_analytics_by_referrer.inputSchema,
+	},
+	{ idField: "goalId", schema: createGoalTools().get_goal_analytics.inputSchema },
+];
+
+describe("agent tool date ranges", () => {
+	test("rejects invalid, partial, and reversed analytics ranges", () => {
+		for (const { idField, schema } of analyticsRanges) {
+			for (const input of [
+				{ [idField]: "definition-1", startDate: "2026-02-30", endDate: "2026-03-01" },
+				{ [idField]: "definition-1", startDate: "2026-03-01" },
+				{ [idField]: "definition-1", startDate: "2026-03-02", endDate: "2026-03-01" },
+			]) {
+				expect(schema.safeParse(input).success).toBe(false);
+			}
+		}
+	});
+
+});

--- a/packages/ai/src/ai/tools/funnels.ts
+++ b/packages/ai/src/ai/tools/funnels.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -9,6 +9,11 @@ import {
 } from "./utils";
 
 const logger = createToolLogger("Funnels Tools");
+
+const funnelAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	funnelId: z.string(),
+	websiteId: z.string().optional(),
+});
 
 export function createFunnelTools() {
 	const listFunnelsTool = tool({
@@ -41,12 +46,7 @@ export function createFunnelTools() {
 	const getFunnelAnalyticsTool = tool({
 		description:
 			"Funnel step conversion and drop-offs for a chosen date range. Do not repeat an exact overall measurement already supplied by the caller.",
-		inputSchema: z.object({
-			funnelId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: funnelAnalyticsInputSchema,
 		execute: async (
 			{ funnelId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -54,17 +54,6 @@ export function createFunnelTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalytics",
@@ -89,12 +78,7 @@ export function createFunnelTools() {
 	const getFunnelAnalyticsByReferrerTool = tool({
 		description:
 			"Funnel analytics broken down by referrer/source. Shows which sources convert best.",
-		inputSchema: z.object({
-			funnelId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: funnelAnalyticsInputSchema,
 		execute: async (
 			{ funnelId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -102,17 +86,6 @@ export function createFunnelTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalyticsByReferrer",

--- a/packages/ai/src/ai/tools/goals.ts
+++ b/packages/ai/src/ai/tools/goals.ts
@@ -1,5 +1,5 @@
 import { tool } from "ai";
-import dayjs from "dayjs";
+import { analyticsDateRangeSchema } from "@databuddy/validation";
 import { z } from "zod";
 import {
 	callRPCProcedure,
@@ -15,6 +15,10 @@ const goalFilterSchema = z.object({
 	field: z.string(),
 	operator: z.enum(["equals", "contains", "not_equals", "in", "not_in"]),
 	value: z.union([z.string(), z.array(z.string())]),
+});
+const goalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	goalId: z.string(),
+	websiteId: z.string().optional(),
 });
 const createGoalInputSchema = z.object({
 	websiteId: z.string(),
@@ -62,12 +66,7 @@ export function createGoalTools() {
 	const getGoalAnalyticsTool = tool({
 		description:
 			"Goal analytics for a chosen date range: conversion rate, users entered, and users completed. Do not repeat an exact measurement already supplied by the caller.",
-		inputSchema: z.object({
-			goalId: z.string(),
-			websiteId: z.string().optional(),
-			startDate: z.string().optional(),
-			endDate: z.string().optional(),
-		}),
+		inputSchema: goalAnalyticsInputSchema,
 		execute: async (
 			{ goalId, websiteId: inputWebsiteId, startDate, endDate },
 			options
@@ -75,17 +74,6 @@ export function createGoalTools() {
 			const context = getAppContext(options);
 			const { websiteId } = resolveToolWebsite(context, inputWebsiteId);
 			try {
-				if (startDate && !dayjs(startDate).isValid()) {
-					throw new Error(
-						"Start date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-				if (endDate && !dayjs(endDate).isValid()) {
-					throw new Error(
-						"End date must be in YYYY-MM-DD format (e.g., 2024-01-15)."
-					);
-				}
-
 				return await callRPCProcedure(
 					"goals",
 					"getAnalytics",

--- a/packages/ai/src/mcp/guide.ts
+++ b/packages/ai/src/mcp/guide.ts
@@ -43,5 +43,5 @@ Do not recreate an investigation with ad hoc anomaly math when a durable case al
 
 ## Mutations
 
-Respect each tool's API-key scopes. Analytics reads require \`read:data\`; website writes and investigation replies require \`manage:websites\`; flag mutations require \`manage:flags\` (and website-scoped ones also require \`read:data\`); link catalog reads require \`read:links\`, while website-scoped link mutations require \`read:data\` plus \`write:links\` (and \`create_link\` also requires \`read:links\`). Preview goal, annotation, and link mutations with \`confirmed=false\`, then apply only after explicit approval with \`confirmed=true\`.
+Analytics and schema/discovery tools require \`read:data\`. Website writes and investigation replies require \`manage:websites\`; flag mutations require \`manage:flags\`. Short-link reads and previews are organization-wide and require \`read:links\`; every link mutation also requires \`write:links\`. Preview goal, annotation, and link mutations with \`confirmed=false\`, then apply only after explicit approval with \`confirmed=true\`.
 `;

--- a/packages/ai/src/mcp/http.ts
+++ b/packages/ai/src/mcp/http.ts
@@ -1,4 +1,5 @@
 import {
+	API_KEY_AUTH_CHALLENGE,
 	getAccessibleWebsiteIds,
 	hasKeyAllScopes,
 	hasWebsiteAllScopes,
@@ -36,8 +37,7 @@ export function createMcpUnauthorizedResponse(): Response {
 		{
 			status: 401,
 			headers: {
-				"WWW-Authenticate":
-					'Bearer realm="databuddy", error="invalid_token", error_description="API key required (x-api-key or Authorization: Bearer)"',
+				"WWW-Authenticate": API_KEY_AUTH_CHALLENGE,
 			},
 		}
 	);

--- a/packages/api-keys/src/resolve.ts
+++ b/packages/api-keys/src/resolve.ts
@@ -20,6 +20,7 @@ export const keys = createKeys({ prefix: "dbdy_", length: 48 });
 
 export const API_KEY_LOOKUP_TIMEOUT_MS = 5000;
 export const API_KEY_STATEMENT_TIMEOUT_MS = API_KEY_LOOKUP_TIMEOUT_MS;
+export const API_KEY_AUTH_CHALLENGE = 'Bearer realm="databuddy"';
 
 export type ApiKeyResolveOutcome =
 	| "ok"

--- a/packages/rpc/src/routers/annotation-schema.ts
+++ b/packages/rpc/src/routers/annotation-schema.ts
@@ -1,30 +1,14 @@
-import { annotationCoordinateSchema } from "@databuddy/validation";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "@databuddy/validation";
 import { z } from "zod";
-
-export const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
 
 export const createAnnotationInputSchema =
 	annotationCoordinateSchema.safeExtend({
 		websiteId: z.string(),
 		chartType: z.enum(["metrics"]),
-		chartContext: chartContextSchema,
+		chartContext: annotationChartContextSchema,
 		yValue: z.number().optional(),
 		text: z.string().min(1).max(500),
 		tags: z.array(z.string()).optional(),

--- a/packages/rpc/src/routers/annotation-schema.ts
+++ b/packages/rpc/src/routers/annotation-schema.ts
@@ -1,0 +1,33 @@
+import { annotationCoordinateSchema } from "@databuddy/validation";
+import { z } from "zod";
+
+export const chartContextSchema = z.object({
+	dateRange: z.object({
+		start_date: z.string(),
+		end_date: z.string(),
+		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
+	}),
+	filters: z
+		.array(
+			z.object({
+				field: z.string(),
+				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
+				value: z.string(),
+			})
+		)
+		.optional(),
+	metrics: z.array(z.string()).optional(),
+	tabId: z.string().optional(),
+});
+
+export const createAnnotationInputSchema =
+	annotationCoordinateSchema.safeExtend({
+		websiteId: z.string(),
+		chartType: z.enum(["metrics"]),
+		chartContext: chartContextSchema,
+		yValue: z.number().optional(),
+		text: z.string().min(1).max(500),
+		tags: z.array(z.string()).optional(),
+		color: z.string().optional(),
+		isPublic: z.boolean().default(false),
+	});

--- a/packages/rpc/src/routers/annotations.test.ts
+++ b/packages/rpc/src/routers/annotations.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { createAnnotationInputSchema } from "./annotation-schema";
+
+const annotation = {
+	websiteId: "website-1",
+	chartType: "metrics" as const,
+	chartContext: {
+		dateRange: {
+			start_date: "2026-03-01",
+			end_date: "2026-03-02",
+			granularity: "daily" as const,
+		},
+	},
+	annotationType: "point" as const,
+	xValue: "2026-03-01",
+	text: "Release",
+};
+
+describe("createAnnotationInputSchema", () => {
+	test("rejects malformed annotation dates and incomplete ranges", () => {
+		for (const input of [
+			{ ...annotation, xValue: "not-a-date" },
+			{ ...annotation, xEndValue: "not-a-date" },
+			{ ...annotation, annotationType: "range" as const },
+		]) {
+			expect(createAnnotationInputSchema.safeParse(input).success).toBe(false);
+		}
+	});
+});

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -7,6 +7,10 @@ import {
 } from "@databuddy/redis";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
+import {
+	chartContextSchema,
+	createAnnotationInputSchema,
+} from "./annotation-schema";
 import { rpcError } from "../errors";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, publicProcedure, trackedProcedure } from "../orpc";
@@ -42,25 +46,6 @@ async function invalidateAnnotationCaches(websiteId: string): Promise<void> {
 		invalidateAgentContextSnapshotsForWebsite(websiteId),
 	]);
 }
-
-const chartContextSchema = z.object({
-	dateRange: z.object({
-		start_date: z.string(),
-		end_date: z.string(),
-		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
-	}),
-	filters: z
-		.array(
-			z.object({
-				field: z.string(),
-				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
-				value: z.string(),
-			})
-		)
-		.optional(),
-	metrics: z.array(z.string()).optional(),
-	tabId: z.string().optional(),
-});
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
@@ -248,21 +233,7 @@ export const annotationsRouter = {
 			summary: "Create annotation",
 			tags: ["Annotations"],
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				chartType: z.enum(["metrics"]),
-				chartContext: chartContextSchema,
-				annotationType: z.enum(["point", "line", "range"]),
-				xValue: z.string(),
-				xEndValue: z.string().optional(),
-				yValue: z.number().optional(),
-				text: z.string().min(1).max(500),
-				tags: z.array(z.string()).optional(),
-				color: z.string().optional(),
-				isPublic: z.boolean().default(false),
-			})
-		)
+		.input(createAnnotationInputSchema)
 		.output(annotationOutputSchema)
 		.handler(async ({ context, input }) => {
 			setTrackProperties({ type: input.annotationType });

--- a/packages/rpc/src/routers/annotations.ts
+++ b/packages/rpc/src/routers/annotations.ts
@@ -6,11 +6,9 @@ import {
 	redis,
 } from "@databuddy/redis";
 import { randomUUIDv7 } from "bun";
+import { annotationChartContextSchema } from "@databuddy/validation";
 import { z } from "zod";
-import {
-	chartContextSchema,
-	createAnnotationInputSchema,
-} from "./annotation-schema";
+import { createAnnotationInputSchema } from "./annotation-schema";
 import { rpcError } from "../errors";
 import { setTrackProperties } from "../middleware/track-mutation";
 import { type Context, publicProcedure, trackedProcedure } from "../orpc";
@@ -49,7 +47,7 @@ async function invalidateAnnotationCaches(websiteId: string): Promise<void> {
 
 const annotationOutputSchema = z.object({
 	annotationType: z.string(),
-	chartContext: chartContextSchema,
+	chartContext: annotationChartContextSchema,
 	chartType: z.string(),
 	color: z.string(),
 	createdAt: z.coerce.date(),
@@ -91,7 +89,7 @@ export const annotationsRouter = {
 			z.object({
 				websiteId: z.string(),
 				chartType: z.enum(["metrics"]),
-				chartContext: chartContextSchema,
+				chartContext: annotationChartContextSchema,
 			})
 		)
 		.output(z.array(annotationOutputSchema))

--- a/packages/rpc/src/routers/autocomplete.ts
+++ b/packages/rpc/src/routers/autocomplete.ts
@@ -1,5 +1,9 @@
 import { chQuery } from "@databuddy/db/clickhouse";
 import { createDrizzleCache, redis } from "@databuddy/redis";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { z } from "zod";
 import { rpcError } from "../errors";
 import { logger } from "../lib/logger";
@@ -11,13 +15,9 @@ const drizzleCache = createDrizzleCache({ redis, namespace: "autocomplete" });
 
 const CACHE_TTL = 1800;
 
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
+const autocompleteInputSchema = analyticsDateRangeSchema.safeExtend({
+	websiteId: z.string(),
+});
 
 const getAutocompleteQuery = () => `
 	SELECT 'customEvents' as category, event_name as value
@@ -154,13 +154,7 @@ export const autocompleteRouter = {
 			summary: "Get autocomplete",
 			tags: ["Autocomplete"],
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(autocompleteInputSchema)
 		.output(autocompleteOutputSchema)
 		.handler(async ({ context, input }) => {
 			const workspace = await withPublicWorkspace(context, {
@@ -171,7 +165,7 @@ export const autocompleteRouter = {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			return drizzleCache.withCache({
 				key: scopedCacheKey(

--- a/packages/rpc/src/routers/funnels.ts
+++ b/packages/rpc/src/routers/funnels.ts
@@ -1,6 +1,10 @@
 import { and, desc, eq, isNull, sql } from "@databuddy/db";
 import { funnelDefinitions } from "@databuddy/db/schema";
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
@@ -46,13 +50,13 @@ const filterSchema = z.object({
 
 type Filter = z.infer<typeof filterSchema>;
 
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
+const funnelAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	funnelId: z.string(),
+	websiteId: z.string(),
+});
+const funnelAnalyticsByLinkInputSchema = funnelAnalyticsInputSchema.safeExtend({
+	linkId: z.string(),
+});
 
 const getEffectiveStartDate = (
 	requestedStartDate: string,
@@ -438,21 +442,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsInputSchema)
 		.output(funnelAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()
@@ -507,21 +504,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics by referrer",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsInputSchema)
 		.output(funnelAnalyticsByReferrerOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()
@@ -576,22 +566,14 @@ export const funnelsRouter = {
 			summary: "Get funnel analytics by link",
 			tags: ["Funnels"],
 		})
-		.input(
-			z.object({
-				funnelId: z.string(),
-				websiteId: z.string(),
-				linkId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-			})
-		)
+		.input(funnelAnalyticsByLinkInputSchema)
 		.output(funnelAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [funnel] = await context.db
 				.select()

--- a/packages/rpc/src/routers/goals.ts
+++ b/packages/rpc/src/routers/goals.ts
@@ -2,6 +2,10 @@ import { and, desc, eq, inArray, isNull } from "@databuddy/db";
 import { goals } from "@databuddy/db/schema";
 import { createDrizzleCache, redis } from "@databuddy/redis";
 import { GATED_FEATURES } from "@databuddy/shared/types/features";
+import {
+	analyticsDateRangeSchema,
+	getDefaultAnalyticsDateRange,
+} from "@databuddy/validation";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
 import { rpcError } from "../errors";
@@ -41,6 +45,17 @@ const filterSchema = z.object({
 });
 
 type Filter = z.infer<typeof filterSchema>;
+
+const goalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	filters: z.array(filterSchema).optional(),
+	goalId: z.string(),
+	websiteId: z.string(),
+});
+const bulkGoalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
+	filters: z.array(filterSchema).optional(),
+	goalIds: z.array(z.string()).min(1),
+	websiteId: z.string(),
+});
 
 const goalOutputSchema = z.object({
 	id: z.string(),
@@ -116,14 +131,6 @@ const goalAnalyticsResultSchema = z.discriminatedUnion("ok", [
 ]);
 
 type GoalAnalyticsResult = z.infer<typeof goalAnalyticsResultSchema>;
-
-const getDefaultDateRange = () => {
-	const endDate = new Date().toISOString().split("T")[0];
-	const startDate = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000)
-		.toISOString()
-		.split("T")[0];
-	return { startDate, endDate };
-};
 
 const getEffectiveStartDate = (
 	requestedStartDate: string,
@@ -376,22 +383,14 @@ export const goalsRouter = {
 			description:
 				"Returns conversion analytics for a single goal. Requires website read permission.",
 		})
-		.input(
-			z.object({
-				goalId: z.string(),
-				websiteId: z.string(),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-				filters: z.array(filterSchema).optional(),
-			})
-		)
+		.input(goalAnalyticsInputSchema)
 		.output(goalAnalyticsOutputSchema)
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const [goal] = await context.db
 				.select()
@@ -463,22 +462,14 @@ export const goalsRouter = {
 			description:
 				"Returns conversion analytics for multiple goals. Requires website read permission.",
 		})
-		.input(
-			z.object({
-				websiteId: z.string(),
-				goalIds: z.array(z.string()).min(1),
-				startDate: z.string().optional(),
-				endDate: z.string().optional(),
-				filters: z.array(filterSchema).optional(),
-			})
-		)
+		.input(bulkGoalAnalyticsInputSchema)
 		.output(z.record(z.string(), goalAnalyticsResultSchema))
 		.use(withWebsiteRead)
 		.handler(async ({ context, input }) => {
 			const { startDate, endDate } =
 				input.startDate && input.endDate
 					? { startDate: input.startDate, endDate: input.endDate }
-					: getDefaultDateRange();
+					: getDefaultAnalyticsDateRange();
 
 			const goalsList = await context.db
 				.select()

--- a/packages/validation/src/schemas/analytics.test.ts
+++ b/packages/validation/src/schemas/analytics.test.ts
@@ -1,5 +1,38 @@
 import { describe, expect, it } from "bun:test";
-import { analyticsEventSchema } from "./analytics";
+import {
+	analyticsDateRangeSchema,
+	analyticsEventSchema,
+	getDefaultAnalyticsDateRange,
+} from "./analytics";
+
+describe("analyticsDateRangeSchema", () => {
+	it("uses an inclusive seven-calendar-day default range", () => {
+		expect(
+			getDefaultAnalyticsDateRange(new Date("2026-04-11T12:00:00.000Z"))
+		).toEqual({ startDate: "2026-04-05", endDate: "2026-04-11" });
+	});
+
+	it("accepts a complete, ordered ISO date range or no explicit range", () => {
+		expect(
+			analyticsDateRangeSchema.safeParse({
+				startDate: "2026-02-01",
+				endDate: "2026-02-28",
+			}).success
+		).toBe(true);
+		expect(analyticsDateRangeSchema.safeParse({}).success).toBe(true);
+	});
+
+	it("rejects invalid, partial, and reversed date ranges", () => {
+		for (const range of [
+			{ startDate: "2026-02-30", endDate: "2026-03-01" },
+			{ startDate: "2026-02-01" },
+			{ endDate: "2026-02-01" },
+			{ startDate: "2026-03-02", endDate: "2026-03-01" },
+		]) {
+			expect(analyticsDateRangeSchema.safeParse(range).success).toBe(false);
+		}
+	});
+});
 
 const validEvent = {
 	eventId: "test-id",

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -7,6 +7,46 @@ import {
 } from "../regexes";
 import { profileIdSchema } from "./identity";
 
+function dateRangeIssue(input: {
+	endDate?: string;
+	startDate?: string;
+}): string | null {
+	if (Boolean(input.startDate) !== Boolean(input.endDate)) {
+		return "Provide both startDate and endDate, or omit both to use the default range.";
+	}
+	if (input.startDate && input.endDate && input.startDate > input.endDate) {
+		return "endDate must be on or after startDate.";
+	}
+	return null;
+}
+
+/** The same inclusive seven-calendar-day window as the `last_7d` preset. */
+export function getDefaultAnalyticsDateRange(now = new Date()) {
+	const start = new Date(now);
+	start.setUTCDate(start.getUTCDate() - 6);
+	return {
+		startDate: start.toISOString().slice(0, 10),
+		endDate: now.toISOString().slice(0, 10),
+	};
+}
+
+/** Date-only analytics inputs must be complete, valid, and ordered. */
+export const analyticsDateRangeSchema = z
+	.object({
+		startDate: z.iso.date().optional(),
+		endDate: z.iso.date().optional(),
+	})
+	.superRefine((input, context) => {
+		const message = dateRangeIssue(input);
+		if (message) {
+			context.addIssue({
+				code: "custom",
+				message,
+				path: ["endDate"],
+			});
+		}
+	});
+
 const resolutionSchema = z
 	.string()
 	.regex(RESOLUTION_REGEX, "Must be in the format 'WIDTHxHEIGHT'")

--- a/packages/validation/src/schemas/annotations.test.ts
+++ b/packages/validation/src/schemas/annotations.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { annotationCoordinateSchema } from "./annotations";
+import {
+	annotationChartContextSchema,
+	annotationCoordinateSchema,
+} from "./annotations";
 
 describe("annotationCoordinateSchema", () => {
 	test("accepts ISO dates and ordered ISO timestamps", () => {
@@ -13,6 +16,21 @@ describe("annotationCoordinateSchema", () => {
 		]) {
 			expect(annotationCoordinateSchema.safeParse(input).success).toBe(true);
 		}
+	});
+
+	test("shares one chart-context shape across annotation callers", () => {
+		expect(
+			annotationChartContextSchema.safeParse({
+				dateRange: {
+					start_date: "2026-03-01",
+					end_date: "2026-03-02",
+					granularity: "daily",
+				},
+			}).success
+		).toBe(true);
+		expect(annotationChartContextSchema.safeParse({ dateRange: {} }).success).toBe(
+			false
+		);
 	});
 
 	test("rejects malformed, reversed, and incomplete coordinates", () => {

--- a/packages/validation/src/schemas/annotations.test.ts
+++ b/packages/validation/src/schemas/annotations.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { annotationCoordinateSchema } from "./annotations";
+
+describe("annotationCoordinateSchema", () => {
+	test("accepts ISO dates and ordered ISO timestamps", () => {
+		for (const input of [
+			{ annotationType: "point", xValue: "2026-03-01" },
+			{
+				annotationType: "range",
+				xValue: "2026-03-01T10:00:00Z",
+				xEndValue: "2026-03-01T12:00:00+00:00",
+			},
+		]) {
+			expect(annotationCoordinateSchema.safeParse(input).success).toBe(true);
+		}
+	});
+
+	test("rejects malformed, reversed, and incomplete coordinates", () => {
+		for (const input of [
+			{ annotationType: "point", xValue: "not-a-date" },
+			{
+				annotationType: "point",
+				xValue: "2026-03-01",
+				xEndValue: "not-a-date",
+			},
+			{
+				annotationType: "range",
+				xValue: "2026-03-02",
+				xEndValue: "2026-03-01",
+			},
+			{ annotationType: "range", xValue: "2026-03-01" },
+		]) {
+			expect(annotationCoordinateSchema.safeParse(input).success).toBe(false);
+		}
+	});
+});

--- a/packages/validation/src/schemas/annotations.ts
+++ b/packages/validation/src/schemas/annotations.ts
@@ -1,15 +1,34 @@
 import z from "zod";
 
-export const annotationTimestampSchema = z.union([
+export const isoDateOrOffsetDateTimeSchema = z.union([
 	z.iso.date(),
 	z.iso.datetime({ offset: true }),
 ]);
 
+export const annotationChartContextSchema = z.object({
+	dateRange: z.object({
+		start_date: z.string(),
+		end_date: z.string(),
+		granularity: z.enum(["hourly", "daily", "weekly", "monthly"]),
+	}),
+	filters: z
+		.array(
+			z.object({
+				field: z.string(),
+				operator: z.enum(["eq", "ne", "gt", "lt", "contains"]),
+				value: z.string(),
+			})
+		)
+		.optional(),
+	metrics: z.array(z.string()).optional(),
+	tabId: z.string().optional(),
+});
+
 export const annotationCoordinateSchema = z
 	.object({
 		annotationType: z.enum(["point", "line", "range"]),
-		xValue: annotationTimestampSchema,
-		xEndValue: annotationTimestampSchema.optional(),
+		xValue: isoDateOrOffsetDateTimeSchema,
+		xEndValue: isoDateOrOffsetDateTimeSchema.optional(),
 	})
 	.superRefine((input, context) => {
 		if (input.annotationType === "range" && !input.xEndValue) {

--- a/packages/validation/src/schemas/annotations.ts
+++ b/packages/validation/src/schemas/annotations.ts
@@ -1,0 +1,30 @@
+import z from "zod";
+
+export const annotationTimestampSchema = z.union([
+	z.iso.date(),
+	z.iso.datetime({ offset: true }),
+]);
+
+export const annotationCoordinateSchema = z
+	.object({
+		annotationType: z.enum(["point", "line", "range"]),
+		xValue: annotationTimestampSchema,
+		xEndValue: annotationTimestampSchema.optional(),
+	})
+	.superRefine((input, context) => {
+		if (input.annotationType === "range" && !input.xEndValue) {
+			context.addIssue({
+				code: "custom",
+				message:
+					"Range annotations require an xEndValue to define the end of the time period.",
+				path: ["xEndValue"],
+			});
+		}
+		if (input.xEndValue && new Date(input.xEndValue) < new Date(input.xValue)) {
+			context.addIssue({
+				code: "custom",
+				message: "xEndValue must be on or after xValue.",
+				path: ["xEndValue"],
+			});
+		}
+	});

--- a/packages/validation/src/schemas/index.ts
+++ b/packages/validation/src/schemas/index.ts
@@ -1,5 +1,6 @@
 /** biome-ignore-all lint/performance/noBarrelFile: It's witerawwy just a bawel file*/
 export * from "./analytics";
+export * from "./annotations";
 export * from "./batch";
 export * from "./custom-events";
 export * from "./errors";


### PR DESCRIPTION
## Summary
- expose the actionable MCP workspace tools already supported by the backend, including funnel/goal/annotation workflows
- keep discovery and schema tools hidden from zero-scope keys
- sanitize internal exception responses while preserving server-side diagnostics
- enforce canonical date presets and shared annotation schemas in MCP execution

## Dependencies
Depends on #657, #658, and #659. This branch includes those reviewed prerequisite commits first; review the final commit (`feat(mcp): expose safe scoped action tools`) as the tool-surface slice.

## Scope
No database or production changes. API discovery/documentation cleanup remains separate.

## Verification
- MCP tool invariants: 23 passed
- full pre-commit typecheck: 35 tasks passed
- full pre-push test suite: 3,908 passed, 34 skipped, 0 failed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes MCP workspace action tools (funnels, goals, annotations) to scoped API keys while keeping discovery/schema tools gated by read:data. Tightens validation: analytics require a complete date range or a preset, annotations share one coordinate/chart-context schema, and internal errors return generic text.

- Enforces scope: zero-scope keys cannot see discovery tools; `capabilities` and `get_schema` require read:data. Unauthorized responses standardize the `WWW-Authenticate` challenge.
- Protects users: internal exceptions return a generic message; server still logs details.
- Canonicalizes analytics dates: adds preset support to MCP inputs and resolves them server-side; RPC adopts a strict `analyticsDateRangeSchema` with a 7‑day default; prevents partial or reversed ranges.
- Unifies annotations: moves coordinate and chart-context validation to `@databuddy/validation`; all callers use the same schemas; `expiresAt` accepts ISO date or offset datetime.

**Required actions**
- Analytics callers must provide both startDate and endDate or omit both; do not mix a preset with from/to.
- Range annotations must include xEndValue and ensure xEndValue is on or after xValue.
- Use a key with read:data to access discovery/schema tools; zero-scope keys cannot call them.

<sup>Written for commit 2ceb6db640b3f9eedb8e92d69bc5dec41a3d3f37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

