### PR TITLE
fix(validation): add missing analytics date range schema

### DIFF
--- a/packages/validation/src/schemas/analytics.test.ts
+++ b/packages/validation/src/schemas/analytics.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { analyticsEventSchema } from "./analytics";
+import {
+	analyticsDateRangeSchema,
+	analyticsEventSchema,
+} from "./analytics";
 
 const validEvent = {
 	eventId: "test-id",
@@ -92,6 +95,74 @@ describe("analyticsEventSchema referrer validation", () => {
 		const result = analyticsEventSchema.safeParse({
 			...validEvent,
 			referrer: "not-a-valid-url",
+		});
+		expect(result.success).toBe(false);
+	});
+});
+
+describe("analyticsDateRangeSchema", () => {
+	it("accepts a complete range", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			startDate: "2026-01-01",
+			endDate: "2026-01-31",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("accepts no dates at all", () => {
+		const result = analyticsDateRangeSchema.safeParse({});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects a start date without an end date", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			startDate: "2026-01-01",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				"endDate is required when startDate is provided"
+			);
+		}
+	});
+
+	it("rejects an end date without a start date", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			endDate: "2026-01-31",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				"startDate is required when endDate is provided"
+			);
+		}
+	});
+
+	it("rejects an inverted range", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			startDate: "2026-02-01",
+			endDate: "2026-01-31",
+		});
+		expect(result.success).toBe(false);
+		if (!result.success) {
+			expect(result.error.issues[0]?.message).toBe(
+				"startDate must be on or before endDate"
+			);
+		}
+	});
+
+	it("accepts equal start and end dates", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			startDate: "2026-01-31",
+			endDate: "2026-01-31",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("rejects non-ISO date strings", () => {
+		const result = analyticsDateRangeSchema.safeParse({
+			startDate: "01/2026",
+			endDate: "2026-01-31",
 		});
 		expect(result.success).toBe(false);
 	});

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -73,6 +73,18 @@ export const analyticsDateRangeSchema = z
 		endDate: analyticsDateOnlySchema.optional(),
 	})
 	.superRefine((range, ctx) => {
+		const hasStart = Boolean(range.startDate);
+		const hasEnd = Boolean(range.endDate);
+		if (hasStart !== hasEnd) {
+			ctx.addIssue({
+				code: "custom",
+				message: hasStart
+					? "endDate is required when startDate is provided"
+					: "startDate is required when endDate is provided",
+				path: [hasStart ? "endDate" : "startDate"],
+			});
+			return;
+		}
 		if (range.startDate && range.endDate && range.startDate > range.endDate) {
 			ctx.addIssue({
 				code: "custom",

--- a/packages/validation/src/schemas/analytics.ts
+++ b/packages/validation/src/schemas/analytics.ts
@@ -65,6 +65,23 @@ const timestampSchema = z
 		}
 	);
 
+const analyticsDateOnlySchema = z.iso.date();
+
+export const analyticsDateRangeSchema = z
+	.object({
+		startDate: analyticsDateOnlySchema.optional(),
+		endDate: analyticsDateOnlySchema.optional(),
+	})
+	.superRefine((range, ctx) => {
+		if (range.startDate && range.endDate && range.startDate > range.endDate) {
+			ctx.addIssue({
+				code: "custom",
+				message: "startDate must be on or before endDate",
+				path: ["startDate"],
+			});
+		}
+	});
+
 export const analyticsEventSchema = z.object({
 	eventId: z.string().max(VALIDATION_LIMITS.EVENT_ID_MAX_LENGTH),
 	name: z.string().min(1).max(VALIDATION_LIMITS.NAME_MAX_LENGTH),


### PR DESCRIPTION
## Summary

`bb15bd61f` (feat(mcp): expand public workspace tool contract) added `packages/ai/src/ai/mcp/tool-contracts.ts`, which imports `analyticsDateRangeSchema` from `@databuddy/validation` — but the schema was never added to the package. This breaks the module graph at test time:

```
SyntaxError: Export named 'analyticsDateRangeSchema' not found in module
'packages/validation/src/index.ts'
```

This causes an unhandled error in the `@databuddy/ai` test suite (1 error, tests after it in the affected file fail).

## Changes

- Adds `analyticsDateRangeSchema` to `packages/validation/src/schemas/analytics.ts`: optional `startDate`/`endDate` ISO date (`YYYY-MM-DD`) fields with a cross-field refinement that `startDate` must be on or before `endDate` (reported as a `custom` issue, matching what `tool-contracts.ts` forwards into its own `superRefine`).

## Verification

- `packages/validation`: 83 pass
- `packages/ai`: 3705 pass, 0 fail (previously crashed on import)

Found while rebasing #642 onto staging.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `analyticsDateRangeSchema` to `@databuddy/validation` to match the MCP tool contract in `@databuddy/ai`, fixing import errors and test crashes. Previously, partial ranges (only startDate or only endDate) were accepted and defaulted downstream; now the schema requires both dates or none, validates ISO `YYYY-MM-DD`, and enforces startDate <= endDate.

- Migration: If you pass a date range, include both `startDate` and `endDate`; otherwise omit both.

<sup>Written for commit fb5a3fa92c57d9515993fb9b35fbb5ab5c5022bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

