### PR TITLE
fix(shared): respect trackOnlyCategories in generic isBot() fallback

### DIFF
--- a/packages/shared/src/utils/bot-detection/__tests__/detector.test.ts
+++ b/packages/shared/src/utils/bot-detection/__tests__/detector.test.ts
@@ -263,7 +263,7 @@ describe("detectBot", () => {
 		});
 	});
 
-		describe("Generic isBot() fallback — config should still apply", () => {
+	describe("generic isBot() fallback", () => {
 		it("respects trackOnlyCategories for bots only caught by ua-parser-js's generic isBot()", () => {
 			const genericBotUA = "PowerShell/7.1.0";
 

--- a/packages/shared/src/utils/bot-detection/__tests__/detector.test.ts
+++ b/packages/shared/src/utils/bot-detection/__tests__/detector.test.ts
@@ -262,6 +262,21 @@ describe("detectBot", () => {
 			expect(custom.action).toBe(BotAction.BLOCK);
 		});
 	});
+
+		describe("Generic isBot() fallback — config should still apply", () => {
+		it("respects trackOnlyCategories for bots only caught by ua-parser-js's generic isBot()", () => {
+			const genericBotUA = "PowerShell/7.1.0";
+
+			const result = detectBot(genericBotUA, {
+				trackOnlyCategories: [BotCategory.UNKNOWN_BOT],
+			});
+
+			expect(result.isBot).toBe(true);
+			expect(result.category).toBe(BotCategory.UNKNOWN_BOT);
+			expect(result.reason).toBe("general_bot_pattern");
+			expect(result.action).toBe(BotAction.TRACK_ONLY);
+		});
+	});
 });
 
 describe("matchCategory", () => {

--- a/packages/shared/src/utils/bot-detection/detector.ts
+++ b/packages/shared/src/utils/bot-detection/detector.ts
@@ -151,7 +151,7 @@ function detect(
 			isBot: true,
 			category: BotCategory.UNKNOWN_BOT,
 			name,
-			action: BotAction.BLOCK,
+			action: getAction(BotCategory.UNKNOWN_BOT, config),
 			confidence: 70,
 			reason: "general_bot_pattern",
 		};


### PR DESCRIPTION
Fixes #<PUT_YOUR_ISSUE_NUMBER_HERE>

## Summary of Changes

Routes the generic `isBot()` fallback in `detectBot()` through `getAction(BotCategory.UNKNOWN_BOT, config)` so that `config.trackOnlyCategories` is properly respected.

## Reproduction & Verification

- Tested with `PowerShell/7.1.0` and `trackOnlyCategories: [BotCategory.UNKNOWN_BOT]`.
- Added unit test in `packages/shared/src/utils/bot-detection/__tests__/detector.test.ts`.
- Ran full test suite (109 tests pass), type checks, and policy linter with zero errors.

## AI Usage Disclosure

Assisted by AI (Antigravity) for draftingt eh message of issue and pull request and finding a new user-agent alis for testing the fix. Implementation and tests were verified locally using `bun test` and `bun run lint`.

Fixes #666 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect trackOnlyCategories in the generic isBot() fallback. Previously, unknown bots caught by `ua-parser-js`’s generic isBot() always BLOCKed; now we derive the action via getAction so UNKNOWN_BOT can be TRACK_ONLY when configured.

- Route the generic fallback through getAction(BotCategory.UNKNOWN_BOT, config) to align with other categories.
- Add a unit test covering user agent "PowerShell/7.1.0" with trackOnlyCategories: [UNKNOWN_BOT].
- Default behavior remains BLOCK unless config.trackOnlyCategories includes UNKNOWN_BOT.

<sup>Written for commit ab30155733bbebe9455d9f9a80385ef2399e61e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

