### PR TITLE
perf(rpc): single-statement link mutations, skip cache lease for generated slugs

### DIFF
--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -8,6 +8,7 @@ type DB = NodePgDatabase<typeof relations>;
 
 const DEFAULT_POOL_MAX = 50;
 const DEFAULT_CONNECTION_TIMEOUT_MS = 10_000;
+const DEFAULT_STATEMENT_TIMEOUT_MS = 30_000;
 
 let _pgErrorFn: ((error: Error) => void) | null = null;
 
@@ -75,6 +76,10 @@ function getDb(): DB {
 			max: parsePositiveInt(process.env.DB_POOL_MAX, DEFAULT_POOL_MAX),
 			idleTimeoutMillis: 30_000,
 			connectionTimeoutMillis: DEFAULT_CONNECTION_TIMEOUT_MS,
+			statement_timeout: parsePositiveInt(
+				process.env.DB_STATEMENT_TIMEOUT_MS,
+				DEFAULT_STATEMENT_TIMEOUT_MS
+			),
 			application_name: process.env.SERVICE_NAME || "databuddy",
 		});
 		timePoolQueries(_pool);

--- a/packages/rpc/src/routers/links.ts
+++ b/packages/rpc/src/routers/links.ts
@@ -10,7 +10,6 @@ import {
 	isNull,
 	isUniqueViolationFor,
 	or,
-	sql,
 } from "@databuddy/db";
 import { linkFolders, links } from "@databuddy/db/schema";
 import {
@@ -70,14 +69,6 @@ const generateLinkSlug = customAlphabet(
 	"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz",
 	8
 );
-const LINK_DB_STATEMENT_TIMEOUT_MS = 10_000;
-
-function setLocalLinkStatementTimeout() {
-	return sql.raw(
-		`SET LOCAL statement_timeout = '${LINK_DB_STATEMENT_TIMEOUT_MS}ms'`
-	);
-}
-
 function hasPostgresSqlState(error: unknown): boolean {
 	const seen = new Set<object>();
 	let current = error;
@@ -608,71 +599,65 @@ export const linksRouter = {
 
 			for (const slug of slugsToTry) {
 				const linkId = randomUUIDv7();
-				let cacheMutations: LinkCacheMutation[] | null;
-				try {
-					cacheMutations = await beginLinkCacheMutations([
-						{ id: linkId, mode: "new", slug },
-					]);
-				} catch (error) {
-					logger.error(
-						{ slug, linkId, ...getErrorLogFields(error) },
-						"Failed to begin link cache mutation before create"
-					);
-					if (input.slug) {
+				// Custom slugs take a cache lease so hot-slug readers never see
+				// stale state. Generated slugs skip it: PostgreSQL's unique
+				// constraint is authoritative, nobody can read a slug before this
+				// response returns it, and redirects read through to PG on misses.
+				let cacheMutations: LinkCacheMutation[] = [];
+				if (input.slug) {
+					let started: LinkCacheMutation[] | null;
+					try {
+						started = await beginLinkCacheMutations([
+							{ id: linkId, mode: "new", slug },
+						]);
+					} catch (error) {
+						logger.error(
+							{ slug, linkId, ...getErrorLogFields(error) },
+							"Failed to begin link cache mutation before create"
+						);
 						throw rpcError.serviceUnavailable(
 							1,
 							"Link cache is temporarily unavailable; retry this custom slug"
 						);
 					}
-					// PostgreSQL's unique constraint is authoritative for generated
-					// slugs. A cache outage must not make random-slug creation
-					// unavailable; redirects read through to PG on cache misses.
-					cacheMutations = [];
-				}
-
-				if (!cacheMutations) {
-					if (input.slug) {
+					if (!started) {
 						throw rpcError.conflict(
 							"This slug is already taken or is being updated"
 						);
 					}
-					continue;
+					cacheMutations = started;
 				}
 
 				const [cacheMutation] = cacheMutations;
 
 				let finalizedFailure = false;
 				try {
-					const newLink = await context.db.transaction(async (tx) => {
-						await tx.execute(setLocalLinkStatementTimeout());
-						const [created] = await tx
-							.insert(links)
-							.values({
-								id: linkId,
-								slug,
-								organizationId,
-								createdBy,
-								folderId: resolvedFolderId,
-								name: input.name,
-								targetUrl: input.targetUrl,
-								targetDomain,
-								sourceType: normalizeNullableText(input.sourceType),
-								sourceId: normalizeNullableText(input.sourceId),
-								sourceOwnerId: normalizeNullableText(input.sourceOwnerId),
-								expiresAt: input.expiresAt ? new Date(input.expiresAt) : null,
-								expiredRedirectUrl: input.expiredRedirectUrl ?? null,
-								ogTitle: input.ogTitle ?? null,
-								ogDescription: input.ogDescription ?? null,
-								ogImageUrl: input.ogImageUrl ?? null,
-								ogVideoUrl: input.ogVideoUrl ?? null,
-								iosUrl: input.iosUrl ?? null,
-								androidUrl: input.androidUrl ?? null,
-								externalId: input.externalId ?? null,
-								deepLinkApp: input.deepLinkApp ?? null,
-							})
-							.returning();
-						return created;
-					});
+					const [newLink] = await context.db
+						.insert(links)
+						.values({
+							id: linkId,
+							slug,
+							organizationId,
+							createdBy,
+							folderId: resolvedFolderId,
+							name: input.name,
+							targetUrl: input.targetUrl,
+							targetDomain,
+							sourceType: normalizeNullableText(input.sourceType),
+							sourceId: normalizeNullableText(input.sourceId),
+							sourceOwnerId: normalizeNullableText(input.sourceOwnerId),
+							expiresAt: input.expiresAt ? new Date(input.expiresAt) : null,
+							expiredRedirectUrl: input.expiredRedirectUrl ?? null,
+							ogTitle: input.ogTitle ?? null,
+							ogDescription: input.ogDescription ?? null,
+							ogImageUrl: input.ogImageUrl ?? null,
+							ogVideoUrl: input.ogVideoUrl ?? null,
+							iosUrl: input.iosUrl ?? null,
+							androidUrl: input.androidUrl ?? null,
+							externalId: input.externalId ?? null,
+							deepLinkApp: input.deepLinkApp ?? null,
+						})
+						.returning();
 
 					if (!newLink) {
 						await abandonLinkCacheMutations(
@@ -723,15 +708,11 @@ export const linksRouter = {
 
 					let persistedLink: LinkRow | undefined;
 					try {
-						persistedLink = await context.db.transaction(async (tx) => {
-							await tx.execute(setLocalLinkStatementTimeout());
-							const [persisted] = await tx
-								.select()
-								.from(links)
-								.where(eq(links.id, linkId))
-								.limit(1);
-							return persisted;
-						});
+						[persistedLink] = await context.db
+							.select()
+							.from(links)
+							.where(eq(links.id, linkId))
+							.limit(1);
 					} catch (reconciliationError) {
 						logger.error(
 							{
@@ -879,39 +860,35 @@ export const linksRouter = {
 
 			let finalizedFailure = false;
 			try {
-				const updatedLink = await context.db.transaction(async (tx) => {
-					await tx.execute(setLocalLinkStatementTimeout());
-					const [updated] = await tx
-						.update(links)
-						.set({
-							...updates,
-							folderId:
-								resolvedFolderId === undefined ? undefined : resolvedFolderId,
-							sourceType:
-								sourceType === undefined
-									? undefined
-									: normalizeNullableText(sourceType),
-							sourceId:
-								sourceId === undefined
-									? undefined
-									: normalizeNullableText(sourceId),
-							sourceOwnerId:
-								sourceOwnerId === undefined
-									? undefined
-									: normalizeNullableText(sourceOwnerId),
-							targetDomain: nextTargetDomain,
-							expiresAt:
-								expiresAt === undefined
-									? undefined
-									: expiresAt
-										? new Date(expiresAt)
-										: null,
-							updatedAt: new Date(),
-						})
-						.where(eq(links.id, id))
-						.returning();
-					return updated;
-				});
+				const [updatedLink] = await context.db
+					.update(links)
+					.set({
+						...updates,
+						folderId:
+							resolvedFolderId === undefined ? undefined : resolvedFolderId,
+						sourceType:
+							sourceType === undefined
+								? undefined
+								: normalizeNullableText(sourceType),
+						sourceId:
+							sourceId === undefined
+								? undefined
+								: normalizeNullableText(sourceId),
+						sourceOwnerId:
+							sourceOwnerId === undefined
+								? undefined
+								: normalizeNullableText(sourceOwnerId),
+						targetDomain: nextTargetDomain,
+						expiresAt:
+							expiresAt === undefined
+								? undefined
+								: expiresAt
+									? new Date(expiresAt)
+									: null,
+						updatedAt: new Date(),
+					})
+					.where(eq(links.id, id))
+					.returning();
 
 				if (!updatedLink) {
 					await tombstoneLinkCacheMutations(
@@ -1026,13 +1003,10 @@ export const linksRouter = {
 
 			let finalizedFailure = false;
 			try {
-				const deleted = await context.db.transaction(async (tx) => {
-					await tx.execute(setLocalLinkStatementTimeout());
-					return tx
-						.delete(links)
-						.where(eq(links.id, input.id))
-						.returning({ id: links.id });
-				});
+				const deleted = await context.db
+					.delete(links)
+					.where(eq(links.id, input.id))
+					.returning({ id: links.id });
 				if (deleted.length === 0) {
 					await tombstoneLinkCacheMutations(
 						cacheMutations,


### PR DESCRIPTION
### Description

Third slice of the links.create latency work (after #677 and the parallelize/burst-cap commits on staging). Removes the last avoidable sequential round-trips from the link mutation paths — this matters because the us-west2 API replica pays ~145ms per round-trip to eu-central datastores.

**1. Single-statement mutations (−3 PG round-trips each).** Create, update, delete, and the create-reconciliation read each wrapped one statement in a `db.transaction` that existed only to carry `SET LOCAL statement_timeout` — paying BEGIN + SET + COMMIT round-trips and holding a pool connection 4x longer than the work required. The pool now sets `statement_timeout` in the connection startup packet (verified in pg 8.20 source: startup parameter, zero per-query cost), configurable via `DB_STATEMENT_TIMEOUT_MS` (default 30s). The mutations run as plain autocommit statements.

**Blast radius note:** the pool-level 30s statement timeout applies to every service using `@databuddy/db`. Today everything except links (10s via SET LOCAL) and org lookups (5s, unchanged — their SET LOCAL still overrides) was unbounded, so this only adds a ceiling, never tightens an existing one. Links queries move from a 10s to a 30s ceiling; the reconciliation path handles ambiguity either way.

**2. Generated slugs skip the cache lease (−1 awaited Redis round-trip).** PG's unique constraint is authoritative for random slugs, no reader can know the slug before the response returns it, and redirects read through to PG on misses — so the begin-lease EVAL bought nothing on the hot path. Custom slugs keep the full lease flow unchanged. The success-path backfill (fire-and-forget, from the previous slice) still warms the cache.

Expected effect from us-west2: roughly −580ms per create (3 PG RTs + 1 Redis RT), plus 4x shorter pool connection holds, which is what actually defuses the burst-queueing tail alongside the org RPM cap.

### Slice

- Issue: Production POST /links/create latency investigation (2026-08-26)
- Scope / owning surface: `rpc` (links router) + `db` (pool statement_timeout)
- Dependencies or overlapping PRs: builds on staging commits 9823ce27f / b91de90f1

### Verification

- `turbo check-types` green for `@databuddy/db` + `@databuddy/rpc`
- `apps/api` link-handler integration tests: 15 pass against real PG/Redis
- Ultracite clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts three PG round-trips per link mutation and one Redis round-trip per generated-slug create, addressing the production POST /links/create latency investigation. Link mutations previously ran in a transaction only to carry `SET LOCAL statement_timeout`; they now run as autocommit statements with the timeout set at the pool level, and generated slugs no longer take the cache begin-lease.

**Refactors**

- The `@databuddy/db` pool sets `statement_timeout` in the connection startup packet, configurable via `DB_STATEMENT_TIMEOUT_MS` (default 30s).
- The 30s ceiling applies to all services using `@databuddy/db`; it only adds a ceiling and never tightens existing limits, with org lookups' 5s override unchanged.
- Links statements move from a 10s to a 30s timeout; the reconciliation path handles either behavior.
- Generated slugs skip the cache lease, saving one awaited Redis round-trip; custom slugs keep the full lease flow, and the success-path backfill still warms the cache.
- From us-west2, expect roughly −580ms per create and 4x shorter pool connection holds.

<sup>Written for commit 79cff5a9515d0a3f8071707a9739894cb47af54b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

