### PR TITLE
fix(redis): rate-limit fail-fast, breaker resets, link resilience tests, deadlock-tolerant reset

### DIFF
--- a/apps/api/src/integration/link-create-resilience.test.ts
+++ b/apps/api/src/integration/link-create-resilience.test.ts
@@ -1,0 +1,109 @@
+import "@databuddy/test/env";
+
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { appRouter } from "@databuddy/rpc";
+import { db, sql } from "@databuddy/db";
+import { resetLinkCacheFailFast, runLinkCacheCommand } from "@databuddy/redis";
+import {
+	reset,
+	cleanup,
+	hasTestDb,
+	userContext,
+	expectCode,
+	insertOrganization,
+	signUp,
+	addToOrganization,
+} from "@databuddy/test";
+import { call } from "./helpers";
+
+const iit = hasTestDb ? it : it.skip;
+
+beforeEach(async () => {
+	resetLinkCacheFailFast();
+	await reset();
+});
+afterAll(async () => {
+	resetLinkCacheFailFast();
+	await cleanup();
+});
+
+async function memberSetup(role: "member" | "owner" = "member") {
+	const user = await signUp();
+	const org = await insertOrganization();
+	await addToOrganization(user.id, org.id, role);
+	return { user, org, context: userContext(user, org.id) };
+}
+
+function tripLinkCacheFailFast() {
+	return runLinkCacheCommand(() =>
+		Promise.reject(new Error("forced link cache failure"))
+	).catch(() => undefined);
+}
+
+describe("links.create under link cache failure", () => {
+	iit("creates with a generated slug while the cache is failing fast", async () => {
+		const { org, context } = await memberSetup();
+		await tripLinkCacheFailFast();
+
+		const result = await call(appRouter.links.create, context)({
+			name: "Cache Down",
+			targetUrl: "https://example.com",
+			organizationId: org.id,
+		});
+
+		expect(result.slug).toBeDefined();
+		expect(result.organizationId).toBe(org.id);
+	});
+
+	iit("rejects a custom slug while the cache is failing fast", async () => {
+		const { org, context } = await memberSetup();
+		await tripLinkCacheFailFast();
+
+		await expectCode(
+			call(appRouter.links.create, context)({
+				name: "Custom Down",
+				targetUrl: "https://example.com",
+				organizationId: org.id,
+				slug: `down-${Date.now()}`,
+			}),
+			"SERVICE_UNAVAILABLE"
+		);
+	});
+});
+
+describe("link mutation round-trip budget", () => {
+	iit("create, update, and delete run without transaction round-trips", async () => {
+		const { org, context } = await memberSetup("owner");
+
+		const warmup = await call(appRouter.links.create, context)({
+			name: "Warmup",
+			targetUrl: "https://example.com",
+			organizationId: org.id,
+		});
+
+		const transactionSpy = vi.spyOn(db, "transaction");
+
+		const created = await call(appRouter.links.create, context)({
+			name: "Budget",
+			targetUrl: "https://example.com",
+			organizationId: org.id,
+		});
+		await call(appRouter.links.update, context)({
+			id: created.id,
+			name: "Budget Renamed",
+		});
+		await call(appRouter.links.delete, context)({ id: created.id });
+		await call(appRouter.links.delete, context)({ id: warmup.id });
+
+		expect(transactionSpy).not.toHaveBeenCalled();
+		transactionSpy.mockRestore();
+	});
+});
+
+describe("pool statement timeout", () => {
+	iit("applies statement_timeout on every pooled connection", async () => {
+		const result = await db.execute(sql`SHOW statement_timeout`);
+		const rows = Array.isArray(result) ? result : result.rows;
+		expect(rows[0]).toEqual({ statement_timeout: "30s" });
+	});
+});

--- a/packages/redis/000-redis.test.ts
+++ b/packages/redis/000-redis.test.ts
@@ -8,7 +8,7 @@ import {
 
 process.env.REDIS_URL = "redis://test-host:6379";
 
-const { getRedisCache, runLinkCacheCommand, shutdownRedis } = await import(
+const { getRedisCache, runLinkCacheCommand, runRateLimitCommand, shutdownRedis } = await import(
 	"./redis"
 );
 
@@ -118,6 +118,39 @@ describe("redis", () => {
 			);
 			expect(error).toBeInstanceOf(Error);
 			expect(error.message).not.toContain("failing fast");
+		});
+	});
+
+	describe("rate limit fail-fast", () => {
+		afterAll(async () => {
+			await shutdownRedis();
+		});
+
+		it("rejects immediately after a recent failure without running the operation", async () => {
+			await expect(
+				runRateLimitCommand(async () => "unreachable")
+			).rejects.toThrow();
+
+			const operation = mock(async () => "value");
+			const startedAt = performance.now();
+			await expect(runRateLimitCommand(operation)).rejects.toThrow(
+				"failing fast"
+			);
+			expect(performance.now() - startedAt).toBeLessThan(100);
+			expect(operation).not.toHaveBeenCalled();
+		});
+
+		it("tracks its window independently of the link cache", async () => {
+			await shutdownRedis();
+			await expect(
+				runRateLimitCommand(async () => "unreachable")
+			).rejects.toThrow();
+
+			const linkCacheError = await runLinkCacheCommand(
+				async () => "value"
+			).catch((caught: Error) => caught);
+			expect(linkCacheError).toBeInstanceOf(Error);
+			expect(linkCacheError.message).not.toContain("failing fast");
 		});
 	});
 });

--- a/packages/redis/redis.ts
+++ b/packages/redis/redis.ts
@@ -15,11 +15,20 @@ let shutdownHooksRegistered = false;
 
 const LINK_CACHE_CONNECT_DEADLINE_MS = 1250;
 export const LINK_CACHE_OPERATION_DEADLINE_MS = 1500;
-const LINK_CACHE_FAIL_FAST_WINDOW_MS = 5000;
+const REDIS_FAIL_FAST_WINDOW_MS = 5000;
 const RATE_LIMIT_CONNECT_DEADLINE_MS = 1250;
 export const RATE_LIMIT_OPERATION_DEADLINE_MS = 1500;
 
 let linkCacheFailFastUntil = 0;
+let rateLimitFailFastUntil = 0;
+
+export function resetLinkCacheFailFast(): void {
+	linkCacheFailFastUntil = 0;
+}
+
+export function resetRateLimitFailFast(): void {
+	rateLimitFailFastUntil = 0;
+}
 
 function withDeadline<T>(
 	operation: Promise<T>,
@@ -178,7 +187,7 @@ async function runLinkCacheRedisCommand<T>(
 		linkCacheFailFastUntil = 0;
 		return result;
 	} catch (error) {
-		linkCacheFailFastUntil = Date.now() + LINK_CACHE_FAIL_FAST_WINDOW_MS;
+		linkCacheFailFastUntil = Date.now() + REDIS_FAIL_FAST_WINDOW_MS;
 		if (instance) {
 			discardLinkCacheRedis(instance);
 		}
@@ -191,6 +200,10 @@ async function runLinkCacheRedisCommand<T>(
 async function runRateLimitRedisCommand<T>(
 	operation: (redis: Redis) => Promise<T>
 ): Promise<T> {
+	if (Date.now() < rateLimitFailFastUntil) {
+		throw new Error("Rate limit is failing fast after a recent Redis failure");
+	}
+
 	let instance: Redis | null = null;
 	const command = getRateLimitRedis().then((redis) => {
 		instance = redis;
@@ -198,12 +211,15 @@ async function runRateLimitRedisCommand<T>(
 	});
 
 	try {
-		return await withDeadline(
+		const result = await withDeadline(
 			command,
 			RATE_LIMIT_OPERATION_DEADLINE_MS,
 			`Rate limit operation exceeded ${RATE_LIMIT_OPERATION_DEADLINE_MS}ms`
 		);
+		rateLimitFailFastUntil = 0;
+		return result;
 	} catch (error) {
+		rateLimitFailFastUntil = Date.now() + REDIS_FAIL_FAST_WINDOW_MS;
 		if (instance) {
 			discardRateLimitRedis(instance);
 		}
@@ -212,7 +228,8 @@ async function runRateLimitRedisCommand<T>(
 }
 
 export async function shutdownRedis() {
-	linkCacheFailFastUntil = 0;
+	resetLinkCacheFailFast();
+	resetRateLimitFailFast();
 	const linkCacheInstance = linkCacheRedisInstance;
 	linkCacheRedisInstance = null;
 	linkCacheConnectPromise = null;

--- a/packages/test/src/db.ts
+++ b/packages/test/src/db.ts
@@ -64,9 +64,36 @@ const TABLES = [
 	"user",
 ] as const;
 
+const PG_DEADLOCK_CODE = "40P01";
+const TRUNCATE_ATTEMPTS = 3;
+
+function isDeadlock(error: unknown): boolean {
+	let current = error;
+	while (typeof current === "object" && current !== null) {
+		if ("code" in current && current.code === PG_DEADLOCK_CODE) {
+			return true;
+		}
+		current = "cause" in current ? current.cause : null;
+	}
+	return false;
+}
+
 export async function truncatePostgres() {
 	const quoted = TABLES.map((t) => `"${t}"`).join(", ");
-	await db().execute(sql.raw(`TRUNCATE TABLE ${quoted} CASCADE`));
+	// Fire-and-forget writes from the previous test (audit inserts, cache
+	// publishes) can still hold row locks when TRUNCATE CASCADE runs; the
+	// deadlock victim is transient, so retry instead of failing the suite.
+	for (let attempt = 1; ; attempt++) {
+		try {
+			await db().execute(sql.raw(`TRUNCATE TABLE ${quoted} CASCADE`));
+			return;
+		} catch (error) {
+			if (attempt >= TRUNCATE_ATTEMPTS || !isDeadlock(error)) {
+				throw error;
+			}
+			await new Promise((resolve) => setTimeout(resolve, 100 * attempt));
+		}
+	}
 }
 
 export async function closePostgres() {


### PR DESCRIPTION
### Description

Validation and hardening follow-up to #683 and the fail-fast merge (`08bd17d7`). Rebased after staging picked up main's breaker — the restore is no longer part of this PR.

**1. Rate limit funnel gets the same 5s fail-fast window as the link cache.** `ratelimit()` already fails open on any error, so during a Redis outage admission checks now cost ~0ms instead of a 1.5s deadline per request on every rate-limited endpoint. Windows are tracked independently per funnel.

**2. Explicit breaker resets.** `resetLinkCacheFailFast()` / `resetRateLimitFailFast()` exports; `shutdownRedis` uses them instead of inline state pokes.

**3. Integration flake fix: `reset()` TRUNCATE deadlocks (40P01).** Fire-and-forget writes from the previous test (cache publishes, audit inserts) can still hold row locks when `TRUNCATE ... CASCADE` runs — intermittent 1-2 failures per full-suite run. `truncatePostgres()` retries transient deadlocks up to 3 times with backoff.

**4. New tests** (`link-create-resilience.test.ts` + redis unit tests):
- generated-slug create succeeds while the link cache is failing fast (lease skip + bypass path end to end)
- custom-slug create returns 503 immediately while failing fast
- zero-transaction budget guard: create/update/delete assert `db.transaction` is never called (locks in #683's single-statement invariant)
- `SHOW statement_timeout` returns 30s on pooled connections
- rate-limit fail-fast rejects instantly without running the operation; window independent of the link cache

### Verification
- integration suite 3x: 170 tests, 0 fail (deadlock flake gone) — redis: 135, 0 fail — rpc: 0 fail — typecheck green (redis/rpc/test)
- Local bench (RTT≈0): create p50 2.6-3.4ms on both staging baseline and branch — no local regression; #683's round-trip win is structural and scales with datastore RTT

### Slice
- Scope / owning surface: `redis` + `test` infra + `api` integration tests
- Dependencies: follows #683 and `08bd17d7`