### PR TITLE
fix(auth): fail-fast Better Auth session Redis reads

### DIFF
--- a/packages/auth/src/auth-redis-storage.test.ts
+++ b/packages/auth/src/auth-redis-storage.test.ts
@@ -1,0 +1,24 @@
+import { afterAll, describe, expect, it } from "bun:test";
+
+process.env.REDIS_URL = "redis://test-host:6379";
+
+const { getRedisCache, resetAuthCacheFailFast } = await import(
+	"@databuddy/redis"
+);
+const { createAuthSecondaryStorage } = await import("./auth-redis-storage");
+
+describe("createAuthSecondaryStorage", () => {
+	afterAll(() => {
+		resetAuthCacheFailFast();
+		getRedisCache().disconnect();
+	});
+
+	it("fails fast on later session reads after Redis fails", async () => {
+		const storage = createAuthSecondaryStorage();
+		await expect(storage.get("session-key")).rejects.toThrow();
+
+		const startedAt = performance.now();
+		await expect(storage.get("session-key")).rejects.toThrow("failing fast");
+		expect(performance.now() - startedAt).toBeLessThan(100);
+	});
+});

--- a/packages/auth/src/auth-redis-storage.ts
+++ b/packages/auth/src/auth-redis-storage.ts
@@ -1,0 +1,20 @@
+import { redisStorage } from "@better-auth/redis-storage";
+import { getRedisCache, runAuthCacheCommand } from "@databuddy/redis";
+
+export function createAuthSecondaryStorage() {
+	const storage = redisStorage({
+		client: getRedisCache(),
+		keyPrefix: "ba:",
+	});
+
+	return {
+		get: (key: string) => runAuthCacheCommand(() => storage.get(key)),
+		getAndDelete: (key: string) =>
+			runAuthCacheCommand(() => storage.getAndDelete(key)),
+		set: (key: string, value: string, ttl?: number) =>
+			runAuthCacheCommand(() => storage.set(key, value, ttl)),
+		delete: (key: string) => runAuthCacheCommand(() => storage.delete(key)),
+		listKeys: () => runAuthCacheCommand(() => storage.listKeys()),
+		clear: () => runAuthCacheCommand(() => storage.clear()),
+	};
+}

--- a/packages/auth/src/auth.ts
+++ b/packages/auth/src/auth.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { redisStorage } from "@better-auth/redis-storage";
 import { sso } from "@better-auth/sso";
 import {
 	getCurrentAdapter,
@@ -54,8 +53,9 @@ import {
 } from "better-auth/plugins";
 import { log } from "evlog";
 import { Resend } from "resend";
-import { ac, admin, member, owner, viewer } from "./permissions";
 import { getAuthAuditContext } from "./audit-context";
+import { createAuthSecondaryStorage } from "./auth-redis-storage";
+import { ac, admin, member, owner, viewer } from "./permissions";
 
 function generateOrgSlug(name: string): string {
 	const base = name
@@ -387,10 +387,7 @@ export const auth = betterAuth({
 		schema,
 		transaction: true,
 	}),
-	secondaryStorage: redisStorage({
-		client: getRedisCache(),
-		keyPrefix: "ba:",
-	}),
+	secondaryStorage: createAuthSecondaryStorage(),
 	session: {
 		storeSessionInDatabase: true,
 		cookieCache: {

--- a/packages/redis/000-redis.test.ts
+++ b/packages/redis/000-redis.test.ts
@@ -6,9 +6,13 @@ import {
 
 process.env.REDIS_URL = "redis://test-host:6379";
 
-const { getRedisCache, runLinkCacheCommand, runRateLimitCommand, shutdownRedis } = await import(
-	"./redis"
-);
+const {
+	getRedisCache,
+	runAuthCacheCommand,
+	runLinkCacheCommand,
+	runRateLimitCommand,
+	shutdownRedis,
+} = await import("./redis");
 
 describe("redis", () => {
 	describe("latency-sensitive rate limit options", () => {
@@ -93,6 +97,43 @@ describe("redis", () => {
 			await expect(
 				runRateLimitCommand(async () => "unreachable")
 			).rejects.toThrow();
+
+			const linkCacheError = await runLinkCacheCommand(
+				async () => "value"
+			).catch((caught: Error) => caught);
+			expect(linkCacheError).toBeInstanceOf(Error);
+			expect(linkCacheError.message).not.toContain("failing fast");
+		});
+	});
+
+	describe("auth cache fail-fast", () => {
+		afterAll(async () => {
+			await shutdownRedis();
+		});
+
+		it("rejects immediately after a recent failure without running the operation", async () => {
+			await expect(
+				runAuthCacheCommand(async () => {
+					throw new Error("redis down");
+				})
+			).rejects.toThrow("redis down");
+
+			const operation = mock(async () => "value");
+			const startedAt = performance.now();
+			await expect(runAuthCacheCommand(operation)).rejects.toThrow(
+				"failing fast"
+			);
+			expect(performance.now() - startedAt).toBeLessThan(100);
+			expect(operation).not.toHaveBeenCalled();
+		});
+
+		it("tracks its window independently of the link cache", async () => {
+			await shutdownRedis();
+			await expect(
+				runAuthCacheCommand(async () => {
+					throw new Error("redis down");
+				})
+			).rejects.toThrow("redis down");
 
 			const linkCacheError = await runLinkCacheCommand(
 				async () => "value"

--- a/packages/redis/redis.ts
+++ b/packages/redis/redis.ts
@@ -18,9 +18,11 @@ export const LINK_CACHE_OPERATION_DEADLINE_MS = 1500;
 const REDIS_FAIL_FAST_WINDOW_MS = 5000;
 const RATE_LIMIT_CONNECT_DEADLINE_MS = 1250;
 export const RATE_LIMIT_OPERATION_DEADLINE_MS = 1500;
+export const AUTH_CACHE_OPERATION_DEADLINE_MS = 1500;
 
 let linkCacheFailFastUntil = 0;
 let rateLimitFailFastUntil = 0;
+let authCacheFailFastUntil = 0;
 
 export function resetLinkCacheFailFast(): void {
 	linkCacheFailFastUntil = 0;
@@ -28,6 +30,10 @@ export function resetLinkCacheFailFast(): void {
 
 export function resetRateLimitFailFast(): void {
 	rateLimitFailFastUntil = 0;
+}
+
+export function resetAuthCacheFailFast(): void {
+	authCacheFailFastUntil = 0;
 }
 
 function withDeadline<T>(
@@ -156,6 +162,12 @@ export function runRateLimitCommand<T>(
 	return runRateLimitRedisCommand(operation);
 }
 
+export function runAuthCacheCommand<T>(
+	operation: (redis: Redis) => Promise<T>
+): Promise<T> {
+	return runAuthCacheRedisCommand(operation);
+}
+
 let _linkCacheTimingFn: ((durationMs: number) => void) | null = null;
 
 export function setLinkCacheTimingFn(
@@ -227,9 +239,31 @@ async function runRateLimitRedisCommand<T>(
 	}
 }
 
+async function runAuthCacheRedisCommand<T>(
+	operation: (redis: Redis) => Promise<T>
+): Promise<T> {
+	if (Date.now() < authCacheFailFastUntil) {
+		throw new Error("Auth cache is failing fast after a recent Redis failure");
+	}
+
+	try {
+		const result = await withDeadline(
+			Promise.resolve(operation(getRedisCache())),
+			AUTH_CACHE_OPERATION_DEADLINE_MS,
+			`Auth cache operation exceeded ${AUTH_CACHE_OPERATION_DEADLINE_MS}ms`
+		);
+		authCacheFailFastUntil = 0;
+		return result;
+	} catch (error) {
+		authCacheFailFastUntil = Date.now() + REDIS_FAIL_FAST_WINDOW_MS;
+		throw error;
+	}
+}
+
 export async function shutdownRedis() {
 	resetLinkCacheFailFast();
 	resetRateLimitFailFast();
+	resetAuthCacheFailFast();
 	const linkCacheInstance = linkCacheRedisInstance;
 	linkCacheRedisInstance = null;
 	linkCacheConnectPromise = null;


### PR DESCRIPTION
### Description

This PR fixes Better Auth session Redis reads so they fail fast when Redis is unavailable, preventing repeated session lookups from waiting for the full Redis timeout.

The change adds a dedicated auth-cache fail-fast path with a 5-second failure window and a 1500ms operation deadline. The auth failure state is kept independent from the existing link-cache failure state, so a failure in one does not affect the other.

Tests were added to verify the fail-fast behavior, independent failure windows, and recovery/reset behavior.

### Slice

- Issue: no dedicated issue filed; leftover from #677 (Better Auth session Redis reads have no fail-fast)
- Scope / owning surface: `packages/auth`, `packages/redis`
- Dependencies or overlapping PRs: None

<details>
<summary>Checklist</summary>

- [x] This branch started from current `staging` and does not include another unmerged PR unless it is named above.
- [x] This is one independently reviewable slice; unrelated cleanup or refactors are in separate PRs.
- [x] I checked open PRs for overlapping files, contracts, schemas, or deployment configuration and made any dependency explicit above.
- [x] This PR targets `staging`; after it closes, this branch will not be reused for another change.
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

</details>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Better Auth session reads fail fast when Redis is down, so requests don't wait out the full timeout on every session lookup.

**Bug Fixes**
- Wraps auth secondary storage calls in `runAuthCacheCommand`, which rejects immediately for 5 seconds after a recent Redis failure and enforces a 1500ms operation deadline.
- Keeps the auth cache fail-fast window separate from the link cache window, so a failure in one cache doesn't trip the other.
- Moves the secondary storage setup into `createAuthSecondaryStorage` with tests covering the fail-fast behavior.

<sup>Written for commit 4f38c6f8745c0761edcf9c27aa40084923e2cdc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->