### PR TITLE
fix(sdk): respect the 30-minute session expiry in getSessionId

### DIFF
--- a/.changeset/sdk-session-id-expiry.md
+++ b/.changeset/sdk-session-id-expiry.md
@@ -1,0 +1,5 @@
+---
+"@databuddy/sdk": patch
+---
+
+`getSessionId` now respects the tracker's 30-minute inactivity window: it returns `null` when the stored session has no timestamp or the timestamp is older than 30 minutes, instead of handing back a session id the tracker has already rotated. `getTrackingIds` and `getTrackingParams` inherit the same behavior. URL params still take priority.

--- a/packages/sdk/src/core/tracker.ts
+++ b/packages/sdk/src/core/tracker.ts
@@ -18,6 +18,10 @@ const PENDING_LIMIT = 100;
 const PENDING_POLL_MS = 150;
 const PENDING_TIMEOUT_MS = 15_000;
 
+// Must match the tracker's inactivity window: it rotates `did_session` once
+// the timestamp is older than this, so a stale id is no longer current.
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
 const pendingCalls: Array<() => void> = [];
 let pendingPoll: ReturnType<typeof setInterval> | undefined;
 let pendingSince = 0;
@@ -181,7 +185,21 @@ export function getSessionId(urlParams?: URLSearchParams): string | null {
 		return fromParams;
 	}
 	try {
-		return sessionStorage.getItem("did_session") || null;
+		const storedId = sessionStorage.getItem("did_session");
+		if (!storedId) {
+			return null;
+		}
+		const storedAt = Number.parseInt(
+			sessionStorage.getItem("did_session_timestamp") ?? "",
+			10
+		);
+		if (
+			!Number.isFinite(storedAt) ||
+			Date.now() - storedAt >= SESSION_TIMEOUT_MS
+		) {
+			return null;
+		}
+		return storedId;
 	} catch {
 		return null;
 	}

--- a/packages/sdk/tests/sdk-functions.spec.ts
+++ b/packages/sdk/tests/sdk-functions.spec.ts
@@ -219,12 +219,52 @@ test.describe("SDK Functions", () => {
 			expect(result).toBeNull();
 		});
 
-		test("returns did_session from sessionStorage", async ({ page }) => {
+		test("returns did_session when the session is fresh", async ({ page }) => {
 			const result = await page.evaluate(() => {
 				sessionStorage.setItem("did_session", "sess-456");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					Date.now().toString()
+				);
 				return window.__SDK__.getSessionId();
 			});
 			expect(result).toBe("sess-456");
+		});
+
+		test("returns null when did_session has no timestamp", async ({ page }) => {
+			const result = await page.evaluate(() => {
+				sessionStorage.setItem("did_session", "sess-no-timestamp");
+				return window.__SDK__.getSessionId();
+			});
+			expect(result).toBeNull();
+		});
+
+		test("returns null when the session is older than 30 minutes", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				sessionStorage.setItem("did_session", "sess-expired");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					(Date.now() - 31 * 60 * 1000).toString()
+				);
+				return window.__SDK__.getSessionId();
+			});
+			expect(result).toBeNull();
+		});
+
+		test("returns the session at exactly the 30 minute boundary as expired", async ({
+			page,
+		}) => {
+			const result = await page.evaluate(() => {
+				sessionStorage.setItem("did_session", "sess-boundary");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					(Date.now() - 30 * 60 * 1000).toString()
+				);
+				return window.__SDK__.getSessionId();
+			});
+			expect(result).toBeNull();
 		});
 
 		test("prioritizes URL param over sessionStorage", async ({ page }) => {
@@ -242,6 +282,10 @@ test.describe("SDK Functions", () => {
 			const result = await page.evaluate(() => {
 				localStorage.setItem("did", "anon-x");
 				sessionStorage.setItem("did_session", "sess-y");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					Date.now().toString()
+				);
 				return window.__SDK__.getTrackingIds();
 			});
 			expect(result.anonId).toBe("anon-x");
@@ -260,6 +304,10 @@ test.describe("SDK Functions", () => {
 			const result = await page.evaluate(() => {
 				localStorage.setItem("did", "anon-a");
 				sessionStorage.setItem("did_session", "sess-b");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					Date.now().toString()
+				);
 				return window.__SDK__.getTrackingParams();
 			});
 
@@ -342,6 +390,10 @@ test.describe("SDK Functions", () => {
 		}) => {
 			const result = await page.evaluate(() => {
 				sessionStorage.setItem("did_session", "sess-ok");
+				sessionStorage.setItem(
+					"did_session_timestamp",
+					Date.now().toString()
+				);
 				const { getItem } = Storage.prototype;
 				localStorage.getItem = () => {
 					throw new DOMException("Access denied", "SecurityError");


### PR DESCRIPTION
Fixes #694

## What

`getSessionId()` reads `did_session` from sessionStorage without checking `did_session_timestamp`. The tracker rotates sessions after 30 minutes of inactivity, so between expiry and the tracker's next visit the SDK hands back a session id that is no longer the current one. `getTrackingIds()` and `getTrackingParams()` inherit the problem since they delegate to it.

## Why it matters

`getTrackingParams()` exists to carry the ids to another origin for cross-domain tracking. If the session has actually expired, propagating the stale id links events to a session the tracker has already closed — anyone keying server-side joins on these ids gets subtly wrong data.

## How

`getSessionId()` now reads the timestamp alongside the id and returns `null` if it's missing or older than 30 minutes — the same rule the tracker uses (`sessionAge < 30 * 60 * 1000` in `getOrCreateSessionId()`). The window is a named constant with a comment pointing at the tracker logic. URL-param priority is untouched, and `getTrackingIds`/`getTrackingParams` are unchanged — they get the behavior for free.

Tests: the existing `did_session` setups now write a fresh timestamp, plus new cases for no-timestamp → null, older than 30 minutes → null, and exactly at the boundary → expired (matching the tracker's strict `<` check).

## Tests

```
109 passed (sdk e2e suite, chromium)
7 getSessionId-specific tests passing
tsc --noEmit: 0 errors
bun run test (monorepo): 27/27 tasks passed
```

---

**AI disclosure**: I used Claude (via Qoder) for research and writing. I found the mismatch myself while comparing the tracker's expiry logic against the SDK helper, reproduced it in the e2e suite, and sketched the fix — Claude helped complete the implementation and fill in the test cases from that. I reviewed all the generated code and ran type-check and the full e2e suite locally; the pre-push hook ran the monorepo suite clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #694: `getSessionId()` no longer returns a session id that the tracker has already rotated. It now returns `null` when the stored session has no `did_session_timestamp` or when the timestamp is older than 30 minutes, matching the tracker's expiry rule. `getTrackingIds()` and `getTrackingParams()` inherit the fix since they delegate to `getSessionId()`, and URL params still take priority.

<sup>Written for commit 5e753a2a9e5a93b76d4e063289f885567aa7b7bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

