### PR TITLE
release: promote staging to main

### DIFF
--- a/.github/workflows/promote-gate.yml
+++ b/.github/workflows/promote-gate.yml
@@ -21,7 +21,7 @@ jobs:
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           required=("Databuddy - API Staging" "Databuddy - Staging Basket")
-          for attempt in $(seq 1 24); do
+          for attempt in $(seq 1 40); do
             statuses=$(gh api "repos/${{ github.repository }}/commits/$SHA/status" --jq '.statuses[] | "\(.context)=\(.state)"')
             ok=0
             for ctx in "${required[@]}"; do
@@ -34,7 +34,7 @@ jobs:
             if [ "$ok" -eq "${#required[@]}" ]; then
               echo "All staging deploys green for $SHA"; exit 0
             fi
-            echo "Waiting for staging deploys ($ok/${#required[@]} green, attempt $attempt/24)"
+            echo "Waiting for staging deploys ($ok/${#required[@]} green, attempt $attempt/40)"
             sleep 30
           done
           echo "Staging deploys did not go green within 12 minutes"; exit 1


### PR DESCRIPTION
- ci(release): widen soak gate deploy wait to 20 minutes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extends the soak gate's staging deploy wait from 12 minutes to 20 minutes so the promotion no longer fails while deploys are still settling.

<sup>Written for commit 81e013dab5ca5c5d4289b439632a64274ea9f895. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

