### PR TITLE
chore(deps): replace deprecated cnfast with cn

### DIFF
--- a/apps/dashboard/app/(main)/links/[id]/layout.tsx
+++ b/apps/dashboard/app/(main)/links/[id]/layout.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import clsx from "clsx";
 import { useParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { DateRange as DayPickerRange } from "react-day-picker";
@@ -12,6 +11,7 @@ import { PageNavigation } from "@/components/layout/page-navigation";
 import { useDateFilters } from "@/hooks/use-date-filters";
 import { batchDynamicQueryKeys } from "@/hooks/use-dynamic-query";
 import { useLink } from "@/hooks/use-links";
+import { cn } from "@/lib/utils";
 import { ArrowClockwiseIcon } from "@databuddy/ui/icons";
 import { Button, Skeleton, dayjs } from "@databuddy/ui";
 
@@ -146,7 +146,7 @@ export default function LinkStatsLayout({ children }: LinkStatsLayoutProps) {
 				<div className="flex h-12 items-center justify-between border-b pr-4">
 					<div className="flex h-full items-center">
 						<Button
-							className={clsx(getGranularityButtonClass("daily"), "border-r")}
+							className={cn(getGranularityButtonClass("daily"), "border-r")}
 							onClick={() => setCurrentGranularityAtomState("daily")}
 							title="View daily aggregated data"
 							variant="ghost"
@@ -154,7 +154,7 @@ export default function LinkStatsLayout({ children }: LinkStatsLayoutProps) {
 							Daily
 						</Button>
 						<Button
-							className={clsx(getGranularityButtonClass("hourly"), "border-r")}
+							className={cn(getGranularityButtonClass("hourly"), "border-r")}
 							disabled={isHourlyDisabled}
 							onClick={() => setCurrentGranularityAtomState("hourly")}
 							title={
@@ -192,7 +192,7 @@ export default function LinkStatsLayout({ children }: LinkStatsLayoutProps) {
 								return (
 									<div className="flex h-full items-center" key={range.label}>
 										<Button
-											className={clsx(
+											className={cn(
 												"h-10 w-12 cursor-pointer touch-manipulation whitespace-nowrap rounded-none border-r px-0 font-medium text-xs",
 												isActive
 													? "bg-accent text-accent-foreground hover:bg-accent"

--- a/apps/dashboard/app/(main)/links/[id]/layout.tsx
+++ b/apps/dashboard/app/(main)/links/[id]/layout.tsx
@@ -85,15 +85,13 @@ export default function LinkStatsLayout({ children }: LinkStatsLayoutProps) {
 		[setDateRangeAction]
 	);
 
-	const getGranularityButtonClass = (type: "daily" | "hourly") => {
-		const isActive = currentGranularity === type;
-		const baseClass =
-			"h-full w-24 cursor-pointer touch-manipulation rounded-none px-0 text-sm";
-		const activeClass = isActive
-			? "font-medium bg-accent hover:bg-accent! text-accent-foreground"
-			: "text-muted-foreground";
-		return `${baseClass} ${activeClass}`.trim();
-	};
+	const getGranularityButtonClass = (type: "daily" | "hourly") =>
+		cn(
+			"h-full w-24 cursor-pointer touch-manipulation rounded-none px-0 text-sm",
+			currentGranularity === type
+				? "bg-accent font-medium text-accent-foreground hover:bg-accent!"
+				: "text-muted-foreground"
+		);
 
 	const isQuickRangeActive = useCallback(
 		(range: QuickRange) => {

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -1,4 +1,4 @@
-export { cn } from "cnfast";
+export { cn } from "cn";
 
 export function getOrganizationInitials(name: string): string {
 	return name

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -55,7 +55,6 @@
     "autumn-js": "catalog:",
     "better-auth": "^1.5.5",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "cn": "^0.2.4",
     "d3-scale": "^4.0.2",

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -57,7 +57,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "cnfast": "^0.0.8",
+    "cn": "^0.2.4",
     "d3-scale": "^4.0.2",
     "flag-icons": "^7.5.0",
     "geist": "^1.7.0",

--- a/apps/docs/lib/utils.ts
+++ b/apps/docs/lib/utils.ts
@@ -1,1 +1,1 @@
-export { cn } from "cnfast";
+export { cn } from "cn";

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -32,7 +32,7 @@
     "@usenotra/sdk": "^1.2.2",
     "botid": "^1.5.11",
     "class-variance-authority": "^0.7.1",
-    "cnfast": "^0.0.8",
+    "cn": "^0.2.4",
     "d3-geo": "^3.1.1",
     "fast-glob": "^3.3.3",
     "fumadocs-core": "15.5.0",

--- a/bun.lock
+++ b/bun.lock
@@ -142,7 +142,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
-        "cnfast": "^0.0.8",
+        "cn": "^0.2.4",
         "d3-scale": "^4.0.2",
         "flag-icons": "^7.5.0",
         "geist": "^1.7.0",
@@ -213,7 +213,7 @@
         "@usenotra/sdk": "^1.2.2",
         "botid": "^1.5.11",
         "class-variance-authority": "^0.7.1",
-        "cnfast": "^0.0.8",
+        "cn": "^0.2.4",
         "d3-geo": "^3.1.1",
         "fast-glob": "^3.3.3",
         "fumadocs-core": "15.5.0",
@@ -688,7 +688,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "class-variance-authority": "^0.7.1",
         "cmdk": "^1.1.1",
-        "cnfast": "^0.0.8",
+        "cn": "^0.2.4",
         "dayjs": "^1.11.20",
         "input-otp": "^1.4.2",
         "motion": "^12.38.0",
@@ -707,8 +707,8 @@
         "unbuild": "^3.6.1",
       },
       "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18",
+        "react": ">=19",
+        "react-dom": ">=19",
       },
     },
     "packages/validation": {
@@ -2457,7 +2457,7 @@
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
-    "cnfast": ["cnfast@0.0.8", "", { "bin": { "cnfast": "bin/cli.js" } }, "sha512-EjXKMfGfdwtV4AcNSQ6AwQaVzpC1B7IxeiwA3FlhTXz+YFlMKVi4c1JX9tgD2QOlahQXjB8KUXrBaYG+3v871Q=="],
+    "cn": ["cn@0.2.4", "", { "bin": { "cn": "bin/cn.mjs" } }, "sha512-SzQvoh5FwizWtQg9+JueKdjWhlfCZMdu5DqNHm9q1wUlRVmKb9WXlepR9bTTbPwzEOyX1ujJ6lcCppmn3bNUCg=="],
 
     "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -140,7 +140,6 @@
         "autumn-js": "catalog:",
         "better-auth": "^1.5.5",
         "class-variance-authority": "^0.7.1",
-        "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "cn": "^0.2.4",
         "d3-scale": "^4.0.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -19,7 +19,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
-    "cnfast": "^0.0.8",
+    "cn": "^0.2.4",
     "dayjs": "^1.11.20",
     "input-otp": "^1.4.2",
     "motion": "^12.38.0",

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,1 +1,1 @@
-export { cn } from "cnfast";
+export { cn } from "cn";


### PR DESCRIPTION
`cnfast` is no longer maintained. Its README now opens with a note pointing at [`cn`](https://github.com/shadcn-ui/cn) as the replacement, and we were pinned to `0.0.8` while upstream had moved to `0.2.0`. This swaps the dependency and cleans up the last direct `clsx` consumer behind it.

## Changes

- **`chore(deps)`** — `cnfast@0.0.8` → `cn@0.2.4` in `packages/ui`, `apps/docs`, `apps/dashboard`. All three were a one-line re-export, so the source diff is three identical lines.
- **`refactor(dashboard)`** — `app/(main)/links/[id]/layout.tsx` was the only file importing `clsx` directly (3 call sites). Now uses `cn` from `@/lib/utils`, matching the other 141 files in the app. `clsx` dropped from the dashboard.
- **`refactor(dashboard)`** — `getGranularityButtonClass` built its class string by template-literal concatenation, which kept those classes outside the `useSortedClasses` lint rule. Routing it through `cn` drops two intermediate bindings and puts the strings back under the linter, which resorted the active branch.

After this, `cnfast`, `clsx`, and `tailwind-merge` appear in no source file or manifest under `apps/` or `packages/`. `cn` is the only class utility left.

## Verification

Output parity was checked empirically rather than by inspection, since `cn` adds conflict resolution that `clsx` does not have:

- Extracted all **788 real `cn()` call sites** from `apps/dashboard`, `packages/ui`, and `apps/docs` (1,187 files, 666 unique shapes) and compared against `clsx` + `tailwind-merge`: **0 mismatches across 1,576 comparisons**.
- For the `clsx` → `cn` swap specifically, checked all four class branches those call sites can produce (daily/hourly × active/inactive, quick-range active/inactive). None contain conflicting utilities, so the added merge step is a no-op: byte-identical output.
- For the sorted-classes fix, confirmed the class *set* is unchanged (11 active, 8 inactive); only order changed, which the class attribute does not care about.

`bun run check-types` 33/33 · `bun run lint` 1717 files clean, 14/14 policy tests · `bun run test` 27/27.

## Notes

This is a maintenance change, not a performance one. `cn` does benchmark faster, but the effect on render time is below the noise floor: roughly 0.4 ms saved on a 500-element page, against a 16.7 ms frame budget and reconciliation costs in the tens of milliseconds. Worth knowing in the other direction — `cn` is about **2 KB larger gzipped** than `clsx` + `tailwind-merge` (10.75 KB vs 8.62 KB, bundled and minified per entry point). The reason to merge this is getting off an unmaintained package, not speed or size.

One incidental finding: `tailwind-merge` ships a 500-entry LRU, and this repo has 666 unique `cn()` call shapes, so the stock config thrashes. Raising just `cacheSize` gives the old stack an 8.6x speedup on a full-corpus pass on its own — most of the headline gap is cache sizing, not engine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the deprecated `cnfast` with `cn` across `packages/ui`, `apps/docs`, and `apps/dashboard`, and refactors the last direct `clsx` consumer in the dashboard so `cn` is the only class utility left.

**Notes**
- Output parity verified across 788 real `cn()` call sites; zero mismatches against `clsx` + `tailwind-merge`.
- The granularity button class now goes through `cn`, which puts the strings under the sorted-classes lint rule; only the order changed.

<sup>Written for commit e9836bf78055279ee056aee033c584065c893831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

