### PR TITLE
fix(api): stop letting userId partition the public flag rate limit

### DIFF
--- a/apps/api/src/routes/public/flags.ts
+++ b/apps/api/src/routes/public/flags.ts
@@ -621,26 +621,18 @@ interface ElysiaSet {
 async function enforcePublicFlagRateLimit(
 	request: Request,
 	clientId: string | undefined,
-	userId: string | undefined,
 	set: ElysiaSet
 ): Promise<boolean> {
 	const ip = getClientIp(request.headers);
-	const visitor = ip || userId || "";
 	const rl = await ratelimit(
-		`flags:eval:${clientId || "anon"}:${visitor || "shared"}`,
+		`flags:eval:${clientId || "anon"}:${ip ?? "shared"}`,
 		PUBLIC_EVAL_RATE_PER_MINUTE,
 		60
 	);
 
-	let rateLimitScope: "ip" | "shared" | "user" = "shared";
-	if (ip) {
-		rateLimitScope = "ip";
-	} else if (userId) {
-		rateLimitScope = "user";
-	}
 	mergeWideEvent({
 		flag_client_id: clientId || "",
-		flag_rate_limit_scope: rateLimitScope,
+		flag_rate_limit_scope: ip ? "ip" : "shared",
 		flag_rate_limited: !rl.success,
 	});
 
@@ -784,14 +776,7 @@ async function evaluateBulkFlags(
 	set: ElysiaSet,
 	request: Request
 ) {
-	if (
-		!(await enforcePublicFlagRateLimit(
-			request,
-			input.clientId,
-			input.userId,
-			set
-		))
-	) {
+	if (!(await enforcePublicFlagRateLimit(request, input.clientId, set))) {
 		return { flags: {}, count: 0, reason: "RATE_LIMITED" };
 	}
 
@@ -932,14 +917,7 @@ export const flagsRoute = new Elysia({ prefix: "/v1/flags" })
 	.get(
 		"/evaluate",
 		async function evaluateFlagEndpoint({ query, set, request }) {
-			if (
-				!(await enforcePublicFlagRateLimit(
-					request,
-					query.clientId,
-					query.userId,
-					set
-				))
-			) {
+			if (!(await enforcePublicFlagRateLimit(request, query.clientId, set))) {
 				return {
 					enabled: false,
 					value: false,


### PR DESCRIPTION
Closes the P1 cubic raised on the release PR (#714) for `apps/api/src/routes/public/flags.ts`.

## The bug

`enforcePublicFlagRateLimit` built its bucket key from `ip || userId`:

```ts
const visitor = ip || userId || "";
await ratelimit(`flags:eval:${clientId || "anon"}:${visitor || "shared"}`, 600, 60);
```

`userId` is read straight off the query string or body. Any caller without an IP header could invent a new value per request and mint a fresh 600/min bucket every time, so the limit did nothing.

## The fix

Drop `userId` from the limiter. The key is the client IP, falling back to one shared bucket when there is no IP:

```ts
const ip = getClientIp(request.headers);
await ratelimit(`flags:eval:${clientId || "anon"}:${ip ?? "shared"}`, 600, 60);
```

Both call sites stop passing `userId`, and `flag_rate_limit_scope` collapses to `ip` / `shared` now that there is no third case.

Net: one file, +4/−26.

## Scope

Deliberately narrow. An earlier revision of this branch added a Cloudflare-only IP reader in `packages/shared` plus a `SELFHOST`-gated aggregate ceiling. Greptile then pointed out the obvious hole — a directly-exposed origin can set `cf-connecting-ip` too, so the ceiling was skipped exactly where it was needed. That design also reintroduced IP-trust configuration that `a18d88bf0` had just removed on purpose. It has been dropped entirely; `packages/shared` is untouched by this PR.

Header spoofing against `getClientIp` remains possible off the edge. That is a property of all 18 of its call sites, not this endpoint, and is not something to fix with bespoke machinery here.

`clientId` rotation also still mints buckets. That predates this change and is inherent to keying a public endpoint on a public identifier.

## Verification

`bun run check-types` 33/33 and `bun run test` 27/27, both re-run with `--force` to bypass the turbo cache. `bun run lint` clean, 14/14 policy tests.

The `Test` failure on the previous push was a CI flake: exit code 130 (SIGINT) with every visible test passing. `packages/rpc`'s real test script gives 149 pass / 0 fail identically on this branch and on `staging`, and the job passed on re-run.