### PR TITLE
fix(basket): stop buffering an unbounded /errors body to measure it

### DIFF
--- a/apps/basket/src/routes/basket.ts
+++ b/apps/basket/src/routes/basket.ts
@@ -171,10 +171,22 @@ async function markOversizedErrorsBody({
 			? OVERSIZED_ERRORS_BODY
 			: undefined;
 	}
-	const body = await request.clone().text();
-	return Buffer.byteLength(body) > ERRORS_BODY_MAX_BYTES
-		? OVERSIZED_ERRORS_BODY
-		: undefined;
+	const stream = request.clone().body;
+	if (!stream) {
+		return;
+	}
+	const reader = stream.getReader();
+	let seenBytes = 0;
+	let chunk = await reader.read();
+	while (!chunk.done) {
+		seenBytes += chunk.value.byteLength;
+		if (seenBytes > ERRORS_BODY_MAX_BYTES) {
+			reader.cancel();
+			return OVERSIZED_ERRORS_BODY;
+		}
+		chunk = await reader.read();
+	}
+	return;
 }
 
 const app = new Elysia()

--- a/apps/basket/src/routes/basket.ts
+++ b/apps/basket/src/routes/basket.ts
@@ -181,7 +181,11 @@ async function markOversizedErrorsBody({
 	while (!chunk.done) {
 		seenBytes += chunk.value.byteLength;
 		if (seenBytes > ERRORS_BODY_MAX_BYTES) {
-			reader.cancel();
+			// Not awaited on purpose: clone() tees the body, and waiting for one
+			// branch to cancel while the other is never read deadlocks the request.
+			reader.cancel().catch(() => {
+				// The request is already rejected; a failed cancel changes nothing.
+			});
 			return OVERSIZED_ERRORS_BODY;
 		}
 		chunk = await reader.read();

--- a/apps/basket/src/routes/integration.test.ts
+++ b/apps/basket/src/routes/integration.test.ts
@@ -441,6 +441,35 @@ describe("POST /errors", () => {
 		expect(mockInsertErrorSpans).not.toHaveBeenCalled();
 	});
 
+	test("a chunked body stops being read once it passes the cap", async () => {
+		const chunk = new TextEncoder().encode("x".repeat(16 * 1024));
+		const ceiling = ERRORS_BODY_MAX_BYTES * 8;
+		let produced = 0;
+		const body = new ReadableStream({
+			pull(controller) {
+				if (produced >= ceiling) {
+					controller.close();
+					return;
+				}
+				produced += chunk.byteLength;
+				controller.enqueue(chunk);
+			},
+		});
+
+		const request = new Request("http://localhost/errors", {
+			method: "POST",
+			body,
+			duplex: "half",
+			headers: { "Content-Type": "application/json" },
+		} as RequestInit);
+
+		const res = await basketApp.handle(request);
+
+		expect(res.status).toBe(413);
+		expect(produced).toBeLessThanOrEqual(ERRORS_BODY_MAX_BYTES * 2);
+		expect(mockInsertErrorSpans).not.toHaveBeenCalled();
+	});
+
 	test("body under the size cap → 200", async () => {
 		const spans = [
 			{


### PR DESCRIPTION
Closes the last live cubic finding on the release PR (#714), `apps/basket/src/routes/basket.ts:174`.

## The bug

`markOversizedErrorsBody` guards `/errors` with a 128 KB cap. When `content-length` is present it trusts the declared value, which is fine — the server stops reading at the length it was given, so a caller cannot understate it to smuggle more.

When the header is absent it did this:

```ts
const body = await request.clone().text();
return Buffer.byteLength(body) > ERRORS_BODY_MAX_BYTES ? OVERSIZED_ERRORS_BODY : undefined;
```

So the one path the guard exists to cover was also the one that let a client stream an arbitrary amount into memory before the size was ever checked.

## The fix

Read the cloned stream chunk by chunk and stop at the first chunk that crosses the cap, so at most one chunk beyond the limit is ever held.

```ts
let chunk = await reader.read();
while (!chunk.done) {
  seenBytes += chunk.value.byteLength;
  if (seenBytes > ERRORS_BODY_MAX_BYTES) {
    reader.cancel();
    return OVERSIZED_ERRORS_BODY;
  }
  chunk = await reader.read();
}
```

**The `cancel()` is deliberately not awaited.** `clone()` tees the body, and awaiting the cancel of one branch while the other is never read deadlocks the request. I hit this: the first version of this fix used `await reader.cancel()` in a `finally`, and it hung both the new test and the pre-existing `oversized body without content-length is still rejected` test at 5s. Worth knowing before anyone "tidies" that line.

## Verification

New test streams a body whose producer is willing to emit 1 MB and asserts the producer is stopped within 2× the cap, which is what proves the early bail rather than just the 413:

```ts
expect(res.status).toBe(413);
expect(produced).toBeLessThanOrEqual(ERRORS_BODY_MAX_BYTES * 2);
```

`bunx vitest run src/routes/integration.test.ts` → 57/57, including the pre-existing oversized-body tests. Basket `check-types` and `test` both re-run with `--force` to bypass the turbo cache. Repo lint clean, 14/14 policy tests.

## Not addressed

Chunk granularity means the effective ceiling is the cap plus one chunk rather than exactly 128 KB. Bounding it precisely would mean truncating mid-chunk for a request that is being rejected anyway.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an unbounded memory read in the `/errors` route when a request lacks a `content-length` header. Previously the whole body was buffered into a string before the 128 KB cap was checked; now the cloned stream is read chunk by chunk and stops as soon as the cap is crossed.

**Bug Fixes**
- Holds at most one chunk beyond the cap instead of the entire request body.
- Leaves `reader.cancel()` unawaited because awaiting it deadlocks the teed request body; a `.catch()` handles a failed cancel so it doesn't surface as an unhandled rejection.
- Adds a test that streams a 1 MB body and asserts the producer stops within 2× the cap.
- The effective ceiling is now the cap plus one chunk, not exactly 128 KB.

<sup>Written for commit f1b737ce79b954a41f4e87867ba2f73d968c40c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

