### PR TITLE
chore(deps): upgrade bun to 1.4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache
@@ -56,7 +56,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache
@@ -157,7 +157,7 @@ jobs:
           fetch-depth: 2
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/dashboard-e2e.yml
+++ b/.github/workflows/dashboard-e2e.yml
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -27,6 +27,6 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - run: bun install --frozen-lockfile --ignore-scripts
       - run: bun audit --audit-level=high

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -673,7 +673,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
 
       - name: Install workspace dependencies
         run: bun install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:

--- a/.github/workflows/sdk-e2e.yml
+++ b/.github/workflows/sdk-e2e.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: "1.4.0"
+          bun-version: "1.4.1"
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/.bun/install/cache

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/api --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 

--- a/apps/basket/package.json
+++ b/apps/basket/package.json
@@ -32,5 +32,5 @@
   "devDependencies": {
     "vitest": "^4.1.4"
   },
-  "packageManager": "bun@1.4.0"
+  "packageManager": "bun@1.4.1"
 }

--- a/apps/insights/package.json
+++ b/apps/insights/package.json
@@ -30,5 +30,5 @@
     "@types/pg": "^8.16.0",
     "pg": "^8.16.3"
   },
-  "packageManager": "bun@1.4.0"
+  "packageManager": "bun@1.4.1"
 }

--- a/apps/uptime/package.json
+++ b/apps/uptime/package.json
@@ -21,5 +21,5 @@
     "kafkajs": "^2.2.4",
     "zod": "catalog:"
   },
-  "packageManager": "bun@1.4.0"
+  "packageManager": "bun@1.4.1"
 }

--- a/basket.Dockerfile
+++ b/basket.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/basket --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 

--- a/dashboard.Dockerfile
+++ b/dashboard.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/dashboard --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 

--- a/init.Dockerfile
+++ b/init.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim
+FROM oven/bun:1.4.1-slim
 
 WORKDIR /app
 

--- a/insights.Dockerfile
+++ b/insights.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/insights --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 

--- a/links.Dockerfile
+++ b/links.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/links --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "next": "16.3.4"
   },
   "trustedDependencies": [],
-  "packageManager": "bun@1.4.0",
+  "packageManager": "bun@1.4.1",
   "private": true,
   "scripts": {
     "prepare": "lefthook install",

--- a/slack.Dockerfile
+++ b/slack.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/slack --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -33,7 +33,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 

--- a/uptime.Dockerfile
+++ b/uptime.Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.0-slim AS pruner
+FROM oven/bun:1.4.1-slim AS pruner
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY . .
 
 RUN bunx turbo prune @databuddy/uptime --docker
 
-FROM oven/bun:1.4.0-slim AS builder
+FROM oven/bun:1.4.1-slim AS builder
 
 WORKDIR /app
 
@@ -30,7 +30,7 @@ RUN bun build \
 	--outfile /app/server \
 	./src/index.ts
 
-FROM oven/bun:1.4.0-distroless
+FROM oven/bun:1.4.1-distroless
 
 WORKDIR /app
 


### PR DESCRIPTION
Bun 1.4.1 was released 2026-09-04T08:33Z, about an hour before this repo's 1.4.0 reached production.

## What changed

Every pin that names a runtime version, 35 lines across 19 files:

- `packageManager` in the root plus `apps/basket`, `apps/insights`, `apps/uptime`
- `bun-version` across 10 workflow steps (`ci` x4, `dashboard-e2e`, `dependency-review`, `docker-publish`, `health-check`, `release`, `sdk-e2e`)
- `oven/bun:1.4.0-slim` and `-distroless` base images in all 8 Dockerfiles

`@types/bun` deliberately stays at **1.4.0** — 1.4.1 is not published to npm (404), the types trail the runtime.

Both `oven/bun:1.4.1-slim` and `oven/bun:1.4.1-distroless` were confirmed present on Docker Hub before pinning, since the release is only hours old.

## Two changes to watch on the first CI run

1. **`localhost` DNS now bypasses the system resolver.** `health-check.yml` stands up services on `localhost` (Redpanda on `localhost:9092`, among others). If resolution behaviour differs in the runner, that is where it shows.
2. **TLS verification now uses the URL hostname rather than the Host header.** `apps/links/src/lib/producer.ts` and the basket producer both reach Redpanda over TLS with `ssl: true`. A hostname mismatch would surface as a connect failure.

Neither is expected to break, but they are the two places this release intersects this codebase, so they are worth a look if anything goes red.

1.4.1 also lists reduced idle memory usage, a fix for memory leaks in test isolation and module loading, and faster Buffer operations. Those are relevant to the Basket memory profile but not something this PR tries to measure.

## Verification

Local Bun upgraded to 1.4.1 first, then everything re-run against it:

- `bun install` → lockfile unchanged, 1902 installs across 2188 packages
- `turbo run check-types --force` → **33/33**, 0 cached
- `turbo run test --force` → **27/27**, 0 cached
- `bun run lint` → clean, 14/14 policy tests

Both turbo runs used `--force` deliberately: the cache key does not include the Bun version, so a normal run would have replayed results computed under 1.4.0 and verified nothing.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the Bun runtime from 1.4.0 to 1.4.1 across all 35 version pins in `packageManager` fields, workflow `bun-version` steps, and Docker base images. Bun 1.4.1 fixes memory leaks and reduces idle memory usage, which matters for the Basket service's memory profile; `@types/bun` stays on 1.4.0 because 1.4.1 isn't published to npm.

**Watch on first CI run**
- `localhost` DNS resolution now bypasses the system resolver; the health check talks to services on `localhost`.
- TLS verification now uses the URL hostname instead of the Host header; the links and basket producers reach Redpanda over TLS.

**Verification**
- `bun install` left the lockfile unchanged.
- Turbo runs used `--force` since the cache key excludes the Bun version.

<sup>Written for commit 375a3b2d75efd4f45a8ce9074f728bfdfaf8db79. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

