### PR TITLE
fix(insights): apply the exact goal and funnel repair shown to users

### DIFF
--- a/apps/api/src/integration/insights-handlers.test.ts
+++ b/apps/api/src/integration/insights-handlers.test.ts
@@ -389,7 +389,7 @@ describe("insight investigation timeline", () => {
 
 	iit("repairs a goal target, type and cohort, then queues its recheck", async () => {
         const changes: InsightDefinitionEditChanges = {
-            name: null, description: null, target: "/workspace", type: "PAGE_VIEW",
+            target: "/workspace", type: "PAGE_VIEW",
             filters: [{ field: "device_type", operator: "equals", value: "mobile" }],
         };
         const { goalId, insightId, member, organization } = await seedExecutableGoalAction(changes);

--- a/apps/api/src/integration/insights-handlers.test.ts
+++ b/apps/api/src/integration/insights-handlers.test.ts
@@ -19,7 +19,7 @@ import {
 	getInsightsQueue,
 	insightsResumeJobId,
 } from "@databuddy/redis";
-import type { InvestigationOutcome } from "@databuddy/shared/insights";
+import type { InsightDefinitionEditChanges, InvestigationOutcome } from "@databuddy/shared/insights";
 import {
 	addToOrganization,
 	cleanup,
@@ -66,7 +66,10 @@ function investigationOutcome(nextType: "act" | "watch"): InvestigationOutcome {
 	};
 }
 
-async function seedExecutableGoalAction() {
+async function seedExecutableGoalAction(changes: InsightDefinitionEditChanges = {
+    description: "Counts navigation activity across the site.",
+    name: "Navigation clicks",
+}) {
 	const member = await signUp();
 	const organization = await insertOrganization();
 	await addToOrganization(member.id, organization.id, "member");
@@ -105,10 +108,7 @@ async function seedExecutableGoalAction() {
 			next: {
 				action: "Rename Clicked Nav to Navigation clicks.",
 				execution: {
-					changes: {
-						description: "Counts navigation activity across the site.",
-						name: "Navigation clicks",
-					},
+					changes,
 					operation: "edit",
 				},
 				target: "Goal: Clicked Nav",
@@ -387,6 +387,40 @@ describe("insight investigation timeline", () => {
 		).toEqual({ replyId: applied.reply.id });
 	});
 
+	iit("repairs a goal target, type and cohort, then queues its recheck", async () => {
+        const changes: InsightDefinitionEditChanges = {
+            name: null, description: null, target: "/workspace", type: "PAGE_VIEW",
+            filters: [{ field: "device_type", operator: "equals", value: "mobile" }],
+        };
+        const { goalId, insightId, member, organization } = await seedExecutableGoalAction(changes);
+        const applied = await call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId });
+        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
+        expect(goal).toMatchObject({ target: changes.target, type: changes.type,
+            filters: changes.filters, name: "Clicked Nav", description: "A narrow description." });
+        expect((await getInsightsQueue().getJob(insightsResumeJobId(applied.reply.id)))?.data)
+            .toEqual({ replyId: applied.reply.id });
+    });
+
+    iit("rejects an unchanged goal patch without queuing a recheck", async () => {
+        const { insightId, member, organization } = await seedExecutableGoalAction({
+            name: "Clicked Nav", description: "A narrow description.", target: "nav_clicked", filters: [],
+        });
+        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
+        expect(await db().select().from(insightReplies)).toHaveLength(0);
+    });
+
+    iit("rejects funnel steps applied to a goal without changing it", async () => {
+        const { goalId, insightId, member, organization } = await seedExecutableGoalAction({
+            name: "Should not change", description: null,
+            steps: [{ name: "Start", target: "/", type: "PAGE_VIEW" },
+                { name: "End", target: "/workspace", type: "PAGE_VIEW" }],
+        });
+        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
+        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
+        expect(goal?.name).toBe("Clicked Nav");
+        expect(await db().select().from(insightReplies)).toHaveLength(0);
+    });
+
 	iit("does not apply a goal action after its definition changes", async () => {
 		const { goalId, insightId, member, organization } =
 			await seedExecutableGoalAction();
@@ -431,6 +465,12 @@ describe("insight investigation timeline", () => {
 					changes: {
 						description: "Tracks visitors who complete account creation.",
 						name: "Account creation journey",
+                        filters: [],
+                        steps: [
+                            { name: "Landing", target: "/start", type: "PAGE_VIEW" },
+                            { name: "Account created", target: "signup_completed", type: "EVENT",
+                                conditions: { plan: "paid" } },
+                        ],
 					},
 					operation: "edit",
 				},
@@ -501,6 +541,8 @@ describe("insight investigation timeline", () => {
 				.select({
 					description: funnelDefinitions.description,
 					name: funnelDefinitions.name,
+                    steps: funnelDefinitions.steps,
+                    filters: funnelDefinitions.filters,
 				})
 				.from(funnelDefinitions)
 				.where(eq(funnelDefinitions.id, funnelId))
@@ -508,6 +550,12 @@ describe("insight investigation timeline", () => {
 			{
 				description: "Tracks visitors who complete account creation.",
 				name: "Account creation journey",
+                filters: [],
+                steps: [
+                    { name: "Landing", target: "/start", type: "PAGE_VIEW" },
+                    { name: "Account created", target: "signup_completed", type: "EVENT",
+                        conditions: { plan: "paid" } },
+                ],
 			},
 		]);
 		expect(

--- a/apps/api/src/integration/insights-handlers.test.ts
+++ b/apps/api/src/integration/insights-handlers.test.ts
@@ -409,6 +409,16 @@ describe("insight investigation timeline", () => {
         expect(await db().select().from(insightReplies)).toHaveLength(0);
     });
 
+    iit("rejects a cosmetic rename disguised by repeating the current goal target", async () => {
+        const { goalId, insightId, member, organization } = await seedExecutableGoalAction({
+            name: "Workspace reached", description: null, target: "nav_clicked",
+        });
+        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
+        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
+        expect(goal?.name).toBe("Clicked Nav");
+        expect(await db().select().from(insightReplies)).toHaveLength(0);
+    });
+
     iit("rejects funnel steps applied to a goal without changing it", async () => {
         const { goalId, insightId, member, organization } = await seedExecutableGoalAction({
             name: "Should not change", description: null,

--- a/apps/api/src/integration/insights-handlers.test.ts
+++ b/apps/api/src/integration/insights-handlers.test.ts
@@ -67,8 +67,8 @@ function investigationOutcome(nextType: "act" | "watch"): InvestigationOutcome {
 }
 
 async function seedExecutableGoalAction(changes: InsightDefinitionEditChanges = {
-    description: "Counts navigation activity across the site.",
-    name: "Navigation clicks",
+	description: "Counts navigation activity across the site.",
+	name: "Navigation clicks",
 }) {
 	const member = await signUp();
 	const organization = await insertOrganization();
@@ -387,49 +387,109 @@ describe("insight investigation timeline", () => {
 		).toEqual({ replyId: applied.reply.id });
 	});
 
-	iit("repairs a goal target, type and cohort, then queues its recheck", async () => {
-        const changes: InsightDefinitionEditChanges = {
-            target: "/workspace", type: "PAGE_VIEW",
-            filters: [{ field: "device_type", operator: "equals", value: "mobile" }],
-        };
-        const { goalId, insightId, member, organization } = await seedExecutableGoalAction(changes);
-        const applied = await call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId });
-        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
-        expect(goal).toMatchObject({ target: changes.target, type: changes.type,
-            filters: changes.filters, name: "Clicked Nav", description: "A narrow description." });
-        expect((await getInsightsQueue().getJob(insightsResumeJobId(applied.reply.id)))?.data)
-            .toEqual({ replyId: applied.reply.id });
-    });
+	iit(
+		"repairs a goal target, type and cohort, then queues its recheck",
+		async () => {
+			const changes: InsightDefinitionEditChanges = {
+				target: "/workspace",
+				type: "PAGE_VIEW",
+				filters: [
+					{ field: "device_type", operator: "equals", value: "mobile" },
+				],
+			};
+			const { goalId, insightId, member, organization } =
+				await seedExecutableGoalAction(changes);
+			const applied = await call(
+				appRouter.insights.applyAction,
+				userContext(member, organization.id)
+			)({ insightId });
+			const [goal] = await db()
+				.select()
+				.from(goals)
+				.where(eq(goals.id, goalId));
+			expect(goal).toMatchObject({
+				target: changes.target,
+				type: changes.type,
+				filters: changes.filters,
+				name: "Clicked Nav",
+				description: "A narrow description.",
+			});
+			expect(
+				(await getInsightsQueue().getJob(insightsResumeJobId(applied.reply.id)))
+					?.data
+			).toEqual({ replyId: applied.reply.id });
+		}
+	);
 
-    iit("rejects an unchanged goal patch without queuing a recheck", async () => {
-        const { insightId, member, organization } = await seedExecutableGoalAction({
-            name: "Clicked Nav", description: "A narrow description.", target: "nav_clicked", filters: [],
-        });
-        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
-        expect(await db().select().from(insightReplies)).toHaveLength(0);
-    });
+	iit("rejects an unchanged goal patch without queuing a recheck", async () => {
+		const { insightId, member, organization } = await seedExecutableGoalAction({
+			name: "Clicked Nav",
+			description: "A narrow description.",
+			target: "nav_clicked",
+			filters: [],
+		});
+		await expectCode(
+			call(
+				appRouter.insights.applyAction,
+				userContext(member, organization.id)
+			)({ insightId }),
+			"BAD_REQUEST"
+		);
+		expect(await db().select().from(insightReplies)).toHaveLength(0);
+	});
 
-    iit("rejects a cosmetic rename disguised by repeating the current goal target", async () => {
-        const { goalId, insightId, member, organization } = await seedExecutableGoalAction({
-            name: "Workspace reached", description: null, target: "nav_clicked",
-        });
-        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
-        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
-        expect(goal?.name).toBe("Clicked Nav");
-        expect(await db().select().from(insightReplies)).toHaveLength(0);
-    });
+	iit(
+		"rejects a cosmetic rename disguised by repeating the current goal target",
+		async () => {
+			const { goalId, insightId, member, organization } =
+				await seedExecutableGoalAction({
+					name: "Workspace reached",
+					description: null,
+					target: "nav_clicked",
+				});
+			await expectCode(
+				call(
+					appRouter.insights.applyAction,
+					userContext(member, organization.id)
+				)({ insightId }),
+				"BAD_REQUEST"
+			);
+			const [goal] = await db()
+				.select()
+				.from(goals)
+				.where(eq(goals.id, goalId));
+			expect(goal?.name).toBe("Clicked Nav");
+			expect(await db().select().from(insightReplies)).toHaveLength(0);
+		}
+	);
 
-    iit("rejects funnel steps applied to a goal without changing it", async () => {
-        const { goalId, insightId, member, organization } = await seedExecutableGoalAction({
-            name: "Should not change", description: null,
-            steps: [{ name: "Start", target: "/", type: "PAGE_VIEW" },
-                { name: "End", target: "/workspace", type: "PAGE_VIEW" }],
-        });
-        await expectCode(call(appRouter.insights.applyAction, userContext(member, organization.id))({ insightId }), "BAD_REQUEST");
-        const [goal] = await db().select().from(goals).where(eq(goals.id, goalId));
-        expect(goal?.name).toBe("Clicked Nav");
-        expect(await db().select().from(insightReplies)).toHaveLength(0);
-    });
+	iit(
+		"rejects funnel steps applied to a goal without changing it",
+		async () => {
+			const { goalId, insightId, member, organization } =
+				await seedExecutableGoalAction({
+					name: "Should not change",
+					description: null,
+					steps: [
+						{ name: "Start", target: "/", type: "PAGE_VIEW" },
+						{ name: "End", target: "/workspace", type: "PAGE_VIEW" },
+					],
+				});
+			await expectCode(
+				call(
+					appRouter.insights.applyAction,
+					userContext(member, organization.id)
+				)({ insightId }),
+				"BAD_REQUEST"
+			);
+			const [goal] = await db()
+				.select()
+				.from(goals)
+				.where(eq(goals.id, goalId));
+			expect(goal?.name).toBe("Clicked Nav");
+			expect(await db().select().from(insightReplies)).toHaveLength(0);
+		}
+	);
 
 	iit("does not apply a goal action after its definition changes", async () => {
 		const { goalId, insightId, member, organization } =
@@ -459,120 +519,232 @@ describe("insight investigation timeline", () => {
 		expect(await db().select().from(insightReplies)).toHaveLength(0);
 	});
 
-	iit("applies an executable funnel action and queues verification together", async () => {
-		const member = await signUp();
-		const organization = await insertOrganization();
-		await addToOrganization(member.id, organization.id, "member");
-		const website = await insertWebsite({ organizationId: organization.id });
-		const funnelId = randomUUIDv7();
-		const insightId = randomUUIDv7();
-		const subjectKey = `funnel:${funnelId}`;
-		const outcome: InvestigationOutcome = {
-			...investigationOutcome("act"),
-			next: {
-				action: "Rename Documentation journey to Account creation journey.",
-				execution: {
-					changes: {
-						description: "Tracks visitors who complete account creation.",
-						name: "Account creation journey",
-                        filters: [],
-                        steps: [
-                            { name: "Landing", target: "/start", type: "PAGE_VIEW" },
-                            { name: "Account created", target: "signup_completed", type: "EVENT",
-                                conditions: { plan: "paid" } },
-                        ],
+	iit(
+		"applies an executable funnel action and queues verification together",
+		async () => {
+			const member = await signUp();
+			const organization = await insertOrganization();
+			await addToOrganization(member.id, organization.id, "member");
+			const website = await insertWebsite({ organizationId: organization.id });
+			const funnelId = randomUUIDv7();
+			const insightId = randomUUIDv7();
+			const subjectKey = `funnel:${funnelId}`;
+			const outcome: InvestigationOutcome = {
+				...investigationOutcome("act"),
+				next: {
+					action: "Rename Documentation journey to Account creation journey.",
+					execution: {
+						changes: {
+							description: "Tracks visitors who complete account creation.",
+							name: "Account creation journey",
+							filters: [],
+							steps: [
+								{ name: "Landing", target: "/start", type: "PAGE_VIEW" },
+								{
+									name: "Account created",
+									target: "signup_completed",
+									type: "EVENT",
+									conditions: { plan: "paid" },
+								},
+							],
+						},
+						operation: "edit",
 					},
-					operation: "edit",
+					target: "Funnel: Documentation journey",
+					type: "act",
+					verification:
+						"The funnel definition describes account creation and keeps its verified steps.",
 				},
-				target: "Funnel: Documentation journey",
-				type: "act",
-				verification:
-					"The funnel definition describes account creation and keeps its verified steps.",
-			},
-			rootCause:
-				"The saved funnel label conflicts with its configured account-creation purpose.",
-		};
-		const actionSignal = {
-			...signal(subjectKey),
-			entity: {
-				id: funnelId,
-				label: "Documentation journey",
-				type: "funnel" as const,
-			},
-		};
-
-		await db().insert(funnelDefinitions).values({
-			createdBy: member.id,
-			description: "A vague journey.",
-			id: funnelId,
-			name: "Documentation journey",
-			steps: [
-				{ name: "Landing", target: "/", type: "PAGE_VIEW" },
-				{
-					name: "Account created",
-					target: "account_created",
-					type: "EVENT",
+				rootCause:
+					"The saved funnel label conflicts with its configured account-creation purpose.",
+			};
+			const actionSignal = {
+				...signal(subjectKey),
+				entity: {
+					id: funnelId,
+					label: "Documentation journey",
+					type: "funnel" as const,
 				},
-			],
-			websiteId: website.id,
-		});
-		await db().insert(analyticsInsights).values(
-			insightRow({
-				id: insightId,
-				organizationId: organization.id,
-				subjectKey,
-				websiteId: website.id,
-			})
-		);
-		await db().insert(insightObservations).values({
-			asOf: new Date("2026-01-10T00:00:00.000Z"),
-			id: randomUUIDv7(),
-			insightId,
-			organizationId: organization.id,
-			outcome,
-			recheckAt: new Date("2026-01-17T00:00:00.000Z"),
-			signal: actionSignal,
-			signalKey: subjectKey,
-			websiteId: website.id,
-		});
+			};
 
-		const applied = await call(
-			appRouter.insights.applyAction,
-			userContext(member, organization.id)
-		)({ insightId });
-
-		expect(applied.reply).toMatchObject({
-			body: "Databuddy applied the funnel action. Recheck its verification condition against current data.",
-			kind: "reply",
-			status: "queued",
-		});
-		expect(
 			await db()
-				.select({
-					description: funnelDefinitions.description,
-					name: funnelDefinitions.name,
-                    steps: funnelDefinitions.steps,
-                    filters: funnelDefinitions.filters,
-				})
+				.insert(funnelDefinitions)
+				.values({
+					createdBy: member.id,
+					description: "A vague journey.",
+					id: funnelId,
+					name: "Documentation journey",
+					steps: [
+						{ name: "Landing", target: "/", type: "PAGE_VIEW" },
+						{
+							name: "Account created",
+							target: "account_created",
+							type: "EVENT",
+							conditions: { plan: "paid" },
+						},
+					],
+					websiteId: website.id,
+				});
+			await db()
+				.insert(analyticsInsights)
+				.values(
+					insightRow({
+						id: insightId,
+						organizationId: organization.id,
+						subjectKey,
+						websiteId: website.id,
+					})
+				);
+			await db()
+				.insert(insightObservations)
+				.values({
+					asOf: new Date("2026-01-10T00:00:00.000Z"),
+					id: randomUUIDv7(),
+					insightId,
+					organizationId: organization.id,
+					outcome,
+					recheckAt: new Date("2026-01-17T00:00:00.000Z"),
+					signal: actionSignal,
+					signalKey: subjectKey,
+					websiteId: website.id,
+				});
+
+			const applied = await call(
+				appRouter.insights.applyAction,
+				userContext(member, organization.id)
+			)({ insightId });
+
+			expect(applied.reply).toMatchObject({
+				body: "Databuddy applied the funnel action. Recheck its verification condition against current data.",
+				kind: "reply",
+				status: "queued",
+			});
+			expect(
+				await db()
+					.select({
+						description: funnelDefinitions.description,
+						name: funnelDefinitions.name,
+						steps: funnelDefinitions.steps,
+						filters: funnelDefinitions.filters,
+					})
+					.from(funnelDefinitions)
+					.where(eq(funnelDefinitions.id, funnelId))
+			).toEqual([
+				{
+					description: "Tracks visitors who complete account creation.",
+					name: "Account creation journey",
+					filters: [],
+					steps: [
+						{ name: "Landing", target: "/start", type: "PAGE_VIEW" },
+						{
+							name: "Account created",
+							target: "signup_completed",
+							type: "EVENT",
+							conditions: { plan: "paid" },
+						},
+					],
+				},
+			]);
+			expect(
+				(await getInsightsQueue().getJob(insightsResumeJobId(applied.reply.id)))
+					?.data
+			).toEqual({ replyId: applied.reply.id });
+		}
+	);
+
+	iit.each(["dropped conditions", "changed conditions", "renamed steps"])(
+		"rejects a funnel repair with %s",
+		async (variant) => {
+			const member = await signUp();
+			const organization = await insertOrganization();
+			await addToOrganization(member.id, organization.id, "member");
+			const website = await insertWebsite({ organizationId: organization.id });
+			const funnelId = randomUUIDv7();
+			const insightId = randomUUIDv7();
+			const subjectKey = `funnel:${funnelId}`;
+			const steps = [
+				{ name: "Start", type: "PAGE_VIEW" as const, target: "/start" },
+				{
+					name: "Finish",
+					type: "EVENT" as const,
+					target: "account_created",
+					conditions: { plan: "paid" },
+				},
+			];
+			const replacement =
+				variant === "renamed steps"
+					? steps.map((step) => ({ ...step, name: `${step.name} renamed` }))
+					: [
+							steps[0],
+							{
+								name: "Finish",
+								type: "EVENT" as const,
+								target: "signup_completed",
+								...(variant === "changed conditions"
+									? { conditions: { plan: "free" } }
+									: {}),
+							},
+						];
+			await db()
+				.insert(funnelDefinitions)
+				.values({
+					id: funnelId,
+					websiteId: website.id,
+					createdBy: member.id,
+					name: "Account journey",
+					steps,
+					updatedAt: new Date("2026-01-01T00:00:00Z"),
+				});
+			await db()
+				.insert(analyticsInsights)
+				.values(
+					insightRow({
+						id: insightId,
+						organizationId: organization.id,
+						subjectKey,
+						websiteId: website.id,
+					})
+				);
+			await db()
+				.insert(insightObservations)
+				.values({
+					id: randomUUIDv7(),
+					insightId,
+					organizationId: organization.id,
+					websiteId: website.id,
+					signalKey: subjectKey,
+					asOf: new Date("2026-01-10T00:00:00Z"),
+					recheckAt: new Date("2026-01-17T00:00:00Z"),
+					signal: {
+						...signal(subjectKey),
+						entity: { type: "funnel", id: funnelId, label: "Account journey" },
+					},
+					outcome: {
+						...investigationOutcome("act"),
+						next: {
+							type: "act",
+							action: "Repair the account journey.",
+							target: "Account journey",
+							verification: "Matching account counts recover.",
+							execution: { operation: "edit", changes: { steps: replacement } },
+						},
+					},
+				});
+			await expectCode(
+				call(
+					appRouter.insights.applyAction,
+					userContext(member, organization.id)
+				)({ insightId }),
+				"BAD_REQUEST"
+			);
+			const [unchanged] = await db()
+				.select()
 				.from(funnelDefinitions)
-				.where(eq(funnelDefinitions.id, funnelId))
-		).toEqual([
-			{
-				description: "Tracks visitors who complete account creation.",
-				name: "Account creation journey",
-                filters: [],
-                steps: [
-                    { name: "Landing", target: "/start", type: "PAGE_VIEW" },
-                    { name: "Account created", target: "signup_completed", type: "EVENT",
-                        conditions: { plan: "paid" } },
-                ],
-			},
-		]);
-		expect(
-			(await getInsightsQueue().getJob(insightsResumeJobId(applied.reply.id)))
-				?.data
-		).toEqual({ replyId: applied.reply.id });
-	});
+				.where(eq(funnelDefinitions.id, funnelId));
+			expect(unchanged?.steps).toEqual(steps);
+			expect(await db().select().from(insightReplies)).toHaveLength(0);
+		}
+	);
 
 	iit("remeasures an open goal investigation after a teammate edits its definition", async () => {
 		const member = await signUp();

--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -7,6 +7,8 @@ import {
 import { getAILogger } from "@databuddy/ai/lib/ai-logger";
 import {
 	agentInvestigationOutcomeSchema,
+	describeInsightDefinitionAction,
+	insightDefinitionEditError,
 	investigationOutcomeSchema,
 	type AgentInvestigationOutcome,
 	type InsightDefinitionOperation,
@@ -226,7 +228,7 @@ Evidence
 - A supplied route-continuation comparison measures later different-page views within ten minutes among matched sessions: state it as an association, never causation, bounce, conversion, or revenue. Payment matches are lower bounds for attributed completed payments, never active subscriptions.
 
 Outcome
-- act: only for an inspected mechanism with the smallest concrete target and change, measured impact, and a verification condition that proves recovery. Set recheckAt to the earliest defensible time given the measurement window. An existing goal or funnel that is materially unsafe for its established purpose gets an exact edit or delete via next.execution; delete only when inspection shows no independent valid use, and cosmetic renames are not actions.
+- act: only for an inspected mechanism with the smallest concrete target and change, measured impact, and a verification condition that proves recovery. Set recheckAt to the earliest defensible time given the measurement window. An existing goal or funnel that is materially unsafe for its established purpose gets an exact edit or delete via next.execution; delete only when inspection shows no independent valid use, and cosmetic renames are not actions. For edits, put the actual goal target/type/filters or complete ordered funnel steps/filters in execution.changes; name and description alone cannot repair what is measured. Preserve existing step conditions. The displayed action is generated from this patch.
 - ask: only after exhausting inspectable context, for one external fact that selects between materially different moves; say what it unlocks. When a material reliability problem needs source access, ask for the owning repository rather than guessing a fix; when a repository is supplied, inspect it before asking about ownership. One repository-access request per website: when other open work already asks for repository access, resolve and state that this signal is blocked on that request; still publish that resolve when the exposure itself is a new, material fact.
 - Otherwise resolve. Use history and other open work to avoid repeating an action or question; reissue only when impact worsens or new evidence changes the target or remedy.
 - Classify every outcome: raw errors and vitals are reliability_exposure; user_experience needs a directly measured downstream consequence (for route vitals, only via supplied qualified matched continuation); product_outcome needs a measured business result; measurement_definition or measurement_coverage needs a named decision made unsafe. The signal's own movement is not a downstream consequence. A measurement finding publishes only alongside its executable definition fix; a definition observation without a fix resolves unpublished.
@@ -361,6 +363,20 @@ function validateDefinitionRecommendation(
 	if (definition.operation === "delete") {
 		return;
 	}
+	const error = insightDefinitionEditError(entityType, definition.changes);
+	if (error) {
+		throw new Error(error);
+	}
+	if (
+		definition.changes.target == null &&
+		definition.changes.type == null &&
+		definition.changes.steps == null &&
+		definition.changes.filters == null
+	) {
+		throw new Error(
+			"Executable repairs must change the measured target, type, steps, or filters. A name or description change alone is not a repair."
+		);
+	}
 	const hasConfiguredPurpose = input.evidence.some((item) =>
 		item.includes("Business meaning:")
 	);
@@ -371,7 +387,7 @@ function validateDefinitionRecommendation(
 		)
 	) {
 		throw new Error(
-			"Insights definition edits require an inspected purpose before changing a name or description"
+			"Insights definition edits require an inspected purpose before changing what a goal or funnel measures"
 		);
 	}
 	if (!hasUsedTool(usedToolNames, DEFINITION_CONTEXT_TOOLS)) {
@@ -650,6 +666,15 @@ function validateAgentOutcome(
 	}
 
 	let next: unknown = outcome.next;
+	if (outcome.next.type === "act" && outcome.next.execution !== null) {
+		next = {
+			...outcome.next,
+			action: describeInsightDefinitionAction(input.signal.entity.label, {
+				...outcome.next.execution,
+				action: outcome.next.action,
+			}),
+		};
+	}
 	if (outcome.next.type === "act" && outcome.next.execution === null) {
 		const { execution: _execution, ...persistedNext } = outcome.next;
 		next = persistedNext;

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -1,5 +1,6 @@
 import "@databuddy/test/env";
 import { describe, expect, it } from "bun:test";
+import { describeInsightDefinitionAction } from "@databuddy/shared/insights";
 import type {
 	InvestigationOutcome,
 	InvestigationSignal,
@@ -135,6 +136,10 @@ const executableDefinitionOutcome = {
 			changes: {
 				description: "Tracks visitors who complete account creation.",
 				name: "Account creation journey",
+				steps: [
+					{ name: "Landing", target: "/", type: "PAGE_VIEW" as const },
+					{ name: "Account created", target: "account_created", type: "EVENT" as const },
+				],
 			},
 			operation: "edit" as const,
 		},
@@ -534,8 +539,36 @@ describe("intelligence agent", () => {
 			}
 		);
 
-		expect(result.outcome.next).toEqual(executableDefinitionOutcome.next);
+		expect(result.outcome.next).toEqual({
+            ...executableDefinitionOutcome.next,
+            action: describeInsightDefinitionAction(funnelSignal.entity.label, {
+                ...executableDefinitionOutcome.next.execution,
+                action: executableDefinitionOutcome.next.action,
+            }),
+        });
 	});
+
+	it("rejects a cosmetic rename presented as a measurement repair", async () => {
+        const cosmetic = {
+            ...executableDefinitionOutcome,
+            next: { ...executableDefinitionOutcome.next, execution: {
+                operation: "edit" as const,
+                changes: { name: "Account creation journey", description: null },
+            } },
+        };
+        await expect(runInsightAgent({
+            appContext: appContext(), evidence, githubRepository: null,
+            history: [], otherOpenWork: [], signal: funnelSignal,
+        }, {
+            model: new MockLanguageModelV3({ doGenerate: mockValues(
+                toolCallsResponse(["list_funnels"]), outputResponse(cosmetic),
+                outputResponse(cosmetic), outputResponse(cosmetic),
+            ) }),
+            tools: { list_funnels: tool({ description: "Inspect definitions.",
+                execute: () => ({ data: [{ id: "checkout" }] }),
+                inputSchema: z.object({}).strict() }) },
+        })).rejects.toThrow("A name or description change alone is not a repair");
+    });
 
 	it("rejects a definition edit without an inspected definition", async () => {
 		await expect(

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -138,7 +138,11 @@ const executableDefinitionOutcome = {
 				name: "Account creation journey",
 				steps: [
 					{ name: "Landing", target: "/", type: "PAGE_VIEW" as const },
-					{ name: "Account created", target: "account_created", type: "EVENT" as const },
+					{
+						name: "Account created",
+						target: "account_created",
+						type: "EVENT" as const,
+					},
 				],
 			},
 			operation: "edit" as const,
@@ -351,7 +355,8 @@ describe("intelligence agent", () => {
 		const exposureOutcome = {
 			...measuredOutcome,
 			findingKind: "reliability_exposure" as const,
-			impact: "Sign-in page loads reached 7.2 seconds in the comparison window.",
+			impact:
+				"Sign-in page loads reached 7.2 seconds in the comparison window.",
 			publicationBasis: "measured_reliability" as const,
 			title: "Sign-in page loads were slow",
 		};
@@ -439,9 +444,7 @@ describe("intelligence agent", () => {
 			{ ...input, hasQualifiedRouteVitalContinuation: true },
 			{ model: measurementModel, tools: {} }
 		);
-		expect(measurementResult.outcome.findingKind).toBe(
-			"reliability_exposure"
-		);
+		expect(measurementResult.outcome.findingKind).toBe("reliability_exposure");
 	});
 
 	it("turns ambiguous definition questions into unpublished resolves", async () => {
@@ -540,35 +543,55 @@ describe("intelligence agent", () => {
 		);
 
 		expect(result.outcome.next).toEqual({
-            ...executableDefinitionOutcome.next,
-            action: describeInsightDefinitionAction(funnelSignal.entity.label, {
-                ...executableDefinitionOutcome.next.execution,
-                action: executableDefinitionOutcome.next.action,
-            }),
-        });
+			...executableDefinitionOutcome.next,
+			action: describeInsightDefinitionAction(funnelSignal.entity.label, {
+				...executableDefinitionOutcome.next.execution,
+				action: executableDefinitionOutcome.next.action,
+			}),
+		});
 	});
 
 	it("rejects a cosmetic rename presented as a measurement repair", async () => {
-        const cosmetic = {
-            ...executableDefinitionOutcome,
-            next: { ...executableDefinitionOutcome.next, execution: {
-                operation: "edit" as const,
-                changes: { name: "Account creation journey", description: null },
-            } },
-        };
-        await expect(runInsightAgent({
-            appContext: appContext(), evidence, githubRepository: null,
-            history: [], otherOpenWork: [], signal: funnelSignal,
-        }, {
-            model: new MockLanguageModelV3({ doGenerate: mockValues(
-                toolCallsResponse(["list_funnels"]), outputResponse(cosmetic),
-                outputResponse(cosmetic), outputResponse(cosmetic),
-            ) }),
-            tools: { list_funnels: tool({ description: "Inspect definitions.",
-                execute: () => ({ data: [{ id: "checkout" }] }),
-                inputSchema: z.object({}).strict() }) },
-        })).rejects.toThrow("A name or description change alone is not a repair");
-    });
+		const cosmetic = {
+			...executableDefinitionOutcome,
+			next: {
+				...executableDefinitionOutcome.next,
+				execution: {
+					operation: "edit" as const,
+					changes: { name: "Account creation journey", description: null },
+				},
+			},
+		};
+		await expect(
+			runInsightAgent(
+				{
+					appContext: appContext(),
+					evidence,
+					githubRepository: null,
+					history: [],
+					otherOpenWork: [],
+					signal: funnelSignal,
+				},
+				{
+					model: new MockLanguageModelV3({
+						doGenerate: mockValues(
+							toolCallsResponse(["list_funnels"]),
+							outputResponse(cosmetic),
+							outputResponse(cosmetic),
+							outputResponse(cosmetic)
+						),
+					}),
+					tools: {
+						list_funnels: tool({
+							description: "Inspect definitions.",
+							execute: () => ({ data: [{ id: "checkout" }] }),
+							inputSchema: z.object({}).strict(),
+						}),
+					},
+				}
+			)
+		).rejects.toThrow("A name or description change alone is not a repair");
+	});
 
 	it("rejects a definition edit without an inspected definition", async () => {
 		await expect(
@@ -1194,8 +1217,7 @@ describe("intelligence agent", () => {
 					{
 						asOf: "2026-07-12T00:30:00.000Z",
 						next: {
-							question:
-								"Connect the repository that owns the checkout flow.",
+							question: "Connect the repository that owns the checkout flow.",
 							type: "ask",
 						},
 						title: "Checkout repository access",

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -40,6 +40,7 @@ import { z } from "zod";
 import { rpcError } from "../errors";
 import { invalidateGoalsCache } from "../lib/goals-cache";
 import { invalidateFunnelsCache } from "../lib/funnels-cache";
+import { requireFunnelSteps, toAnalyticsSteps } from "./funnel-steps";
 import { logger } from "../lib/logger";
 import { setAuditOrganization } from "../lib/audit";
 import {
@@ -965,9 +966,32 @@ async function applyInsightAction(input: {
 					steps: action.changes.steps ?? funnel.steps,
 					filters: action.changes.filters ?? funnel.filters,
 				};
+				const currentSteps = requireFunnelSteps(funnel.steps);
+				const replacementSteps = requireFunnelSteps(changes.steps);
+				// Conditions are stored but not evaluated by funnel analytics. Never
+				// silently discard them or present changing them as a repair.
+				if (
+					[...currentSteps, ...replacementSteps].some(
+						(step) => Object.keys(step.conditions ?? {}).length > 0
+					) &&
+					!isDeepStrictEqual(
+						currentSteps.map((step) => step.conditions ?? {}),
+						replacementSteps.map((step) => step.conditions ?? {})
+					)
+				) {
+					throw rpcError.badRequest(
+						"Automatic funnel repairs must preserve existing step conditions and cannot add conditions that analytics does not evaluate."
+					);
+				}
 				const changesMeasurement = !(
-					isDeepStrictEqual(changes.steps, funnel.steps) &&
-					isDeepStrictEqual(changes.filters ?? [], funnel.filters ?? [])
+					isDeepStrictEqual(
+						toAnalyticsSteps(replacementSteps).map(
+							({ name: _name, ...step }) => step
+						),
+						toAnalyticsSteps(currentSteps).map(
+							({ name: _name, ...step }) => step
+						)
+					) && isDeepStrictEqual(changes.filters ?? [], funnel.filters ?? [])
 				);
 				const includesMeasurement =
 					action.changes.steps != null || action.changes.filters != null;

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -888,6 +888,19 @@ async function applyInsightAction(input: {
 					type: action.changes.type ?? goal.type,
 					filters: action.changes.filters ?? goal.filters,
 				};
+				const changesMeasurement =
+					changes.target !== goal.target ||
+					changes.type !== goal.type ||
+					!isDeepStrictEqual(changes.filters ?? [], goal.filters ?? []);
+				const includesMeasurement =
+					action.changes.target != null ||
+					action.changes.type != null ||
+					action.changes.filters != null;
+				if (includesMeasurement && !changesMeasurement) {
+					throw rpcError.badRequest(
+						"This repair does not change what the goal measures."
+					);
+				}
 				if (
 					changes.description === goal.description &&
 					changes.name === goal.name &&
@@ -952,6 +965,17 @@ async function applyInsightAction(input: {
 					steps: action.changes.steps ?? funnel.steps,
 					filters: action.changes.filters ?? funnel.filters,
 				};
+				const changesMeasurement = !(
+					isDeepStrictEqual(changes.steps, funnel.steps) &&
+					isDeepStrictEqual(changes.filters ?? [], funnel.filters ?? [])
+				);
+				const includesMeasurement =
+					action.changes.steps != null || action.changes.filters != null;
+				if (includesMeasurement && !changesMeasurement) {
+					throw rpcError.badRequest(
+						"This repair does not change what the funnel measures."
+					);
+				}
 				if (
 					changes.description === funnel.description &&
 					changes.name === funnel.name &&

--- a/packages/rpc/src/routers/insights.ts
+++ b/packages/rpc/src/routers/insights.ts
@@ -31,7 +31,9 @@ import {
 	insightTimelineReplySchema,
 	parseInvestigationOutcome,
 	parseInvestigationSignal,
+	insightDefinitionEditError,
 } from "@databuddy/shared/insights";
+import { isDeepStrictEqual } from "node:util";
 import { ORPCError } from "@orpc/server";
 import { randomUUIDv7 } from "bun";
 import { z } from "zod";
@@ -678,10 +680,7 @@ function sameDefinitionExecution(
 	if (left.operation === "delete" || right.operation === "delete") {
 		return true;
 	}
-	return (
-		left.changes.name === right.changes.name &&
-		left.changes.description === right.changes.description
-	);
+	return isDeepStrictEqual(left.changes, right.changes);
 }
 
 function definitionActionError(
@@ -836,12 +835,21 @@ async function applyInsightAction(input: {
 		}
 
 		const completedAt = new Date();
+		if (action.operation === "edit") {
+			const error = insightDefinitionEditError(entityType, action.changes);
+			if (error) {
+				throw rpcError.badRequest(error);
+			}
+		}
 		if (entityType === "goal") {
 			const [goal] = await tx
 				.select({
 					description: goals.description,
 					id: goals.id,
 					name: goals.name,
+					target: goals.target,
+					type: goals.type,
+					filters: goals.filters,
 					updatedAt: goals.updatedAt,
 				})
 				.from(goals)
@@ -873,11 +881,28 @@ async function applyInsightAction(input: {
 					})
 					.where(eq(goals.id, goal.id));
 			} else {
+				const changes = {
+					description: action.changes.description ?? goal.description,
+					name: action.changes.name ?? goal.name,
+					target: action.changes.target ?? goal.target,
+					type: action.changes.type ?? goal.type,
+					filters: action.changes.filters ?? goal.filters,
+				};
+				if (
+					changes.description === goal.description &&
+					changes.name === goal.name &&
+					changes.target === goal.target &&
+					changes.type === goal.type &&
+					isDeepStrictEqual(changes.filters ?? [], goal.filters ?? [])
+				) {
+					throw rpcError.badRequest(
+						"This action does not change the goal definition."
+					);
+				}
 				await tx
 					.update(goals)
 					.set({
-						description: action.changes.description ?? goal.description,
-						name: action.changes.name ?? goal.name,
+						...changes,
 						updatedAt: completedAt,
 					})
 					.where(eq(goals.id, goal.id));
@@ -888,6 +913,8 @@ async function applyInsightAction(input: {
 					description: funnelDefinitions.description,
 					id: funnelDefinitions.id,
 					name: funnelDefinitions.name,
+					steps: funnelDefinitions.steps,
+					filters: funnelDefinitions.filters,
 					updatedAt: funnelDefinitions.updatedAt,
 				})
 				.from(funnelDefinitions)
@@ -919,11 +946,26 @@ async function applyInsightAction(input: {
 					})
 					.where(eq(funnelDefinitions.id, funnel.id));
 			} else {
+				const changes = {
+					description: action.changes.description ?? funnel.description,
+					name: action.changes.name ?? funnel.name,
+					steps: action.changes.steps ?? funnel.steps,
+					filters: action.changes.filters ?? funnel.filters,
+				};
+				if (
+					changes.description === funnel.description &&
+					changes.name === funnel.name &&
+					isDeepStrictEqual(changes.steps, funnel.steps) &&
+					isDeepStrictEqual(changes.filters ?? [], funnel.filters ?? [])
+				) {
+					throw rpcError.badRequest(
+						"This action does not change the funnel definition."
+					);
+				}
 				await tx
 					.update(funnelDefinitions)
 					.set({
-						description: action.changes.description ?? funnel.description,
-						name: action.changes.name ?? funnel.name,
+						...changes,
 						updatedAt: completedAt,
 					})
 					.where(eq(funnelDefinitions.id, funnel.id));

--- a/packages/shared/src/insights.test.ts
+++ b/packages/shared/src/insights.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "bun:test";
 import {
 	agentInvestigationOutcomeSchema,
+	describeInsightDefinitionAction,
+	insightDefinitionEditError,
 	insightBriefItemSchema,
 	insightDefinitionOperationSchema,
 	investigationOutcomeSchema,
@@ -142,6 +144,27 @@ const agentFields = {
 };
 
 describe("insightDefinitionOperationSchema", () => {
+    it("describes the executable patch instead of a conflicting model action", () => {
+        const operation = insightDefinitionOperationSchema.parse({
+            operation: "edit", action: "Delete the goal.",
+            changes: { name: null, description: null, target: "/workspace", type: "PAGE_VIEW", filters: [] },
+        });
+        expect(describeInsightDefinitionAction("Reached workspace", operation))
+            .toBe('For Reached workspace, set target to "/workspace"; set type to PAGE_VIEW; set filters to none.');
+        if (operation.operation !== "edit") throw new Error("Expected an edit");
+        expect(insightDefinitionEditError("goal", operation.changes)).toBeNull();
+        expect(insightDefinitionEditError("funnel", operation.changes)).toContain("replace steps");
+    });
+
+    it("rejects unsupported filter fields in executable patches", () => {
+        expect(insightDefinitionOperationSchema.safeParse({
+            operation: "edit", action: "Change the cohort.",
+            changes: { name: null, description: null, filters: [
+                { field: "unknown_column", operator: "equals", value: "mobile" },
+            ] },
+        }).success).toBe(false);
+    });
+
 	it("accepts an exact funnel rename", () => {
 		const execution = {
 			action: "Rename Sign-Up Flow to Homepage-to-Getting Started Journey.",

--- a/packages/shared/src/insights.test.ts
+++ b/packages/shared/src/insights.test.ts
@@ -144,6 +144,11 @@ const agentFields = {
 };
 
 describe("insightDefinitionOperationSchema", () => {
+    it("accepts a minimal goal target patch without redundant metadata fields", () => {
+        expect(insightDefinitionOperationSchema.parse({ operation: "edit", action: "Repair the workspace goal target.",
+            changes: { target: "/workspace" } }).changes).toEqual({ target: "/workspace" });
+    });
+
     it("describes the executable patch instead of a conflicting model action", () => {
         const operation = insightDefinitionOperationSchema.parse({
             operation: "edit", action: "Delete the goal.",

--- a/packages/shared/src/insights.test.ts
+++ b/packages/shared/src/insights.test.ts
@@ -115,7 +115,9 @@ describe("investigationSignalSchema", () => {
 			baselineDates,
 		};
 
-		expect(investigationSignalSchema.safeParse(zscoreSignal).success).toBe(true);
+		expect(investigationSignalSchema.safeParse(zscoreSignal).success).toBe(
+			true
+		);
 		expect(
 			investigationSignalSchema.safeParse({
 				...zscoreSignal,
@@ -127,7 +129,8 @@ describe("investigationSignalSchema", () => {
 
 const outcomeBase = {
 	title: "Checkout recovered after the handler rollback",
-	summary: "Checkout failures ended after the latest handler change was rolled back.",
+	summary:
+		"Checkout failures ended after the latest handler change was rolled back.",
 	impact: "The failure blocked 18 checkout attempts before the rollback.",
 	rootCause: null,
 	evidence: ["Checkout submissions resumed after the handler rollback."],
@@ -144,31 +147,55 @@ const agentFields = {
 };
 
 describe("insightDefinitionOperationSchema", () => {
-    it("accepts a minimal goal target patch without redundant metadata fields", () => {
-        expect(insightDefinitionOperationSchema.parse({ operation: "edit", action: "Repair the workspace goal target.",
-            changes: { target: "/workspace" } }).changes).toEqual({ target: "/workspace" });
-    });
+	it("accepts a minimal goal target patch without redundant metadata fields", () => {
+		expect(
+			insightDefinitionOperationSchema.parse({
+				operation: "edit",
+				action: "Repair the workspace goal target.",
+				changes: { target: "/workspace" },
+			}).changes
+		).toEqual({ target: "/workspace" });
+	});
 
-    it("describes the executable patch instead of a conflicting model action", () => {
-        const operation = insightDefinitionOperationSchema.parse({
-            operation: "edit", action: "Delete the goal.",
-            changes: { name: null, description: null, target: "/workspace", type: "PAGE_VIEW", filters: [] },
-        });
-        expect(describeInsightDefinitionAction("Reached workspace", operation))
-            .toBe('For Reached workspace, set target to "/workspace"; set type to PAGE_VIEW; set filters to none.');
-        if (operation.operation !== "edit") throw new Error("Expected an edit");
-        expect(insightDefinitionEditError("goal", operation.changes)).toBeNull();
-        expect(insightDefinitionEditError("funnel", operation.changes)).toContain("replace steps");
-    });
+	it("describes the executable patch instead of a conflicting model action", () => {
+		const operation = insightDefinitionOperationSchema.parse({
+			operation: "edit",
+			action: "Delete the goal.",
+			changes: {
+				name: null,
+				description: null,
+				target: "/workspace",
+				type: "PAGE_VIEW",
+				filters: [],
+			},
+		});
+		expect(
+			describeInsightDefinitionAction("Reached workspace", operation)
+		).toBe(
+			'For Reached workspace, set target to "/workspace"; set type to PAGE_VIEW; set filters to none.'
+		);
+		if (operation.operation !== "edit") throw new Error("Expected an edit");
+		expect(insightDefinitionEditError("goal", operation.changes)).toBeNull();
+		expect(insightDefinitionEditError("funnel", operation.changes)).toContain(
+			"replace steps"
+		);
+	});
 
-    it("rejects unsupported filter fields in executable patches", () => {
-        expect(insightDefinitionOperationSchema.safeParse({
-            operation: "edit", action: "Change the cohort.",
-            changes: { name: null, description: null, filters: [
-                { field: "unknown_column", operator: "equals", value: "mobile" },
-            ] },
-        }).success).toBe(false);
-    });
+	it("rejects unsupported filter fields in executable patches", () => {
+		expect(
+			insightDefinitionOperationSchema.safeParse({
+				operation: "edit",
+				action: "Change the cohort.",
+				changes: {
+					name: null,
+					description: null,
+					filters: [
+						{ field: "unknown_column", operator: "equals", value: "mobile" },
+					],
+				},
+			}).success
+		).toBe(false);
+	});
 
 	it("accepts an exact funnel rename", () => {
 		const execution = {
@@ -180,7 +207,9 @@ describe("insightDefinitionOperationSchema", () => {
 			operation: "edit" as const,
 		};
 
-		expect(insightDefinitionOperationSchema.parse(execution)).toEqual(execution);
+		expect(insightDefinitionOperationSchema.parse(execution)).toEqual(
+			execution
+		);
 	});
 
 	it("rejects an empty edit and display-only operations", () => {
@@ -190,7 +219,9 @@ describe("insightDefinitionOperationSchema", () => {
 			operation: "edit" as const,
 		};
 
-		expect(insightDefinitionOperationSchema.safeParse(base).success).toBe(false);
+		expect(insightDefinitionOperationSchema.safeParse(base).success).toBe(
+			false
+		);
 		expect(
 			insightDefinitionOperationSchema.safeParse({
 				action: "Review the funnel definition.",
@@ -233,7 +264,6 @@ describe("insightBriefItemSchema", () => {
 			}).success
 		).toBe(false);
 	});
-
 });
 
 describe("investigationOutcomeSchema", () => {
@@ -433,16 +463,16 @@ describe("investigationOutcomeSchema", () => {
 		);
 		expect(
 			agentInvestigationOutcomeSchema.safeParse({
-			...candidate,
-			next: {
-				...action,
-				execution: {
-					...action.execution,
-					changes: { description: null, name: null },
+				...candidate,
+				next: {
+					...action,
+					execution: {
+						...action.execution,
+						changes: { description: null, name: null },
+					},
 				},
-			},
-		}).success
-	).toBe(false);
+			}).success
+		).toBe(false);
 		const legacyAction = agentInvestigationOutcomeSchema.safeParse({
 			...candidate,
 			next: {
@@ -483,9 +513,7 @@ describe("investigationOutcomeSchema", () => {
 			publicationBasis: null,
 		};
 
-		expect(investigationOutcomeSchema.safeParse(candidate).success).toBe(
-			true
-		);
+		expect(investigationOutcomeSchema.safeParse(candidate).success).toBe(true);
 		expect(
 			agentInvestigationOutcomeSchema.safeParse({
 				...candidate,
@@ -494,18 +522,19 @@ describe("investigationOutcomeSchema", () => {
 	});
 
 	it("accepts concise output with measured or unknown impact", () => {
-		expect(investigationOutcomeSchema.safeParse(outcomeBase).success).toBe(true);
+		expect(investigationOutcomeSchema.safeParse(outcomeBase).success).toBe(
+			true
+		);
 		expect(
 			investigationOutcomeSchema.safeParse({ ...outcomeBase, impact: null })
 				.success
 		).toBe(true);
-			expect(
-				investigationOutcomeSchema.safeParse({
-					...outcomeBase,
-					impact: null,
-					rootCause:
-						"The handler change dropped valid checkout submissions.",
-					next: {
+		expect(
+			investigationOutcomeSchema.safeParse({
+				...outcomeBase,
+				impact: null,
+				rootCause: "The handler change dropped valid checkout submissions.",
+				next: {
 					action: "Roll back the checkout handler.",
 					target: "Checkout handler",
 					type: "act",

--- a/packages/shared/src/insights.ts
+++ b/packages/shared/src/insights.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { goalFunnelFilterFields } from "./analytics-filters";
 
 export const weekOverWeekPeriodSchema = z
 	.object({
@@ -136,9 +137,61 @@ export const insightDefinitionEditChangesSchema = z
 			.max(100)
 			.nullable()
 			.describe("Exact replacement name; null to leave unchanged."),
+		target: z
+			.string()
+			.trim()
+			.min(1)
+			.max(2000)
+			.nullish()
+			.describe(
+				"Exact replacement page path or event name for a goal; omit or null to leave unchanged. Not valid for funnels."
+			),
+		type: z
+			.enum(["PAGE_VIEW", "EVENT", "CUSTOM"])
+			.nullish()
+			.describe(
+				"Replacement goal type; omit or null to leave unchanged. Not valid for funnels."
+			),
+		steps: z
+			.array(
+				z.strictObject({
+					name: z.string().trim().min(1).max(100),
+					target: z.string().trim().min(1).max(2000),
+					type: z.enum(["PAGE_VIEW", "EVENT", "CUSTOM"]),
+					conditions: z.record(z.string(), z.unknown()).optional(),
+				})
+			)
+			.min(2)
+			.max(20)
+			.nullish()
+			.describe(
+				"Complete ordered replacement steps for a funnel, preserving any existing conditions. Not valid for goals."
+			),
+		filters: z
+			.array(
+				z.strictObject({
+					field: z.enum(goalFunnelFilterFields.map((field) => field.value)),
+					operator: z.enum([
+						"equals",
+						"contains",
+						"not_contains",
+						"starts_with",
+						"ends_with",
+						"not_equals",
+						"in",
+						"not_in",
+					]),
+					value: z.union([z.string(), z.array(z.string())]),
+				})
+			)
+			.max(20)
+			.nullish()
+			.describe(
+				"Complete replacement filters; [] clears filters, omit or null leaves them unchanged."
+			),
 	})
 	.strict()
-	.refine((changes) => changes.description !== null || changes.name !== null, {
+	.refine((changes) => Object.values(changes).some((value) => value != null), {
 		message: "Definition edits require at least one changed field",
 	});
 
@@ -699,6 +752,53 @@ export type InsightDefinitionEditChanges = z.infer<
 export type InsightDefinitionOperation = z.infer<
 	typeof insightDefinitionOperationSchema
 >;
+
+export function describeInsightDefinitionAction(
+	label: string,
+	operation: InsightDefinitionOperation
+): string {
+	if (operation.operation === "delete") {
+		return `Delete ${label}.`;
+	}
+	const changes = operation.changes;
+	const edits: string[] = [];
+	if (changes.target != null) {
+		edits.push(`set target to ${JSON.stringify(changes.target)}`);
+	}
+	if (changes.type != null) {
+		edits.push(`set type to ${changes.type}`);
+	}
+	if (changes.steps != null) {
+		edits.push(
+			`replace steps with ${changes.steps.map((step) => `${step.name} (${step.type}: ${step.target})`).join(" → ")}`
+		);
+	}
+	if (changes.filters != null) {
+		edits.push(
+			`set filters to ${changes.filters.length ? changes.filters.map((filter) => `${filter.field} ${filter.operator} ${JSON.stringify(filter.value)}`).join(" AND ") : "none"}`
+		);
+	}
+	if (changes.name != null) {
+		edits.push(`rename to ${JSON.stringify(changes.name)}`);
+	}
+	if (changes.description != null) {
+		edits.push(`set description to ${JSON.stringify(changes.description)}`);
+	}
+	return `For ${label}, ${edits.join("; ")}.`;
+}
+
+export function insightDefinitionEditError(
+	entity: "goal" | "funnel",
+	changes: InsightDefinitionEditChanges
+): string | null {
+	if (entity === "goal" && changes.steps != null) {
+		return "Goal edits cannot replace funnel steps.";
+	}
+	if (entity === "funnel" && (changes.target != null || changes.type != null)) {
+		return "Funnel edits must replace steps, not a goal target or type.";
+	}
+	return null;
+}
 export type InsightWatchThreshold = z.infer<typeof insightWatchThresholdSchema>;
 export type InsightReplySlackDelivery = z.infer<
 	typeof insightReplySlackDeliverySchema

--- a/packages/shared/src/insights.ts
+++ b/packages/shared/src/insights.ts
@@ -128,14 +128,14 @@ export const insightDefinitionEditChangesSchema = z
 			.trim()
 			.min(1)
 			.max(500)
-			.nullable()
+			.nullish()
 			.describe("Exact replacement description; null to leave unchanged."),
 		name: z
 			.string()
 			.trim()
 			.min(1)
 			.max(100)
-			.nullable()
+			.nullish()
 			.describe("Exact replacement name; null to leave unchanged."),
 		target: z
 			.string()

--- a/packages/shared/src/insights.ts
+++ b/packages/shared/src/insights.ts
@@ -165,7 +165,7 @@ export const insightDefinitionEditChangesSchema = z
 			.max(20)
 			.nullish()
 			.describe(
-				"Complete ordered replacement steps for a funnel, preserving any existing conditions. Not valid for goals."
+				"Complete ordered replacement steps for a funnel. Preserve existing conditions at their positions; do not add or change conditions, which analytics does not evaluate. Renaming steps alone does not repair measurement. Not valid for goals."
 			),
 		filters: z
 			.array(


### PR DESCRIPTION
A generated insight could promise to repair a goal target while Apply only changed its name and description. Executable edits now carry goal target/type/filters or complete funnel steps/filters through the existing transaction, and the displayed action is derived from the actual payload. New agent repairs cannot be cosmetic renames.

Apply rejects wrong-entity fields, stale definitions, and no-op patches before queuing verification. Historical metadata edits remain readable and applicable when they actually change the definition. Minimal target-only patches do not require redundant metadata fields. No schema migration is required.

Validation: 17 API integration tests against disposable PostgreSQL/Redis, 230 insight tests, 22 shared-contract tests, root lint, all 33 type/build tasks, and the full pre-push suite (27 tasks) passed.

Scope: executable repair contract, agent validation, and Apply boundary. Based directly on staging; no PR dependency. The separate evidence-quality slice also touches agent.ts and shared insights types in different sections, so review the integration after rebasing. AI-assisted implementation; maintainer contribution.

The final commit d3f9b46f0 also passed all 17 insight router integration tests in CI (run 33971762151, job 101321407873), including the minimal target patch and cosmetic-edit rejection. The local rerun had stalled when Docker stopped responding; CI closes that validation gap. Docker was not restarted.
