### PR TITLE
refactor(insights): simplify repairs and investigation briefs

### DIFF
--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -11,6 +11,7 @@ import { insightRepairError } from "@databuddy/rpc/insight-repairs";
 import {
 	agentInvestigationOutcomeSchema,
 	describeInsightDefinitionAction,
+	insightDefinitionEditChangesSchema,
 	investigationOutcomeSchema,
 	insightMeasurementSchema,
 	insightVerificationDefinitionSchema,
@@ -171,7 +172,7 @@ Evidence
 - A supplied route-continuation comparison measures later different-page views within ten minutes among matched sessions: state it as an association, never causation, bounce, conversion, or revenue. Payment matches are lower bounds for attributed completed payments, never active subscriptions.
 
 Outcome
-- act: only for an inspected mechanism with the smallest concrete target and change, measured business impact or reliability exposure, and a verification condition that proves recovery. Set recheckAt to the earliest defensible time given the measurement window. For a goal/funnel repair with known future dates, include next.check for that definition’s completed users or conversion percent, inclusive UTC dates, representative minimum entrants and an evidence-backed healthy baseline or configured target. More than zero alone is not recovery. Use null if dates or a suitable metric/population are unknown, or the definition is deleted. An existing goal or funnel that is materially unsafe for its established purpose gets an exact edit or delete via next.execution; delete only when inspection shows no independent valid use, and cosmetic renames are not actions. For edits, put the actual goal target/type/filters or complete ordered funnel steps/filters in execution.changes; name and description alone cannot repair what is measured. Preserve existing step conditions. The displayed action is generated from this patch. Match the listed definition by the signal entity id, not its label. Compare the proposed measurement fields against that exact current definition; an already-correct target or renamed step is not a repair. Validation checks the proposal against the latest successful definition read before publication. If that read cannot verify the exact subject, resolve privately with rootCause null; a missing or unreadable definition does not establish a reporting gap or intentional deletion.
+- act: only for an inspected mechanism with the smallest concrete target and change, measured business impact, reliability exposure or a verified measurement blind spot, and a verification condition that proves recovery. Use execution null for a manual repair supported by inspected evidence, even without a connected repository. Set recheckAt to the earliest defensible time given the measurement window. For a goal/funnel repair with known future dates, include next.check for that definition’s completed users or conversion percent, inclusive UTC dates, representative minimum entrants and an evidence-backed healthy baseline or configured target. More than zero alone is not recovery. Use null if dates or a suitable metric/population are unknown, or the definition is deleted. An existing goal or funnel that is materially unsafe for its established purpose gets an exact edit or delete via next.execution; delete only when inspection shows no independent valid use, and cosmetic renames are not actions. For edits, put the actual goal target/type/filters or complete ordered funnel steps/filters in execution.changes; name and description alone cannot repair what is measured. Preserve existing step conditions. The displayed action is generated from this patch. Match the listed definition by the signal entity id, not its label. Compare the proposed measurement fields against that exact current definition; an already-correct target or renamed step is not a repair. Validation checks the proposal against the latest successful definition read before publication. If that read cannot verify the exact subject, resolve privately with rootCause null; a missing or unreadable definition does not establish a reporting gap or intentional deletion.
 - ask: for errors, capabilities.canAskAboutError must be true (qualified matched impact or at least the supplied minimum visitor reach). Below that floor, resolve without a question. Otherwise only after exhausting inspectable context, for one external fact that selects between materially different moves; say what it unlocks. When a material reliability problem needs source access, ask for the owning repository rather than guessing a fix; when a repository is supplied, inspect it before asking about ownership. One repository-access request per website: when other open work already asks for repository access, resolve and state that this signal is blocked on that request; still publish that resolve when the exposure itself is a new, material fact.
 - Otherwise resolve. Use history and other open work to avoid repeating an action or question; reissue only when impact worsens or new evidence changes the target or remedy.
 - Classify every outcome: raw errors and vitals are reliability_exposure; user_experience needs a directly measured downstream consequence (for route vitals, only via supplied qualified matched continuation); product_outcome needs a measured business result; measurement_definition or measurement_coverage needs a named decision made unsafe. The signal's own movement is not a downstream consequence. A measurement_definition finding publishes only alongside its executable definition fix. A measurement_coverage finding can publish without an executable fix when measured coverage identifies a specific decision that is now unsafe; state the blind spot without claiming that customer activity stopped. It can resolve as a useful discovery or ask for one necessary external fact.
@@ -180,12 +181,10 @@ Publishing
 - A raw website traffic change is not a verified product outcome. It may publish only as measurement_coverage with cited collection or implementation evidence. Uncited context, analytics counts, goal/funnel listings, and sibling metrics do not establish visitor loss. A verified sibling product result belongs to its own signal and subject. For a measurement-definition headline, name the mismatch and put period-specific counts in the evidence instead of estimating affected visits.
 - The Insights feed is scarce teammate attention. Decide feed publication separately from opening an investigation. Publish a distinct decision, action, or durable understanding. A verified material product result can be a useful discovery with next.resolve and rootCause null; an unavailable repair is not a reason to hide it. Explain which established outcome changed and the measured scope, not merely a percentage. Keep unchanged, duplicate, routine, low-volume, and unproven-impact work out of the feed.
 - Distinguish an observed collection gap from an inability to explain a metric. Publish measurement_coverage only for a measured missing population or inspected tracking defect that makes a specific decision unsafe. An unavailable connector, absent diagnostic data, or an untested explanation is an investigation limit; resolve privately when that is the only new finding. A successful unrelated read does not turn that limit into a discovery. Still publish an independently verified outage or material product result.
-- When a reported action is complete, remeasure its saved verification window and report whether the condition passed, failed, or remains inconclusive. Use the reported deployment time, not the reply timestamp, to select that window. An improvement that remains unhealthy is not recovery. When verification.read is supplied, use its exact query. Code computes the verdict and writes the summary, so omit that field when the finish schema omits it; keep the rest of the finding consistent. Missing, incomplete or undersampled measurements are inconclusive. A passed condition does not establish that a deployment preceded it or caused the improvement.
+- When a reported action is complete, remeasure its saved verification window and report whether the condition passed, failed, or remains inconclusive. Use the reported deployment time, not the reply timestamp, to select that window. An improvement that remains unhealthy is not recovery. When verification.read is supplied, use its exact query. Classify a measured goal or funnel recovery result as product_outcome; reserve measurement_definition for a newly inspected mismatch that needs a repair. Code computes the verdict and writes the summary, so omit that field when the finish schema omits it; keep the rest of the finding consistent. Missing, incomplete or undersampled measurements are inconclusive. A passed condition does not establish that a deployment preceded it or caused the improvement.
 
 Writing
-- Write a finding, its supporting comparison, and an optional next move. Keep title, summary, rootCause, and evidence under 60 words combined; aim for 40–50. Title names the finding; summary states its consequence in roughly twelve words; rootCause describes the inspected failing operation, not a later operation that never ran; evidence supplies the measured scope and comparison. State each fact once. Never infer failed tasks or lost customers from error exposure or missing telemetry.
-- Use one evidence entry by default, at most two when the second adds a distinct fact or contradiction; each can cite multiple sources. Cite inspected code without repeating the mechanism already stated in rootCause. Preserve the contrast that changes the interpretation, such as steady arrivals alongside fewer completions, and any cohort or attribution qualifications. Prefer before/after counts over restating the same change as both a percentage and an absolute loss.
-- Omit investigation narration and generic decision-safety language. For a definition repair, name the mismatch once and the decision it blocks once. Say what can no longer be measured, rather than declaring a decision "unsafe". Source citations need not repeat the causal explanation already in rootCause.
+- Keep title, summary, rootCause and evidence under 60 words combined; aim for 40–50. Title names the finding; summary adds a distinct consequence; rootCause names only the inspected failing operation; evidence supplies the before/after comparison and measured scope. State each fact once. Cite inspected code alongside the comparison without repeating its mechanism in the evidence text. Use one evidence entry, or two for a distinct comparison or contradiction. Preserve the affected cohort, denominator, period and stable control when they change the interpretation. Describe recorded behavior; eligible website visitors are not goal attempts, and missing telemetry or error exposure cannot prove failed tasks. Prefer the matched cohort and unchanged control over restating the definition. For repairs, say which behavior cannot be measured instead of calling reporting or decisions "unsafe". Omit investigation narration and repeated descriptions of the same change.
 - Never call occurrences, sessions, entrants, or samples "people"; distinguish visitors, identified profiles, and customers with attributed payment history. Translate raw event names into behavior; if behavior is unknown, say "this event." Never expose raw user, session, order, payment, or request identifiers.
 - Report only numbers you were given or measured. Keep whole counts as integers; use at most one decimal place for rates and durations. Use the supplied metricDelta for a change in native units; do not add unrelated counts or turn a tool row count into a customer count.
 
@@ -908,62 +907,59 @@ function validateAgentOutcome(
 		results,
 		attemptedToolNames
 	);
-	if (outcome.next.type === "act") {
-		const recheckAt = outcome.next.recheckAt;
-		if (!recheckAt || new Date(recheckAt).getTime() <= asOf.getTime()) {
-			throw new Error(
-				"Insights agent scheduled a recheck before this investigation"
-			);
-		}
-		const check = outcome.next.check;
-		if (
-			check &&
-			(!["goal", "funnel"].includes(input.signal.entity.type) ||
-				outcome.next.execution?.operation === "delete" ||
-				Date.parse(check.startDate) < asOf.getTime() ||
-				Date.parse(check.endDate) + 86_400_000 > Date.parse(recheckAt) ||
-				(check.metric === "overall_conversion_rate" &&
-					check.threshold.value > 100))
-		) {
-			throw new Error(
-				"Verification checks require a retained goal or funnel, a future full UTC window ending before recheckAt, and a threshold in the metric's native unit."
-			);
-		}
+	if (outcome.next.type !== "act") {
+		return investigationOutcomeSchema.parse(outcome);
 	}
-
-	let next: InvestigationOutcome["next"] = outcome.next;
-	if (outcome.next.type === "act" && outcome.next.execution !== null) {
+	const { execution, ...action } = outcome.next;
+	const recheckAt = outcome.next.recheckAt;
+	if (!recheckAt || new Date(recheckAt).getTime() <= asOf.getTime()) {
+		throw new Error(
+			"Insights agent scheduled a recheck before this investigation"
+		);
+	}
+	const check = outcome.next.check;
+	if (
+		check &&
+		(!["goal", "funnel"].includes(input.signal.entity.type) ||
+			outcome.next.execution?.operation === "delete" ||
+			Date.parse(check.startDate) < asOf.getTime() ||
+			Date.parse(check.endDate) + 86_400_000 > Date.parse(recheckAt) ||
+			(check.metric === "overall_conversion_rate" &&
+				check.threshold.value > 100))
+	) {
+		throw new Error(
+			"Verification checks require a retained goal or funnel, a future full UTC window ending before recheckAt, and a threshold in the metric's native unit."
+		);
+	}
+	if (execution?.operation === "edit") {
+		const current = z.record(z.string(), z.unknown()).parse(definition);
+		execution.changes = insightDefinitionEditChangesSchema.parse(
+			Object.fromEntries(
+				Object.entries(execution.changes).filter(
+					([key, value]) =>
+						value != null && !isDeepStrictEqual(value, current[key])
+				)
+			)
+		);
+	}
+	let next: InvestigationOutcome["next"] = action;
+	if (execution) {
 		next = {
-			...outcome.next,
+			...action,
+			execution,
 			action: describeInsightDefinitionAction(input.signal.entity.label, {
-				...outcome.next.execution,
-				action: outcome.next.action,
+				...execution,
+				action: action.action,
 			}),
 		};
 	}
-	if (outcome.next.type === "act" && outcome.next.execution === null) {
-		const { execution: _execution, ...persistedNext } = outcome.next;
-		next = persistedNext;
-	}
-	if (next.type === "act" && next.check) {
-		const current = insightVerificationDefinitionSchema.parse(definition);
-		const changes =
-			next.execution?.operation === "edit"
-				? Object.fromEntries(
-						Object.entries(next.execution.changes).filter(
-							([, value]) => value != null
-						)
-					)
-				: {};
-		next = {
-			...next,
-			check: {
-				...next.check,
-				definition: insightVerificationDefinitionSchema.parse({
-					...current,
-					...changes,
-				}),
-			},
+	if (next.check) {
+		next.check = {
+			...next.check,
+			definition: insightVerificationDefinitionSchema.parse({
+				...insightVerificationDefinitionSchema.parse(definition),
+				...(execution?.operation === "edit" ? execution.changes : {}),
+			}),
 		};
 	}
 	return investigationOutcomeSchema.parse({ ...outcome, next });

--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -937,7 +937,9 @@ function validateAgentOutcome(
 			Object.fromEntries(
 				Object.entries(execution.changes).filter(
 					([key, value]) =>
-						value != null && !isDeepStrictEqual(value, current[key])
+						value != null &&
+						key in current &&
+						!isDeepStrictEqual(value, current[key])
 				)
 			)
 		);

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -122,6 +122,7 @@ const agentOutcome = {
 const inspectedFunnel = {
 	id: "checkout",
 	name: "Checkout journey",
+	description: null,
 	filters: [],
 	steps: [
 		{ name: "Landing", target: "/", type: "PAGE_VIEW" as const },
@@ -709,8 +710,13 @@ describe("intelligence agent", () => {
 			return;
 		}
 		const result = await run;
+		const expectedExecution = {
+			...proposal.next.execution,
+			changes: native ? { steps: proposal.next.execution.changes.steps } : proposal.next.execution.changes,
+		};
 		expect(result.outcome.next).toEqual({
 			...proposal.next,
+			execution: expectedExecution,
 			...(scenario !== "legacy"
 				? {
 						check: {
@@ -725,7 +731,7 @@ describe("intelligence agent", () => {
 					}
 				: {}),
 			action: describeInsightDefinitionAction(funnelSignal.entity.label, {
-				...proposal.next.execution,
+				...expectedExecution,
 				action: executableDefinitionOutcome.next.action,
 			}),
 		});

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -731,6 +731,83 @@ describe("intelligence agent", () => {
 		});
 	});
 
+	it.each([
+		false,
+		true,
+	])("strips unchanged repair fields while retaining a real filter removal: %s", async (filtered) => {
+		const changes = {
+			name: inspectedFunnel.name,
+			description: null,
+			filters: [],
+			steps: executableDefinitionOutcome.next.execution.changes.steps,
+		};
+		const result = await runInsightAgent(
+			{
+				appContext: appContext(),
+				evidence: [
+					...evidence,
+					"Business meaning: Tracks account creation across all countries.",
+				],
+				signal: funnelSignal,
+				githubRepository: null,
+				history: [],
+				otherOpenWork: [],
+			},
+			{
+				model: new MockLanguageModelV3({
+					doGenerate: mockValues(
+						toolCallsResponse(["list_funnels", "scrape_page"]),
+						outputResponse({
+							...executableDefinitionOutcome,
+							next: {
+								...executableDefinitionOutcome.next,
+								execution: { operation: "edit", changes },
+							},
+						})
+					),
+				}),
+				tools: {
+					scrape_page: tool({
+						inputSchema: z.object({}),
+						execute: () => ({
+							content:
+								"Successful account creation emits account_created for visitors in all countries.",
+						}),
+					}),
+					list_funnels: tool({
+						inputSchema: z.object({}),
+						execute: () => ({
+							funnels: [
+								{
+									...inspectedFunnel,
+									filters: filtered
+										? [{ field: "country", operator: "equals", value: "US" }]
+										: [],
+								},
+							],
+						}),
+					}),
+				},
+			}
+		);
+		const execution = {
+			operation: "edit" as const,
+			changes: {
+				steps: changes.steps,
+				...(filtered ? { filters: [] } : {}),
+			},
+		};
+		expect(result.outcome.next).toMatchObject({
+			execution,
+			action: describeInsightDefinitionAction(funnelSignal.entity.label, {
+				...execution,
+				action: executableDefinitionOutcome.next.action,
+			}),
+		});
+		if (result.outcome.next.type !== "act") throw new Error("Expected repair");
+		expect(result.outcome.next.execution).toEqual(execution);
+	});
+
 	it("rejects a cosmetic rename presented as a measurement repair", async () => {
 		const cosmetic = {
 			...executableDefinitionOutcome,

--- a/packages/rpc/src/routers/insight-repairs.ts
+++ b/packages/rpc/src/routers/insight-repairs.ts
@@ -61,27 +61,18 @@ export function insightRepairError(
 	}
 	const funnel = parsed.data;
 	const steps = changes.steps ?? funnel.steps;
-	const beforeConditions = funnel.steps.map((step) => step.conditions ?? {});
-	const afterConditions = steps.map((step) => step.conditions ?? {});
-	const sharedLength = Math.min(
-		beforeConditions.length,
-		afterConditions.length
-	);
-	const hasConditions = (conditions: Record<string, unknown>) =>
-		Object.keys(conditions).length > 0;
-	// Conditions must be untouched wherever a step already existed. Steps added
-	// or removed beyond that are only allowed when they carry no conditions, so
-	// a condition-free step can be appended or dropped without tripping this.
-	if (
-		!isDeepStrictEqual(
-			beforeConditions.slice(0, sharedLength),
-			afterConditions.slice(0, sharedLength)
-		) ||
-		afterConditions.slice(sharedLength).some(hasConditions) ||
-		beforeConditions.slice(sharedLength).some(hasConditions)
+	for (
+		let index = 0;
+		index < Math.max(funnel.steps.length, steps.length);
+		index++
 	) {
-		return "Automatic funnel repairs must preserve existing step conditions and cannot add conditions that analytics does not evaluate.";
+		const before = funnel.steps[index]?.conditions ?? {};
+		const after = steps[index]?.conditions ?? {};
+		if (!isDeepStrictEqual(before, after)) {
+			return "Automatic funnel repairs must preserve existing step conditions and cannot add conditions that analytics does not evaluate.";
+		}
 	}
+
 	if (
 		isDeepStrictEqual(
 			toAnalyticsSteps(steps).map(({ name: _name, ...step }) => step),


### PR DESCRIPTION
Investigation repairs included unchanged fields, repeated their mechanism across the brief, withheld manual repairs without a repository connection, and spent a correction turn classifying successful verification as a new definition problem. Strip null, uninspected and unchanged edit fields before generating the displayed action and saved verification, flatten action normalization, and replace repeated funnel-condition transforms with one comparison loop. Consolidate writing guidance and clarify manual repairs and recovery classification.

Scope: investigation action normalization, prompt guidance and the shared funnel-condition guard. No schema or tool additions. No dependencies or known open-PR overlaps. Runtime is 11 lines smaller; focused regression tests verify unchanged-field removal while preserving a real filter removal. Existing no-op, changed-condition, native-measurement, manual action and verification tests pass.

Validation: root lint, typecheck and tests pass (339 insights tests). Audited 86 fresh synthetic real-model runs / 176 observable steps, preserving the first candidate and 24 separate network-failed attempts. Matched 24-run baseline→final: turns 51→48, input tokens 307,771→284,885, output tokens 15,896→15,433, summed duration 236.8→227.2s, mean brief words 54.1→52.2. Latency is directional; the final comparison overlapped a separate regression group. Nine repairs retain 9 changed fields instead of 25 supplied fields; their displayed actions total 111 words instead of 147.

Concrete outcomes: all three bootstrap recommendations restored; recovery classification retries 3→0; all three source comparisons retain Google 600 entrants / 100→20 completions and stable Direct 400 / 80. Fourteen additional fresh boundary evals kept missing definitions and partial/undersampled windows inconclusive, retained failed recovery, and preserved true filter removal. No customer data or delivery tools used.

Limits: five of 24 final briefs still exceed 60 words; mechanism repetition remains, and one source-citation shape error needed a retry. The first compact prompt introduced generic safety wording and omitted the control cohort once; the final revision corrected those observed regressions. This does not claim full product price-fit or a dramatic latency improvement.

Review dispositions: temporary request-filter loss is not reachable through the investigation tool. `goalAnalyticsInputSchema` accepts dates, goalId and websiteId; execute explicitly forwards only those fields to `goals.getAnalytics`. The RPC supports extra filters for other clients, but the agent cannot pass them or receive another client's response. Native verification and filter-removal cases cover the actual path. The `z.record(z.string(), z.unknown())` is runtime validation of an unknown tool-output boundary after exact-subject validation, not a cast. Applying the edit-input schema to stored definitions would impose edit-only metadata limits and could discard fields needed for equality checks. This boundary validation follows the existing tool-output pattern.

Completed review: native snapshots intentionally omit name/description; the latest normalization keeps only inspected keys and tests preserve only the verified steps in native-only/native-after-list cases. The follow-up claim that these tests should retain metadata is not reproducible: validateDefinitionOutcome parses insightMeasurementSchema, whose nested definition schema strips name/description before returning current. All nine definition-repair scenarios pass on deb404fc9, including both cited native cases; CI lint, types, tests and completed AI review checks pass.
