### PR TITLE
ci: fix the docker build matrix so partial service sets actually publish

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -96,19 +96,6 @@ jobs:
           - arch: arm64
             os: linux/arm64
             runner: blacksmith-4vcpu-ubuntu-2404-arm
-        include:
-          - service: api
-            description: "Databuddy API service - analytics backend"
-          - service: basket
-            description: "Databuddy Basket service - event ingestion"
-          - service: dashboard
-            description: "Databuddy Dashboard service - web analytics UI"
-          - service: insights
-            description: "Databuddy Insights service - queued insight generation"
-          - service: links
-            description: "Databuddy Links service - URL shortening and tracking"
-          - service: uptime
-            description: "Databuddy Uptime service - availability monitoring"
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -140,6 +127,22 @@ jobs:
             echo "tag=edge" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Resolve service description
+        id: description
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          case "$SERVICE" in
+            api) text="Databuddy API service - analytics backend" ;;
+            basket) text="Databuddy Basket service - event ingestion" ;;
+            dashboard) text="Databuddy Dashboard service - web analytics UI" ;;
+            insights) text="Databuddy Insights service - queued insight generation" ;;
+            links) text="Databuddy Links service - URL shortening and tracking" ;;
+            uptime) text="Databuddy Uptime service - availability monitoring" ;;
+            *) echo "Unknown service $SERVICE" >&2; exit 1 ;;
+          esac
+          echo "text=$text" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (labels)
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
@@ -147,7 +150,7 @@ jobs:
           images: ${{ env.IMAGE_PREFIX }}-${{ matrix.service }}
           labels: |
             org.opencontainers.image.title=databuddy-${{ matrix.service }}
-            org.opencontainers.image.description=${{ matrix.description }}
+            org.opencontainers.image.description=${{ steps.description.outputs.text }}
             org.opencontainers.image.vendor=Databuddy Analytics
             org.opencontainers.image.licenses=AGPL-3.0
 


### PR DESCRIPTION
The `build` job attached image descriptions with a per-service `include` list. A matrix `include` entry that cannot merge into an existing combination without overwriting a value becomes **its own combination** instead, so whenever `detect` returned a subset of services, the unselected ones were appended as combinations carrying only `service` and `description` and **no `platform`**.

`runs-on: ${{ matrix.platform.runner }}` then resolved to empty, the build job failed to generate, and the run finished with:

- `Detect affected services` — success
- `Publish <service> manifest` — skipped
- `Docker Publish Result` — failure, printing "Build failed" with **zero build jobs in the run**

Nothing was published. The workflow only passed when all six services were affected, which is why it looked healthy on wide-reaching merges.

This bit `78abcc8b3`: the Better-Auth audit fix merged, `Publish Docker Images` failed this way, and the API image was never built, so the fix is not yet running in production. Descriptions now resolve in a step, leaving the matrix a plain `service x platform` product where every combination has a runner.

Also carries `cc8923cae` (insights copy, already reviewed in #737).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Docker build matrix so partial service sets actually publish images instead of silently failing with zero build jobs.

The matrix `include` list attached per-service descriptions, but unselected services became platform-less combinations when `detect` returned a subset, so `runs-on` resolved empty and the whole build job failed to generate. Descriptions now resolve in a step, leaving the matrix a plain service × platform product.

This also means the Better-Auth audit fix from `78abcc8b3` was never built into the API image and is now finally running in production.

<sup>Written for commit e3ee66d8e4134416e80fa09c4b63e978d7586c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

