### PR TITLE
feat(insights): discover hidden commercial and conversion changes

### DIFF
--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -224,6 +224,7 @@ export interface InsightAgentInput {
 				kind: "reply";
 		  }
 	)[];
+	investigationObjective?: string;
 	otherOpenWork: {
 		asOf: string;
 		next: InterruptingNext;
@@ -282,6 +283,7 @@ Subject
 - The signal is a detection snapshot. Reuse its counts when the measured definition, population and dates still match. If current configuration or a successful read conflicts, reconcile with an exact native measurement; a definition listing alone cannot validate old counts. Compare the same definition, filters and metric over the intended complete windows. A clipped window is partial: never call it unchanged or recovered against a full window. Prefer current measured evidence over a stale signal; if the conflict is the only finding, resolve privately with rootCause null. Retain narrower measured cohort comparisons and useful findings even when their cause is unknown.
 
 Evidence
+- The optional investigationObjective is a machine-selected question, not a human request or citable measurement. Use it to choose useful diagnostic work; verify its premise with source data.
 - Cite each evidence sentence to its actual source: source signal for the supplied signal; source provided with a valid zero-based evidence index; source history with the index of a prior action for its saved verification condition only (not historical or current measurements); source customer_impact for supplied customerImpact; source related_signal with its array index; or source tool with its exact name, toolCallId, and get_data resultKey (null for other tools). Use an array of source references per evidence entry, including every contributing period, population, and inspected mechanism. One concise comparison can cite several sources without repeating its facts. An exact verification read also supports the saved condition and code verdict returned with it. Correct a mismatched citation without discarding a supported discovery. Never cite a failed read as evidence. An empty evidence array does not invalidate the supplied signal.
 - Tool availability is not proof of a connected integration. If a connector reports missing access, stop trying that connector. Preserve an independently verified product or reliability finding, with an unknown cause when necessary. Missing diagnostic access is not evidence that tracking failed, and does not itself deserve a coverage notice or a connection request.
 - get_data can return a partial table. returnedRows is what you saw; rowCount is query rows, not visitors or all matching entities. A path missing from a top-N table is not absent. Use an exact filtered lookup or a dedicated aggregate before making absence, total, or exhaustive claims. Omit orderBy unless discovery documents the field and use only declared row filters.
@@ -848,6 +850,20 @@ function verificationFor(
 		return;
 	}
 	const check = prior.outcome.next.check;
+	// A source case cannot recover on whole-funnel counts, including legacy checks.
+	if (
+		input.signal.signalKey.startsWith(
+			`funnel:${input.signal.entity.id}:referrer:`
+		)
+	) {
+		return {
+			check,
+			status: "inconclusive",
+			measured: null,
+			entrants: null,
+			source: null,
+		};
+	}
 	const result = [...results].reverse().find(
 		(item) =>
 			item.toolName === `get_${input.signal.entity.type}_analytics` &&
@@ -995,9 +1011,22 @@ function validateAgentOutcome(
 	}
 	if (
 		outcome.publish &&
+		signalKey.startsWith("attribution_rate:") &&
+		!hasNativeRevenueEvidence
+	) {
+		throw new Error(
+			"Attribution findings require native attributed_revenue and total_revenue evidence for this exact currency and complete comparison windows. A provided detector snapshot cannot confirm coverage."
+		);
+	}
+	if (
+		outcome.publish &&
 		!isError &&
 		!isVital &&
-		(!hasNativeRevenueEvidence || outcome.findingKind !== "product_outcome") &&
+		(!hasNativeRevenueEvidence ||
+			outcome.findingKind !==
+				(signalKey.startsWith("attribution_rate:")
+					? "measurement_coverage"
+					: "product_outcome")) &&
 		input.signal.entity.type === "website"
 	) {
 		const citedContext = outcome.evidenceRefs
@@ -1049,6 +1078,14 @@ function validateAgentOutcome(
 		);
 	}
 	const check = outcome.next.check;
+	if (
+		check &&
+		signalKey.startsWith(`funnel:${input.signal.entity.id}:referrer:`)
+	) {
+		throw new Error(
+			"Verification checks require the exact affected population. Aggregate funnel counts cannot verify a referrer case; omit check until referrer-specific verification is available."
+		);
+	}
 	if (
 		check &&
 		(!["goal", "funnel"].includes(input.signal.entity.type) ||
@@ -1231,6 +1268,7 @@ export async function runInsightAgent(
 			name: input.appContext.websiteName ?? null,
 		},
 		repository: input.githubRepository,
+		investigationObjective: input.investigationObjective,
 		evidence: input.evidence,
 		history: input.history.map((item) =>
 			item.kind === "investigation"
@@ -1366,8 +1404,16 @@ export async function runInsightAgent(
 						candidate.evidence.some(
 							(item) =>
 								typeof item !== "string" &&
-								item.fields.includes("total_revenue") &&
-								input.signal.signalKey === `revenue:${item.currency}`
+								((item.fields.includes("total_revenue") &&
+									input.signal.signalKey === `revenue:${item.currency}`) ||
+									(item.fields.includes("refund_amount") &&
+										item.fields.includes("refund_count") &&
+										input.signal.signalKey ===
+											`refund_amount:${item.currency}`) ||
+									(item.fields.includes("attributed_revenue") &&
+										item.fields.includes("total_revenue") &&
+										input.signal.signalKey ===
+											`attribution_rate:${item.currency}`))
 						)
 					);
 					const serialize = (value: unknown) =>

--- a/apps/insights/src/coverage-planner.ts
+++ b/apps/insights/src/coverage-planner.ts
@@ -81,6 +81,9 @@ export function coveragePortfolioLimit(
 }
 
 function signalGroup(signal: DetectedSignal): string {
+	if (signal.subjectKey?.includes(":referrer:")) {
+		return signal.subjectKey;
+	}
 	if (signal.subjectKey?.startsWith("route:") && signal.entityId) {
 		return `route-health:${signal.entityId}`;
 	}

--- a/apps/insights/src/detection.test.ts
+++ b/apps/insights/src/detection.test.ts
@@ -2096,13 +2096,13 @@ describe("independent commercial discovery", () => {
 		currency: "USD",
 		total_revenue: 40_000,
 		total_transactions: 400,
-		refund_amount: 500,
+		refund_amount: -500,
 		refund_count: 5,
 		attributed_revenue: 38_000,
 	};
 	const changed = {
 		...previous,
-		refund_amount: 2500,
+		refund_amount: -2500,
 		refund_count: 25,
 		attributed_revenue: 20_000,
 	};
@@ -2113,6 +2113,46 @@ describe("independent commercial discovery", () => {
 			changed,
 			previous,
 			keys,
+		],
+		[
+			"material refund amounts are independent of unchanged refund counts",
+			{
+				...changed,
+				refund_count: 5,
+				attributed_revenue: previous.attributed_revenue,
+			},
+			previous,
+			["refund_amount:USD"],
+		],
+		[
+			"positive refund magnitudes retain compatibility",
+			{ ...changed, refund_amount: 2500 },
+			{ ...previous, refund_amount: 500 },
+			keys,
+		],
+		[
+			"invalid optional refunds do not suppress valid attribution",
+			{ ...changed, refund_amount: Number.POSITIVE_INFINITY },
+			previous,
+			["attribution_rate:USD"],
+		],
+		[
+			"invalid optional attribution does not suppress valid refunds",
+			{ ...changed, attributed_revenue: "not measured" },
+			previous,
+			["refund_amount:USD"],
+		],
+		[
+			"negative counts cannot create a refund finding",
+			{ ...changed, refund_count: -25 },
+			previous,
+			["attribution_rate:USD"],
+		],
+		[
+			"invalid gross suppresses ratios and relative materiality",
+			{ ...changed, total_revenue: Number.NaN },
+			previous,
+			[],
 		],
 		["unchanged commercial activity stays quiet", previous, previous, []],
 		[
@@ -2146,7 +2186,7 @@ describe("independent commercial discovery", () => {
 		],
 		[
 			"small refund movement stays quiet",
-			{ ...previous, refund_amount: 520 },
+			{ ...previous, refund_amount: -520 },
 			previous,
 			[],
 		],
@@ -2213,4 +2253,50 @@ describe("independent commercial discovery", () => {
 			)
 		).toBe(true);
 	});
+	for (const [
+		name,
+		current,
+		before,
+		currentMagnitude,
+		previousMagnitude,
+		sentiment,
+	] of [
+		["worsening", changed, previous, 2500, 500, "negative"],
+		["improving", previous, changed, 500, 2500, "positive"],
+		["unchanged recheck", previous, previous, 500, 500, "neutral"],
+	] as const) {
+		it(`signed refund ${name} preserves amount, identity and sentiment on recheck`, async () => {
+			const params = { ...BASE_PARAMS, lookbackDays: 7 };
+			const detected = await detectSignals(
+				params,
+				createMockQueryFn(
+					[],
+					{},
+					{},
+					{ revenue_overview: [changed, previous] }
+				),
+				dayjs("2026-09-07")
+			);
+			const refund = detected.find(
+				(signal) => signal.subjectKey === "refund_amount:USD"
+			);
+			if (!refund) throw new Error("Missing signed refund candidate");
+			const prior = prepareInvestigation(refund, 7).signal;
+			expect(prior.sentiment).toBe("negative");
+			expect(prior.metric.current).toBe(2500);
+			const measured = await remeasureMetricSignal(
+				params,
+				prior,
+				createMockQueryFn([], {}, {}, { revenue_overview: [current, before] }),
+				dayjs("2026-09-08")
+			);
+			if (!measured) throw new Error("Missing exact refund remeasurement");
+			expect(measured.subjectKey).toBe("refund_amount:USD");
+			expect(measured.current).toBe(currentMagnitude);
+			expect(measured.baseline).toBe(previousMagnitude);
+			expect(prepareInvestigation(measured, 7).signal.sentiment).toBe(
+				sentiment
+			);
+		});
+	}
 });

--- a/apps/insights/src/detection.test.ts
+++ b/apps/insights/src/detection.test.ts
@@ -2090,3 +2090,127 @@ describe("detectSignals", () => {
 		});
 	});
 });
+
+describe("independent commercial discovery", () => {
+	const previous = {
+		currency: "USD",
+		total_revenue: 40_000,
+		total_transactions: 400,
+		refund_amount: 500,
+		refund_count: 5,
+		attributed_revenue: 38_000,
+	};
+	const changed = {
+		...previous,
+		refund_amount: 2500,
+		refund_count: 25,
+		attributed_revenue: 20_000,
+	};
+	const keys = ["attribution_rate:USD", "refund_amount:USD"];
+	for (const [name, current, before, expected] of [
+		[
+			"flat gross does not hide refunds or attribution",
+			changed,
+			previous,
+			keys,
+		],
+		["unchanged commercial activity stays quiet", previous, previous, []],
+		[
+			"sparse settlements do not establish a commercial alert",
+			{ ...changed, total_transactions: 3 },
+			{ ...previous, total_transactions: 3 },
+			[],
+		],
+		[
+			"missing refund counts preserve the independent attribution alert",
+			{ ...changed, refund_count: null },
+			previous,
+			["attribution_rate:USD"],
+		],
+		[
+			"missing attribution preserves the independent refund alert",
+			{ ...changed, attributed_revenue: null },
+			previous,
+			["refund_amount:USD"],
+		],
+		[
+			"absent measurements are not zero",
+			{
+				...changed,
+				refund_amount: null,
+				refund_count: null,
+				attributed_revenue: null,
+			},
+			previous,
+			[],
+		],
+		[
+			"small refund movement stays quiet",
+			{ ...previous, refund_amount: 520 },
+			previous,
+			[],
+		],
+		[
+			"invalid attribution cannot become a coverage alert",
+			{ ...changed, attributed_revenue: 50_000 },
+			previous,
+			["refund_amount:USD"],
+		],
+	] as const) {
+		it(name, async () => {
+			const signals = await detectSignals(
+				{ ...BASE_PARAMS, lookbackDays: 7 },
+				createMockQueryFn(
+					[],
+					{ sessions: 0 },
+					{ sessions: 0 },
+					{ revenue_overview: [current, before] }
+				),
+				dayjs("2026-09-07")
+			);
+			expect(signals.map((signal) => signal.subjectKey).sort()).toEqual(
+				expected
+			);
+		});
+	}
+	it("matches currency rows and native numeric strings without inventing website traffic", async () => {
+		const strings = (row: Record<string, unknown>) =>
+			Object.fromEntries(
+				Object.entries(row).map(([key, value]) => [
+					key,
+					typeof value === "number" ? String(value) : value,
+				])
+			);
+		const euro = {
+			...previous,
+			currency: "EUR",
+			total_revenue: 100_000,
+			attributed_revenue: 90_000,
+		};
+		const signals = await detectSignals(
+			{ ...BASE_PARAMS, lookbackDays: 7 },
+			createMockQueryFn(
+				[],
+				{ sessions: 0 },
+				{ sessions: 0 },
+				{
+					revenue_overview: [
+						[euro, strings(changed)],
+						[strings(previous), euro],
+					],
+				}
+			),
+			dayjs("2026-09-07")
+		);
+		expect(signals.map((signal) => signal.subjectKey).sort()).toEqual(keys);
+		const prepared = signals.map((signal) => prepareInvestigation(signal, 7));
+		expect(prepared.every((item) => item.investigationObjective)).toBe(true);
+		expect(
+			prepared.every((item) =>
+				item.evidence.every(
+					(value) => !value.includes("Machine-selected investigation objective")
+				)
+			)
+		).toBe(true);
+	});
+});

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -282,13 +282,18 @@ function makeRevenueSignal(
 	current: Record<string, unknown>,
 	previous: Record<string, unknown>,
 	detectedAt: string
-): DetectedSignal {
+): DetectedSignal | null {
+	const c = commercialNumberSchema.safeParse(current.total_revenue);
+	const p = commercialNumberSchema.safeParse(previous.total_revenue);
+	if (!(c.success && p.success) || c.data < 0 || p.data < 0) {
+		return null;
+	}
 	return {
 		...makeWowSignal(
 			"revenue",
 			`${currency} gross revenue`,
-			numberField(current, "total_revenue"),
-			numberField(previous, "total_revenue"),
+			c.data,
+			p.data,
 			detectedAt
 		),
 		subjectKey: `revenue:${currency}`,
@@ -300,13 +305,25 @@ function makeRevenueSignal(
 
 const commercialNumberSchema = z
 	.union([z.number(), z.string().trim().min(1)])
-	.pipe(z.coerce.number<string | number>().finite().nonnegative());
+	.pipe(z.coerce.number<string | number>().finite());
 const commercialOverviewSchema = z.object({
-	total_revenue: commercialNumberSchema,
-	total_transactions: commercialNumberSchema.pipe(z.number().int()),
-	refund_amount: commercialNumberSchema.nullish(),
-	refund_count: commercialNumberSchema.pipe(z.number().int()).nullish(),
-	attributed_revenue: commercialNumberSchema.nullish(),
+	total_revenue: commercialNumberSchema.pipe(z.number().nonnegative()),
+	total_transactions: commercialNumberSchema.pipe(
+		z.number().int().nonnegative()
+	),
+	// The native ledger sums refunds as negative amounts; discovery compares money returned.
+	refund_amount: commercialNumberSchema
+		.transform(Math.abs)
+		.nullish()
+		.catch(null),
+	refund_count: commercialNumberSchema
+		.pipe(z.number().int().nonnegative())
+		.nullish()
+		.catch(null),
+	attributed_revenue: commercialNumberSchema
+		.pipe(z.number().nonnegative())
+		.nullish()
+		.catch(null),
 });
 
 function commercialSignals(
@@ -336,7 +353,6 @@ function commercialSignals(
 			!applyThreshold ||
 			(sampled &&
 				Math.max(c.refund_count, p.refund_count) >= 5 &&
-				Math.abs(c.refund_count - p.refund_count) >= 5 &&
 				delta >= Math.max(c.total_revenue, p.total_revenue) * 0.02 &&
 				Math.abs(safeDeltaPercent(c.refund_amount, p.refund_amount)) >= 30)
 		) {
@@ -1470,6 +1486,7 @@ async function detectWow(
 			numberField(previous, "total_transactions")
 		);
 		if (
+			signal &&
 			(signal.current > 0 || signal.baseline > 0) &&
 			(Math.abs(signal.current - signal.baseline) >=
 				REVENUE_MIN_ABSOLUTE_CHANGE ||

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -7,6 +7,7 @@ import type {
 import dayjs from "dayjs";
 import timezonePlugin from "dayjs/plugin/timezone";
 import utcPlugin from "dayjs/plugin/utc";
+import { z } from "zod";
 import {
 	hasMaterialRouteContinuation,
 	matchedErrorContinuationMeasurement,
@@ -28,6 +29,7 @@ export interface DetectedSignal {
 	direction: "up" | "down";
 	entityId?: string;
 	entityLabel?: string;
+	investigationObjective?: string;
 	label: string;
 	method: "behavior" | "zscore" | "wow";
 	metric: string;
@@ -227,6 +229,8 @@ const METRIC_FILTERS: Record<string, SignalFilter> = {
 	inp: () => true,
 	lcp: () => true,
 	revenue: () => true,
+	refund_amount: () => true,
+	attribution_rate: () => true,
 	session_duration: (s) =>
 		Math.abs(s.current - s.baseline) >= FILTER_SESSION_DURATION_MIN_DELTA &&
 		Math.max(s.current, s.baseline) >= FILTER_SESSION_DURATION_MIN_PEAK,
@@ -288,8 +292,100 @@ function makeRevenueSignal(
 			detectedAt
 		),
 		subjectKey: `revenue:${currency}`,
+		investigationObjective:
+			"Find which measured products account for the gross revenue change and what decision that concentration changes. Inspect an available revenue_by_product breakdown; separate missing product coverage from an unchanged product. Do not infer profit, acquisition ROI or subscription churn.",
 		definitionEvidence: `Business meaning: gross settled revenue in ${currency}, excluding refunds. The snapshot alone is not publication evidence: confirm with revenue_overview for this currency across both complete signal windows.`,
 	};
+}
+
+const commercialNumberSchema = z
+	.union([z.number(), z.string().trim().min(1)])
+	.pipe(z.coerce.number<string | number>().finite().nonnegative());
+const commercialOverviewSchema = z.object({
+	total_revenue: commercialNumberSchema,
+	total_transactions: commercialNumberSchema.pipe(z.number().int()),
+	refund_amount: commercialNumberSchema.nullish(),
+	refund_count: commercialNumberSchema.pipe(z.number().int()).nullish(),
+	attributed_revenue: commercialNumberSchema.nullish(),
+});
+
+function commercialSignals(
+	currency: string,
+	current: Record<string, unknown>,
+	previous: Record<string, unknown>,
+	detectedAt: string,
+	applyThreshold = true
+): DetectedSignal[] {
+	const cur = commercialOverviewSchema.safeParse(current);
+	const prev = commercialOverviewSchema.safeParse(previous);
+	if (!(cur.success && prev.success)) {
+		return [];
+	}
+	const c = cur.data;
+	const p = prev.data;
+	const signals: DetectedSignal[] = [];
+	const sampled = Math.min(c.total_transactions, p.total_transactions) >= 20;
+	if (
+		c.refund_amount != null &&
+		p.refund_amount != null &&
+		c.refund_count != null &&
+		p.refund_count != null
+	) {
+		const delta = Math.abs(c.refund_amount - p.refund_amount);
+		if (
+			!applyThreshold ||
+			(sampled &&
+				Math.max(c.refund_count, p.refund_count) >= 5 &&
+				Math.abs(c.refund_count - p.refund_count) >= 5 &&
+				delta >= Math.max(c.total_revenue, p.total_revenue) * 0.02 &&
+				Math.abs(safeDeltaPercent(c.refund_amount, p.refund_amount)) >= 30)
+		) {
+			signals.push({
+				...makeWowSignal(
+					"refund_amount",
+					`${currency} refunds`,
+					c.refund_amount,
+					p.refund_amount,
+					detectedAt
+				),
+				subjectKey: `refund_amount:${currency}`,
+				investigationObjective:
+					"Investigate the independent refund change and its operational consequence even if gross settled revenue is unchanged. Reconcile amounts and refund counts in this exact currency; do not let stable gross suppress refund review.",
+				definitionEvidence: `${currency} refunds: ${p.refund_amount} across ${p.refund_count} refunds → ${c.refund_amount} across ${c.refund_count}. Gross settled revenue: ${p.total_revenue} → ${c.total_revenue}; refunds are independent of gross, not subtracted from it. Refunds can refer to earlier purchases, so this is not a purchase-cohort refund rate. Confirm both complete windows with revenue_overview.`,
+			});
+		}
+	}
+	if (
+		c.attributed_revenue != null &&
+		p.attributed_revenue != null &&
+		c.total_revenue > 0 &&
+		p.total_revenue > 0 &&
+		c.attributed_revenue <= c.total_revenue &&
+		p.attributed_revenue <= p.total_revenue
+	) {
+		const currentRate = (100 * c.attributed_revenue) / c.total_revenue;
+		const previousRate = (100 * p.attributed_revenue) / p.total_revenue;
+		if (
+			!applyThreshold ||
+			(sampled && Math.abs(currentRate - previousRate) >= 15)
+		) {
+			signals.push({
+				...makeWowSignal(
+					"attribution_rate",
+					`${currency} revenue attribution coverage`,
+					currentRate,
+					previousRate,
+					detectedAt,
+					{ round: true }
+				),
+				subjectKey: `attribution_rate:${currency}`,
+				investigationObjective:
+					"Investigate the independent attribution coverage change and which acquisition comparison is now unsafe or newly supported. Retain this decision separately from refunds or gross movement. Unattributed revenue is not lost sales.",
+				definitionEvidence: `${currency} attributed settled revenue: ${p.attributed_revenue} of ${p.total_revenue} gross → ${c.attributed_revenue} of ${c.total_revenue} gross. Coverage is ${previousRate}% → ${currentRate}%. This changes which acquisition decisions the observed attribution supports; unattributed revenue is not lost sales. Confirm both complete windows with revenue_overview; attribution does not establish acquisition causality.`,
+			});
+		}
+	}
+	return signals;
 }
 
 function passesImpactFilter(signal: DetectedSignal): boolean {
@@ -309,6 +405,12 @@ function passesLowTrafficFloor(
 ): boolean {
 	if (weeklySessions >= LOW_TRAFFIC_WEEKLY_SESSIONS) {
 		return true;
+	}
+	if (
+		signal.metric === "refund_amount" ||
+		signal.metric === "attribution_rate"
+	) {
+		return true; // Commercial cohorts have their own transaction floor.
 	}
 	if (RATE_METRICS.has(signal.metric)) {
 		return false;
@@ -740,8 +842,12 @@ export async function remeasureMetricSignal(
 		);
 	}
 
-	if (prior.signalKey.startsWith("revenue:")) {
-		const currency = prior.signalKey.slice("revenue:".length);
+	if (
+		["revenue", "refund_amount", "attribution_rate"].some((metric) =>
+			prior.signalKey.startsWith(`${metric}:`)
+		)
+	) {
+		const [metric, currency] = prior.signalKey.split(":");
 		if (normalizeCurrencyCode(currency) !== currency) {
 			return null;
 		}
@@ -758,7 +864,15 @@ export async function remeasureMetricSignal(
 		);
 		// An absent currency is not a measured zero; unscoped legacy signals are inconclusive.
 		return current && previous
-			? makeRevenueSignal(currency, current, previous, currentTo)
+			? metric === "revenue"
+				? makeRevenueSignal(currency, current, previous, currentTo)
+				: (commercialSignals(
+						currency,
+						current,
+						previous,
+						currentTo,
+						false
+					).find((signal) => signal.metric === metric) ?? null)
 			: null;
 	}
 
@@ -1349,6 +1463,7 @@ async function detectWow(
 		if (!previous || normalizeCurrencyCode(currency) !== currency) {
 			continue;
 		}
+		signals.push(...commercialSignals(currency, current, previous, currentTo));
 		const signal = makeRevenueSignal(currency, current, previous, currentTo);
 		const transactions = Math.max(
 			numberField(current, "total_transactions"),

--- a/apps/insights/src/funnel-detection.test.ts
+++ b/apps/insights/src/funnel-detection.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, spyOn } from "bun:test";
+import { clickHouse } from "@databuddy/db/clickhouse";
 import dayjs from "dayjs";
 import type { DetectSignalsParams } from "./detection";
 import {
@@ -1398,36 +1399,63 @@ describe("independent source discovery", () => {
 });
 
 describe("optional referrer deadlines", () => {
-	it("retains the goal when only the optional probe times out", async () => {
+	it("retains the goal when the shared deadline cancels all six optional reads", async () => {
 		const diagnostics: FunnelGoalDetectionDiagnostics = {
 			failedDefinitions: 0,
 		};
+		const probeSignals = new Set<AbortSignal>();
+		let reads = 0;
+		let active = 0;
 		const signals = await detectFunnelGoalSignals(
 			PARAMS,
 			TODAY,
 			makeDeps({
-				fetchFunnels: async () => [FUNNEL],
+				fetchFunnels: async () =>
+					Array.from({ length: 3 }, (_, index) => ({
+						...FUNNEL,
+						id: `deadline-${index}`,
+						steps: [
+							{
+								name: "Start",
+								target: `/deadline-${index}`,
+								type: "PAGE_VIEW" as const,
+							},
+							FUNNEL.steps[1],
+						],
+					})),
 				fetchGoals: async () => [GOAL],
 				funnelConversion: async () => funnelResult(50, 1000),
 				goalConversion: async (_goal, range) =>
 					range.from === "2026-05-22"
 						? goalResult(10, 50, 500)
 						: goalResult(50, 250, 500),
-				funnelReferrers: async (_funnel, _range, signal) =>
-					await waitForAbort(signal),
+				funnelReferrers: async (_funnel, _range, signal) => {
+					if (!signal) throw new Error("Missing probe cancellation");
+					probeSignals.add(signal);
+					reads += 1;
+					active += 1;
+					try {
+						return await waitForAbort(signal);
+					} finally {
+						active -= 1;
+					}
+				},
 			}),
 			{ diagnostics, timeoutMs: 10, overallTimeoutMs: 1000 }
 		);
 		expect(signals.map((signal) => signal.metric)).toEqual(["goal:g1"]);
+		expect(reads).toBe(6);
+		expect(active).toBe(0);
+		expect(probeSignals.size).toBe(1);
 		expect(diagnostics.failedDefinitions).toBe(0);
 		expect(diagnostics.referrerCoverage).toEqual({
-			eligibleFunnels: 1,
-			probedFunnels: 1,
+			eligibleFunnels: 3,
+			probedFunnels: 3,
 			unprobedFunnels: 0,
-			failedProbes: 1,
+			failedProbes: 3,
 		});
 	});
-	it("propagates the parent's abort reason and never starts the next funnel probe", async () => {
+	it("stops launching probes if the parent aborts synchronously during the first launch", async () => {
 		const controller = new AbortController();
 		const reason = new Error("parent discovery canceled");
 		const observed = new Set<string>();
@@ -1468,5 +1496,160 @@ describe("optional referrer deadlines", () => {
 			unprobedFunnels: 1,
 			failedProbes: 0,
 		});
+	});
+});
+
+describe("parallel bounded referrer reads", () => {
+	it("runs only six reads concurrently and retains definition order after out-of-order completion", async () => {
+		const pending: { id: string; finish: () => void }[] = [];
+		const definitions = Array.from({ length: 5 }, (_, index) => ({
+			...FUNNEL,
+			id: `parallel-${index}`,
+			steps: [
+				{
+					name: "Start",
+					target: `/parallel-${index}`,
+					type: "PAGE_VIEW" as const,
+				},
+				FUNNEL.steps[1],
+			],
+		}));
+		let ready: () => void = () => {};
+		const started = new Promise<void>((resolve) => {
+			ready = resolve;
+		});
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		const detection = detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () => definitions,
+				funnelConversion: async () => funnelResult(50, 1000),
+				funnelReferrers: (funnel, range) =>
+					new Promise((resolve) => {
+						pending.push({
+							id: funnel.id,
+							finish: () =>
+								resolve([
+									{
+										referrer: "direct",
+										total_users: 500,
+										completed_users: range.from === "2026-05-22" ? 100 : 300,
+									},
+								]),
+						});
+						if (pending.length === 6) ready();
+					}),
+			}),
+			{ diagnostics, timeoutMs: 1000 }
+		);
+		await started;
+		expect(pending).toHaveLength(6);
+		for (const read of [...pending].reverse()) read.finish();
+		expect((await detection).map((signal) => signal.subjectKey)).toEqual([
+			"funnel:parallel-0:referrer:direct",
+			"funnel:parallel-1:referrer:direct",
+			"funnel:parallel-2:referrer:direct",
+		]);
+		expect(diagnostics.referrerCoverage).toEqual({
+			eligibleFunnels: 5,
+			probedFunnels: 3,
+			unprobedFunnels: 2,
+			failedProbes: 0,
+		});
+	});
+	it("aborts all six in-flight reads together without marking a parent cancel as source failure", async () => {
+		const controller = new AbortController();
+		const reason = new Error("cancel concurrent source reads");
+		let ready: () => void = () => {};
+		const started = new Promise<void>((resolve) => {
+			ready = resolve;
+		});
+		let active = 0;
+		const signals: AbortSignal[] = [];
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		const detection = detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () =>
+					Array.from({ length: 5 }, (_, index) => ({
+						...FUNNEL,
+						id: `cancel-${index}`,
+						steps: [
+							{
+								name: "Start",
+								target: `/cancel-${index}`,
+								type: "PAGE_VIEW" as const,
+							},
+							FUNNEL.steps[1],
+						],
+					})),
+				funnelConversion: async () => funnelResult(50, 1000),
+				funnelReferrers: async (_funnel, _range, signal) => {
+					if (!signal) throw new Error("Missing probe cancellation");
+					signals.push(signal);
+					active += 1;
+					if (active === 6) ready();
+					try {
+						return await waitForAbort(signal);
+					} finally {
+						active -= 1;
+					}
+				},
+			}),
+			{ diagnostics, abortSignal: controller.signal }
+		);
+		await started;
+		expect(active).toBe(6);
+		expect(new Set(signals).size).toBe(1);
+		controller.abort(reason);
+		await expect(detection).rejects.toBe(reason);
+		expect(active).toBe(0);
+		expect(signals.every((signal) => signal.reason === reason)).toBe(true);
+		expect(diagnostics.referrerCoverage).toEqual({
+			eligibleFunnels: 5,
+			probedFunnels: 3,
+			unprobedFunnels: 2,
+			failedProbes: 0,
+		});
+	});
+	it("forwards the detector's active signal through the native RPC into ClickHouse", async () => {
+		const controller = new AbortController();
+		const reason = new Error("detector canceled native referrer read");
+		let querySignal: AbortSignal | undefined;
+		const query = spyOn(clickHouse, "query").mockImplementation((options) => {
+			querySignal = options.abort_signal;
+			expect(options.query_params?.websiteId).toBe(PARAMS.websiteId);
+			return new Promise<never>((_resolve, reject) =>
+				querySignal?.addEventListener(
+					"abort",
+					() => reject(querySignal?.reason),
+					{ once: true }
+				)
+			);
+		});
+		try {
+			const read = defaultFunnelGoalDeps(
+				PARAMS.websiteId,
+				TODAY.toDate()
+			).funnelReferrers;
+			if (!read) throw new Error("Native referrer dependency missing");
+			const result = read(
+				FUNNEL,
+				{ from: "2026-05-22", to: "2026-05-28" },
+				controller.signal
+			);
+			expect(query).toHaveBeenCalledTimes(1);
+			controller.abort(reason);
+			await expect(result).rejects.toBe(reason);
+			expect(querySignal?.reason).toBe(reason);
+		} finally {
+			query.mockRestore();
+		}
 	});
 });

--- a/apps/insights/src/funnel-detection.test.ts
+++ b/apps/insights/src/funnel-detection.test.ts
@@ -7,6 +7,7 @@ import {
 	detectFunnelGoalSignals,
 	type FunnelDef,
 	type FunnelGoalDeps,
+	type FunnelGoalDetectionDiagnostics,
 	type GoalDef,
 	remeasureFunnelGoalSignal,
 } from "./funnel-detection";
@@ -305,9 +306,7 @@ describe("detectFunnelGoalSignals", () => {
 			fetchFunnels: async () => [FUNNEL],
 			funnelConversion: async () => {
 				call += 1;
-				return call === 1
-					? funnelResult(10, 100)
-					: funnelResult(20, 120);
+				return call === 1 ? funnelResult(10, 100) : funnelResult(20, 120);
 			},
 		});
 
@@ -469,9 +468,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(20, 20, 100);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(20, 20, 100);
 				},
 			})
 		);
@@ -494,9 +491,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(0, 0, 120);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(0, 0, 120);
 				},
 			})
 		);
@@ -529,9 +524,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(1.67, 2, 120);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(1.67, 2, 120);
 				},
 			})
 		);
@@ -553,9 +546,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchFunnels: async () => [FUNNEL],
 				funnelConversion: async () => {
 					call += 1;
-					return call === 1
-						? funnelResult(0, 100, 0)
-						: funnelResult(0, 120, 0);
+					return call === 1 ? funnelResult(0, 100, 0) : funnelResult(0, 120, 0);
 				},
 			})
 		);
@@ -635,9 +626,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 49)
-						: goalResult(0, 0, 120);
+					return call === 1 ? goalResult(0, 0, 49) : goalResult(0, 0, 120);
 				},
 			})
 		);
@@ -688,9 +677,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(0, 0, 120);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(0, 0, 120);
 				},
 			})
 		);
@@ -728,9 +715,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(5, 5, 100)
-						: goalResult(0, 0, 120);
+					return call === 1 ? goalResult(5, 5, 100) : goalResult(0, 0, 120);
 				},
 			})
 		);
@@ -779,7 +764,9 @@ describe("detectFunnelGoalSignals", () => {
 			subjectKey: "funnel:f1:zero-completions",
 		});
 		expect(signal?.definitionEvidence).toContain("converted 0 of 1 entrants");
-		expect(signal?.definitionEvidence).not.toContain("completed 0 of 1 entrants");
+		expect(signal?.definitionEvidence).not.toContain(
+			"completed 0 of 1 entrants"
+		);
 	});
 
 	it("reports partial regressions without pre-classifying an action", async () => {
@@ -791,9 +778,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(1, 1, 100)
-						: goalResult(20, 20, 100);
+					return call === 1 ? goalResult(1, 1, 100) : goalResult(20, 20, 100);
 				},
 			})
 		);
@@ -813,9 +798,7 @@ describe("detectFunnelGoalSignals", () => {
 				fetchGoals: async () => [GOAL],
 				goalConversion: async () => {
 					call += 1;
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(20, 20, 100);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(20, 20, 100);
 				},
 			})
 		);
@@ -906,7 +889,12 @@ describe("detectFunnelGoalSignals", () => {
 			PARAMS,
 			TODAY,
 			makeDeps({
-				fetchFunnels: async () => [FUNNEL, filtered, reordered, competingPurpose],
+				fetchFunnels: async () => [
+					FUNNEL,
+					filtered,
+					reordered,
+					competingPurpose,
+				],
 				funnelConversion: async (funnel, range) => {
 					calls.push(funnel.id);
 					return range.from === "2026-05-22"
@@ -992,9 +980,7 @@ describe("detectFunnelGoalSignals", () => {
 					}
 					const call = (calls.get(goal.id) ?? 0) + 1;
 					calls.set(goal.id, call);
-					return call === 1
-						? goalResult(0, 0, 100)
-						: goalResult(20, 20, 100);
+					return call === 1 ? goalResult(0, 0, 100) : goalResult(20, 20, 100);
 				},
 			}),
 			{ diagnostics }
@@ -1290,5 +1276,197 @@ describe("detectFunnelGoalSignals", () => {
 		await expect(detection).rejects.toThrow("discovery canceled");
 		expect(calls).toBe(4);
 		expect(active).toBe(0);
+	});
+});
+
+describe("bounded independent referrer discovery", () => {
+	it("reports five eligible funnels, probes only three, and does not invent findings", async () => {
+		const observed: string[] = [];
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		const definitions = Array.from({ length: 5 }, (_, index) => ({
+			...FUNNEL,
+			id: `bounded-${index}`,
+			steps: [
+				{
+					name: "Start",
+					target: `/start-${index}`,
+					type: "PAGE_VIEW" as const,
+				},
+				FUNNEL.steps[1],
+			],
+		}));
+		const signals = await detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () => definitions,
+				funnelConversion: async () => funnelResult(50, 1000),
+				funnelReferrers: async (funnel) => {
+					observed.push(funnel.id);
+					return [
+						{ referrer: "direct", total_users: 1000, completed_users: 500 },
+					];
+				},
+			}),
+			{ diagnostics }
+		);
+		expect(signals).toEqual([]);
+		expect(observed).toHaveLength(6);
+		expect(new Set(observed).size).toBe(3);
+		expect(diagnostics.referrerCoverage).toEqual({
+			eligibleFunnels: 5,
+			probedFunnels: 3,
+			unprobedFunnels: 2,
+			failedProbes: 0,
+		});
+	});
+});
+
+describe("independent source discovery", () => {
+	it.each([
+		new Error("source warehouse unavailable"),
+		new DOMException("source request canceled", "AbortError"),
+	])("retains core coverage when an optional source rejects: %s", async (failure) => {
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		const result = await detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () => [FUNNEL],
+				fetchGoals: async () => [GOAL],
+				funnelConversion: async () => funnelResult(50, 1000),
+				goalConversion: async (_goal, range) =>
+					range.from === "2026-05-22"
+						? goalResult(10, 50, 500)
+						: goalResult(50, 250, 500),
+				funnelReferrers: async () => {
+					throw failure;
+				},
+			}),
+			{ diagnostics }
+		);
+		expect(result.map((signal) => signal.metric)).toEqual(["goal:g1"]);
+		expect(diagnostics).toEqual({
+			failedDefinitions: 0,
+			referrerCoverage: {
+				eligibleFunnels: 1,
+				probedFunnels: 1,
+				unprobedFunnels: 0,
+				failedProbes: 1,
+			},
+		});
+	});
+	it("finds both opposing source changes behind a stable aggregate", async () => {
+		const signals = await detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () => [FUNNEL],
+				funnelConversion: async () => funnelResult(50, 1000),
+				funnelReferrers: async (_funnel, range) => [
+					{
+						referrer: "direct",
+						total_users: 500,
+						completed_users: range.from === "2026-05-22" ? 200 : 400,
+					},
+					{
+						referrer: "search.example",
+						total_users: 500,
+						completed_users: range.from === "2026-05-22" ? 300 : 100,
+					},
+				],
+			})
+		);
+		expect(
+			signals.map((signal) => [
+				signal.subjectKey,
+				signal.baseline,
+				signal.current,
+			])
+		).toEqual([
+			["funnel:f1:referrer:direct", 80, 40],
+			["funnel:f1:referrer:search.example", 20, 60],
+		]);
+		expect(
+			signals.map((signal) => prepareInvestigation(signal, 7).signal.sentiment)
+		).toEqual(["negative", "positive"]);
+	});
+});
+
+describe("optional referrer deadlines", () => {
+	it("retains the goal when only the optional probe times out", async () => {
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		const signals = await detectFunnelGoalSignals(
+			PARAMS,
+			TODAY,
+			makeDeps({
+				fetchFunnels: async () => [FUNNEL],
+				fetchGoals: async () => [GOAL],
+				funnelConversion: async () => funnelResult(50, 1000),
+				goalConversion: async (_goal, range) =>
+					range.from === "2026-05-22"
+						? goalResult(10, 50, 500)
+						: goalResult(50, 250, 500),
+				funnelReferrers: async (_funnel, _range, signal) =>
+					await waitForAbort(signal),
+			}),
+			{ diagnostics, timeoutMs: 10, overallTimeoutMs: 1000 }
+		);
+		expect(signals.map((signal) => signal.metric)).toEqual(["goal:g1"]);
+		expect(diagnostics.failedDefinitions).toBe(0);
+		expect(diagnostics.referrerCoverage).toEqual({
+			eligibleFunnels: 1,
+			probedFunnels: 1,
+			unprobedFunnels: 0,
+			failedProbes: 1,
+		});
+	});
+	it("propagates the parent's abort reason and never starts the next funnel probe", async () => {
+		const controller = new AbortController();
+		const reason = new Error("parent discovery canceled");
+		const observed = new Set<string>();
+		const diagnostics: FunnelGoalDetectionDiagnostics = {
+			failedDefinitions: 0,
+		};
+		await expect(
+			detectFunnelGoalSignals(
+				PARAMS,
+				TODAY,
+				makeDeps({
+					fetchFunnels: async () => [
+						FUNNEL,
+						{
+							...FUNNEL,
+							id: "f2",
+							steps: [
+								{ name: "Start", target: "/other", type: "PAGE_VIEW" },
+								FUNNEL.steps[1],
+							],
+						},
+					],
+					funnelConversion: async () => funnelResult(50, 1000),
+					funnelReferrers: async (funnel, _range, signal) => {
+						observed.add(funnel.id);
+						controller.abort(reason);
+						return await waitForAbort(signal);
+					},
+				}),
+				{ diagnostics, abortSignal: controller.signal }
+			)
+		).rejects.toBe(reason);
+		expect([...observed]).toEqual(["f1"]);
+		expect(diagnostics.failedDefinitions).toBe(0);
+		expect(diagnostics.referrerCoverage).toEqual({
+			eligibleFunnels: 2,
+			probedFunnels: 1,
+			unprobedFunnels: 1,
+			failedProbes: 0,
+		});
 	});
 });

--- a/apps/insights/src/funnel-detection.ts
+++ b/apps/insights/src/funnel-detection.ts
@@ -9,6 +9,7 @@ import {
 	type AnalyticsStep,
 	getTotalWebsiteUsers,
 	processFunnelAnalytics,
+	processFunnelAnalyticsByReferrer,
 	processGoalAnalytics,
 } from "@databuddy/rpc/analytics-utils";
 import type {
@@ -39,7 +40,7 @@ const DEFINITION_QUERY_TIMEOUT_MS = 45_000;
 const DEFINITION_SCAN_TIMEOUT_MS = 180_000;
 const ZERO_COMPLETION_SUFFIX = "zero-completions";
 const FUNNEL_SIGNAL_KEY =
-	/^funnel:([^:]+)(?::step:(\d+)|:(zero-completions))?$/;
+	/^funnel:([^:]+)(?::step:(\d+)|:(zero-completions)|:referrer:([^:]+))?$/;
 const GOAL_SIGNAL_KEY = /^goal:([^:]+)(?::(zero-completions))?$/;
 
 export interface FunnelDef {
@@ -84,6 +85,13 @@ export interface FunnelGoalDeps {
 		range: PeriodRange,
 		abortSignal?: AbortSignal
 	) => Promise<ConversionResult>;
+	funnelReferrers?: (
+		funnel: FunnelDef,
+		range: PeriodRange,
+		abortSignal?: AbortSignal
+	) => Promise<
+		{ referrer: string; total_users: number; completed_users: number }[]
+	>;
 	goalConversion: (
 		goal: GoalDef,
 		range: PeriodRange,
@@ -93,6 +101,12 @@ export interface FunnelGoalDeps {
 
 export interface FunnelGoalDetectionDiagnostics {
 	failedDefinitions: number;
+	referrerCoverage?: {
+		eligibleFunnels: number;
+		failedProbes: number;
+		probedFunnels: number;
+		unprobedFunnels: number;
+	};
 }
 
 interface GoalConversionDependencies {
@@ -227,6 +241,16 @@ export function defaultFunnelGoalDeps(
 					)
 				)
 				.orderBy(goals.createdAt),
+		funnelReferrers: async (funnel, range, abortSignal) => {
+			abortSignal?.throwIfAborted();
+			const result = await processFunnelAnalyticsByReferrer(
+				toAnalyticsSteps(funnel.steps),
+				funnel.filters ?? [],
+				{ websiteId, startDate: range.from, endDate: `${range.to} 23:59:59` }
+			);
+			abortSignal?.throwIfAborted();
+			return result.referrer_analytics;
+		},
 		funnelConversion: async (funnel, range, abortSignal) => {
 			const analytics = await processFunnelAnalytics(
 				toAnalyticsSteps(funnel.steps),
@@ -675,6 +699,26 @@ export async function remeasureFunnelGoalSignal(
 				`Funnel "${funnel.name}" no longer contains ${prior.entity.label}.`
 			);
 		}
+		if (funnelMatch?.[4]) {
+			if (
+				inactiveDefinitionEvidence(funnel, "funnel") ||
+				!definitionPredatesComparison(funnel, previous.from, params.timezone)
+			) {
+				return null;
+			}
+			return (
+				(
+					await detectFunnelReferrers(
+						funnel,
+						activeDeps,
+						current,
+						previous,
+						abortSignal,
+						decodeURIComponent(funnelMatch[4])
+					)
+				)[0] ?? null
+			);
+		}
 		const [cur, prev] = await Promise.all([
 			activeDeps.funnelConversion(funnel, current, abortSignal),
 			activeDeps.funnelConversion(funnel, previous, abortSignal),
@@ -848,6 +892,94 @@ async function detectStoredDefinitionSignal(
 	return detected;
 }
 
+async function detectFunnelReferrers(
+	funnel: FunnelDef,
+	deps: FunnelGoalDeps,
+	current: PeriodRange,
+	previous: PeriodRange,
+	signal?: AbortSignal,
+	exactReferrer?: string
+): Promise<DetectedSignal[]> {
+	if (!deps.funnelReferrers) {
+		return [];
+	}
+	const [cur, prev] = await Promise.all([
+		deps.funnelReferrers(funnel, current, signal),
+		deps.funnelReferrers(funnel, previous, signal),
+	]);
+	// Ambiguous or missing groups are unknown, never zero-filled or merged.
+	if (
+		new Set(cur.map((row) => row.referrer)).size !== cur.length ||
+		new Set(prev.map((row) => row.referrer)).size !== prev.length
+	) {
+		return [];
+	}
+	const previousBySource = new Map(prev.map((row) => [row.referrer, row]));
+	const found: DetectedSignal[] = [];
+	for (const row of cur) {
+		const before = previousBySource.get(row.referrer);
+		if (
+			!(before && row.referrer) ||
+			(exactReferrer !== undefined && exactReferrer !== row.referrer)
+		) {
+			continue;
+		}
+		if (
+			[row, before].some(
+				(value) =>
+					!(
+						Number.isSafeInteger(value.total_users) &&
+						Number.isSafeInteger(value.completed_users)
+					) ||
+					value.total_users < 100 ||
+					value.completed_users < 0 ||
+					value.completed_users > value.total_users
+			)
+		) {
+			continue;
+		}
+		const currentRate = row.completed_users / row.total_users;
+		const previousRate = before.completed_users / before.total_users;
+		const difference = Math.abs(currentRate - previousRate);
+		const error = Math.sqrt(
+			(currentRate * (1 - currentRate)) / row.total_users +
+				(previousRate * (1 - previousRate)) / before.total_users
+		);
+		if (
+			exactReferrer === undefined &&
+			(difference < 0.1 ||
+				difference < 3 * error ||
+				difference * Math.min(row.total_users, before.total_users) < 30)
+		) {
+			continue;
+		}
+		const subjectKey = `funnel:${funnel.id}:referrer:${encodeURIComponent(row.referrer)}`;
+		if (subjectKey.length > 160) {
+			continue; // Keep remeasurement identities lossless.
+		}
+		found.push({
+			...makeWowSignal(
+				`funnel:${funnel.id}`,
+				`Funnel "${funnel.name}" completion from ${row.referrer}`,
+				currentRate * 100,
+				previousRate * 100,
+				current.to,
+				{ round: true }
+			),
+			subjectKey,
+			investigationObjective:
+				"Explain the within-referrer completion change even when aggregate funnel completion is stable. Compare both source cohorts and their arrival mix; distinguish an activation regression from a positive opportunity without inventing acquisition cost or causality.",
+			entityLabel: funnel.name,
+			definitionEvidence: `Funnel "${funnel.name}"; entry referrer ${JSON.stringify(row.referrer)}: ${before.completed_users}/${before.total_users} → ${row.completed_users}/${row.total_users} completed visitors. Definition and filters are unchanged. These are source cohorts, not randomized groups; no acquisition cost, revenue or causal mechanism is established. Referrer groups omit single visitors; unreturned sources are unknown. Inspect get_funnel_analytics_by_referrer for both windows.`,
+		});
+	}
+	return found.sort(
+		(a, b) =>
+			Math.abs(b.current - b.baseline) - Math.abs(a.current - a.baseline) ||
+			(a.subjectKey ?? "").localeCompare(b.subjectKey ?? "")
+	);
+}
+
 export async function detectFunnelGoalSignals(
 	params: DetectSignalsParams,
 	today: dayjs.Dayjs = params.timezone ? dayjs().tz(params.timezone) : dayjs(),
@@ -970,6 +1102,58 @@ export async function detectFunnelGoalSignals(
 			}
 		}
 	}
+
+	// A stable aggregate must not prevent source discovery. Bound extra reads to
+	// three unchanged definitions, two complete windows each, under the scan deadline.
+	const eligibleProbeFunnels = canonicalFunnels.filter(
+		(funnel) =>
+			definitionPredatesComparison(funnel, previous.from, params.timezone) &&
+			!signals.some((signal) => signal.metric === `funnel:${funnel.id}`)
+	);
+	const probeFunnels = activeDeps.funnelReferrers
+		? eligibleProbeFunnels.slice(0, 3)
+		: [];
+	const coverage = {
+		eligibleFunnels: eligibleProbeFunnels.length,
+		failedProbes: 0,
+		probedFunnels: 0,
+		unprobedFunnels: eligibleProbeFunnels.length,
+	};
+	if (options.diagnostics) {
+		options.diagnostics.referrerCoverage = coverage;
+	}
+	for (const funnel of probeFunnels) {
+		overallSignal.throwIfAborted();
+		coverage.probedFunnels += 1;
+		coverage.unprobedFunnels -= 1;
+		const cohorts = await withDefinitionDeadline(
+			(signal) =>
+				detectFunnelReferrers(funnel, activeDeps, current, previous, signal),
+			Math.max(1, Math.min(definitionTimeoutMs, deadlineAt - Date.now())),
+			overallSignal
+		).catch((error: unknown) => {
+			// Optional source failure is not incomplete core definition coverage.
+			// Only a real parent/scan abort cancels otherwise valid investigations.
+			overallSignal.throwIfAborted();
+			coverage.failedProbes += 1;
+			emitInsightsEvent("warn", "detection.funnel_referrer.probe_failed", {
+				website_id: params.websiteId,
+				definition_id: funnel.id,
+				error_type:
+					error instanceof Error ? error.constructor.name : typeof error,
+			});
+			return [];
+		});
+		const decline = cohorts.find((signal) => signal.direction === "down");
+		const improvement = cohorts.find((signal) => signal.direction === "up");
+		if (decline) {
+			signals.push(decline);
+		}
+		if (improvement) {
+			signals.push(improvement);
+		}
+	}
 	overallSignal.throwIfAborted();
+	emitInsightsEvent("info", "detection.funnel_referrer.coverage", coverage);
 	return signals;
 }

--- a/apps/insights/src/funnel-detection.ts
+++ b/apps/insights/src/funnel-detection.ts
@@ -246,7 +246,8 @@ export function defaultFunnelGoalDeps(
 			const result = await processFunnelAnalyticsByReferrer(
 				toAnalyticsSteps(funnel.steps),
 				funnel.filters ?? [],
-				{ websiteId, startDate: range.from, endDate: `${range.to} 23:59:59` }
+				{ websiteId, startDate: range.from, endDate: `${range.to} 23:59:59` },
+				abortSignal
 			);
 			abortSignal?.throwIfAborted();
 			return result.referrer_analytics;
@@ -1122,28 +1123,46 @@ export async function detectFunnelGoalSignals(
 	if (options.diagnostics) {
 		options.diagnostics.referrerCoverage = coverage;
 	}
-	for (const funnel of probeFunnels) {
-		overallSignal.throwIfAborted();
-		coverage.probedFunnels += 1;
-		coverage.unprobedFunnels -= 1;
-		const cohorts = await withDefinitionDeadline(
-			(signal) =>
-				detectFunnelReferrers(funnel, activeDeps, current, previous, signal),
-			Math.max(1, Math.min(definitionTimeoutMs, deadlineAt - Date.now())),
-			overallSignal
-		).catch((error: unknown) => {
-			// Optional source failure is not incomplete core definition coverage.
-			// Only a real parent/scan abort cancels otherwise valid investigations.
+	const probeController = new AbortController();
+	const probeSignal = AbortSignal.any([
+		overallSignal,
+		probeController.signal,
+		AbortSignal.timeout(
+			Math.max(1, Math.min(definitionTimeoutMs, deadlineAt - Date.now()))
+		),
+	]);
+	const probes = await Promise.all(
+		probeFunnels.map(async (funnel) => {
 			overallSignal.throwIfAborted();
-			coverage.failedProbes += 1;
-			emitInsightsEvent("warn", "detection.funnel_referrer.probe_failed", {
-				website_id: params.websiteId,
-				definition_id: funnel.id,
-				error_type:
-					error instanceof Error ? error.constructor.name : typeof error,
+			coverage.probedFunnels += 1;
+			coverage.unprobedFunnels -= 1;
+			return await raceWithAbort(
+				() =>
+					detectFunnelReferrers(
+						funnel,
+						activeDeps,
+						current,
+						previous,
+						probeSignal
+					),
+				probeSignal
+			).catch((error: unknown) => {
+				// Optional source failure is not incomplete core definition coverage.
+				// Only a real parent/scan abort cancels otherwise valid investigations.
+				overallSignal.throwIfAborted();
+				coverage.failedProbes += 1;
+				emitInsightsEvent("warn", "detection.funnel_referrer.probe_failed", {
+					website_id: params.websiteId,
+					definition_id: funnel.id,
+					error_type:
+						error instanceof Error ? error.constructor.name : typeof error,
+				});
+				return [];
 			});
-			return [];
-		});
+		})
+	).finally(() => probeController.abort());
+	// Promise.all preserves definition order even when reads finish out of order.
+	for (const cohorts of probes) {
 		const decline = cohorts.find((signal) => signal.direction === "down");
 		const improvement = cohorts.find((signal) => signal.direction === "up");
 		if (decline) {

--- a/apps/insights/src/generation-sources.test.ts
+++ b/apps/insights/src/generation-sources.test.ts
@@ -4,6 +4,12 @@ import type { InvestigationOutcome } from "@databuddy/shared/insights";
 import { InsightAgentGenerationError } from "./agent";
 import type { DetectedSignal } from "./detection";
 import {
+	detectFunnelGoalSignals,
+	type FunnelDef,
+	type GoalDef,
+	type FunnelGoalDetectionDiagnostics,
+} from "./funnel-detection";
+import {
 	type InvestigationCoverage,
 	type InvestigationSources,
 	investigateWebsitePortfolioWithSources,
@@ -193,7 +199,10 @@ describe("fixture investigation sources", () => {
 		const outcome: InvestigationOutcome = {
 			evidence: ["The selected signal was measured in the comparison window."],
 			impact: null,
-			next: { reason: "No action is required in this fixture.", type: "resolve" },
+			next: {
+				reason: "No action is required in this fixture.",
+				type: "resolve",
+			},
 			rootCause: null,
 			summary: "The selected signal changed in the comparison window.",
 			title: "Measured signal",
@@ -204,7 +213,8 @@ describe("fixture investigation sources", () => {
 			fetchAnnotations: async () => [],
 			investigateSignal: async (input) => {
 				seen.push({
-					related: input.relatedSignals?.map((signal) => signal.signalKey) ?? [],
+					related:
+						input.relatedSignals?.map((signal) => signal.signalKey) ?? [],
 					signal: input.signal.signalKey,
 				});
 				return { outcome, toolCallCount: 1 };
@@ -268,7 +278,10 @@ describe("fixture investigation sources", () => {
 		const outcome: InvestigationOutcome = {
 			evidence: ["The selected signal was measured in the comparison window."],
 			impact: null,
-			next: { reason: "No action is required in this fixture.", type: "resolve" },
+			next: {
+				reason: "No action is required in this fixture.",
+				type: "resolve",
+			},
 			rootCause: null,
 			summary: "The selected signal changed in the comparison window.",
 			title: "Measured signal",
@@ -295,11 +308,7 @@ describe("fixture investigation sources", () => {
 		});
 
 		await expect(
-			investigateWebsitePortfolioWithSources(
-				fixtureInput,
-				sources,
-				"manual"
-			)
+			investigateWebsitePortfolioWithSources(fixtureInput, sources, "manual")
 		).rejects.toThrow("Model returned malformed structured output");
 		expect(attempted).toEqual([
 			"route:error:/explore",
@@ -322,8 +331,9 @@ describe("fixture investigation sources", () => {
 			severity: "warning",
 			subjectKey: "route:error:/explore",
 		};
-		let received: Parameters<InvestigationSources["investigateSignal"]>[0] | null =
-			null;
+		let received:
+			| Parameters<InvestigationSources["investigateSignal"]>[0]
+			| null = null;
 		const outcome: InvestigationOutcome = {
 			evidence: ["The exact error cohort was measured."],
 			impact: "Thirty-five visitor identifiers were affected.",
@@ -387,8 +397,9 @@ describe("fixture investigation sources", () => {
 			severity: "warning",
 			subjectKey: "route:lcp:/sign-in",
 		};
-		let received: Parameters<InvestigationSources["investigateSignal"]>[0] | null =
-			null;
+		let received:
+			| Parameters<InvestigationSources["investigateSignal"]>[0]
+			| null = null;
 		let continuationCalls = 0;
 		const outcome: InvestigationOutcome = {
 			evidence: ["The matched route cohort was measured."],
@@ -453,11 +464,7 @@ describe("fixture investigation sources", () => {
 		});
 
 		await expect(
-			investigateWebsitePortfolioWithSources(
-				fixtureInput,
-				sources,
-				"manual"
-			)
+			investigateWebsitePortfolioWithSources(fixtureInput, sources, "manual")
 		).rejects.toThrow("AI gateway configuration is unavailable");
 		expect(attempted).toEqual(["visitors"]);
 	});
@@ -489,11 +496,7 @@ describe("fixture investigation sources", () => {
 		});
 
 		await expect(
-			investigateWebsitePortfolioWithSources(
-				fixtureInput,
-				sources,
-				"manual"
-			)
+			investigateWebsitePortfolioWithSources(fixtureInput, sources, "manual")
 		).rejects.toThrow("Annotation storage unavailable");
 		expect(annotationCalls).toEqual(["visitors"]);
 		expect(attempted).toEqual([]);
@@ -579,7 +582,7 @@ describe("fixture investigation sources", () => {
 		});
 
 		const artifact = await investigateFixture(sources, {
-				githubRepository: { owner: "databuddy-analytics", repo: "app" },
+			githubRepository: { owner: "databuddy-analytics", repo: "app" },
 		});
 
 		expect(artifact).toMatchObject({
@@ -587,15 +590,13 @@ describe("fixture investigation sources", () => {
 			status: "completed",
 		});
 		expect(artifact.signal?.signalKey).toBe("visitors");
-		expect(receivedHistoryBody).toBe(
-			"The campaign was intentionally paused."
-		);
+		expect(receivedHistoryBody).toBe("The campaign was intentionally paused.");
 		expect(receivedOpenWorkTitle).toBe("Checkout repository access");
 		expect(receivedRepository).toEqual({
 			owner: "databuddy-analytics",
 			repo: "app",
 		});
-			expect(receivedRelatedMetrics).toEqual(["revenue"]);
+		expect(receivedRelatedMetrics).toEqual(["revenue"]);
 		expect(calls.sort()).toEqual(
 			[
 				"agent:visitors",
@@ -649,9 +650,7 @@ describe("fixture investigation sources", () => {
 		const sources = fixtureSources({
 			loadDueInvestigation: async () => null,
 			detectDefinitionSignals: async () => [],
-			detectMetricSignals: async () => [
-				{ ...trafficDrop, severity: "info" },
-			],
+			detectMetricSignals: async () => [{ ...trafficDrop, severity: "info" }],
 			investigateSignal: async () => {
 				throw new Error("Informational traffic must not reach the agent");
 			},
@@ -803,14 +802,10 @@ describe("fixture investigation sources", () => {
 			},
 		});
 
-		const artifact = await investigateFixture(
-			sources,
-			{},
-			async () => {
-				calls.push("agent access");
-				return false;
-			}
-		);
+		const artifact = await investigateFixture(sources, {}, async () => {
+			calls.push("agent access");
+			return false;
+		});
 
 		expect(artifact).toMatchObject({
 			outcome: null,
@@ -1204,5 +1199,117 @@ describe("fixture investigation sources", () => {
 		expect(remeasureCalls).toBe(1);
 		expect(investigated).toBe("error:clerk-duplicate-provider");
 		expect(artifact.signal?.signalKey).toBe("error:clerk-duplicate-provider");
+	});
+});
+
+describe("native definition detection in portfolio generation", () => {
+	it.each([
+		false,
+		true,
+	])("keeps optional breakdown failure separate from core failure=%s", async (coreFails) => {
+		const funnel: FunnelDef = {
+			id: "checkout",
+			name: "Checkout",
+			description: "Complete a purchase",
+			filters: null,
+			createdAt: new Date("2026-01-01"),
+			updatedAt: new Date("2026-01-01"),
+			steps: [
+				{ name: "Cart", target: "/cart", type: "PAGE_VIEW" },
+				{ name: "Purchase", target: "purchase", type: "EVENT" },
+			],
+		};
+		const goal: GoalDef = {
+			id: "signup",
+			name: "Signup",
+			description: "Create an account",
+			type: "EVENT",
+			target: "sign_up",
+			filters: null,
+			createdAt: new Date("2026-01-01"),
+			updatedAt: new Date("2026-01-01"),
+		};
+		const seen: string[] = [];
+		let diagnostics: FunnelGoalDetectionDiagnostics | undefined;
+		const sources = fixtureSources({
+			detectMetricSignals: async () => [],
+			detectDefinitionSignals: async (params, today, _deps, options) => {
+				expect(params.websiteId).toBe(fixtureInput.websiteId);
+				expect(options?.abortSignal).toBeDefined();
+				diagnostics = options?.diagnostics;
+				return await detectFunnelGoalSignals(
+					params,
+					today,
+					{
+						fetchFunnels: async () => [funnel],
+						fetchGoals: async () => [goal],
+						funnelConversion: async () => {
+							if (coreFails) throw new Error("core conversion unavailable");
+							return { entrants: 1000, completions: 500, rate: 50 };
+						},
+						goalConversion: async (_goal, range) => ({
+							entrants: 500,
+							completions: range.from === "2026-07-05" ? 50 : 250,
+							rate: range.from === "2026-07-05" ? 10 : 50,
+						}),
+						funnelReferrers: async () => {
+							throw new Error("optional breakdown unavailable");
+						},
+					},
+					options
+				);
+			},
+			loadDueInvestigation: async () => null,
+			loadHistory: async () => [],
+			loadObservations: async () => new Map(),
+			fetchAnnotations: async () => [],
+			investigateSignal: async (input) => {
+				seen.push(input.signal.signalKey);
+				expect(input.signal).toMatchObject({
+					entity: { type: "goal", id: "signup" },
+					metric: { current: 10, previous: 50 },
+					sentiment: "negative",
+				});
+				return {
+					outcome: {
+						title: "Signup completion declined",
+						summary: "Signup completed for fewer eligible visitors.",
+						rootCause: null,
+						impact: null,
+						evidence: [
+							"50 of 500 visitors completed signup, previously 250 of 500.",
+						],
+						publish: false,
+						next: {
+							type: "resolve",
+							reason: "Synthetic generation boundary check.",
+						},
+					},
+					toolCallCount: 0,
+				};
+			},
+		});
+		const run = investigateFixture(sources, {}, undefined, "scheduled");
+		if (coreFails) {
+			await expect(run).rejects.toThrow(
+				"0 metric families and 1 conversion definitions failed"
+			);
+			expect(seen).toEqual([]);
+		} else {
+			expect(await run).toMatchObject({
+				status: "completed",
+				signal: { signalKey: "goal:signup" },
+			});
+			expect(seen).toEqual(["goal:signup"]);
+		}
+		expect(diagnostics).toEqual({
+			failedDefinitions: coreFails ? 1 : 0,
+			referrerCoverage: {
+				eligibleFunnels: 1,
+				probedFunnels: 1,
+				unprobedFunnels: 0,
+				failedProbes: 1,
+			},
+		});
 	});
 });

--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -483,6 +483,7 @@ function toPlannedCandidate(
 	);
 	return {
 		evidence: investigation.evidence,
+		investigationObjective: investigation.investigationObjective,
 		signal: investigation.signal,
 	};
 }
@@ -863,6 +864,7 @@ async function investigatePlannedCandidate(
 				: {}),
 			history,
 			otherOpenWork: [...otherOpenWork, ...siblingOpenWork],
+			investigationObjective: candidate.investigationObjective,
 			relatedSignals,
 			signal: candidate.signal,
 		});

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -590,6 +590,7 @@ describe("intelligence agent", () => {
 		"unanchored",
 		"past-window",
 		"wrong-units",
+		"referrer-check",
 	] as const)("validates a definition repair and saved verification: %s", async (scenario) => {
 		const native = scenario.startsWith("native");
 		const current = {
@@ -681,7 +682,13 @@ describe("intelligence agent", () => {
 				githubRepository: null,
 				history: [],
 				otherOpenWork: [],
-				signal: funnelSignal,
+				signal:
+					scenario === "referrer-check"
+						? {
+								...funnelSignal,
+								signalKey: "funnel:checkout:referrer:paid.example",
+							}
+						: funnelSignal,
 			},
 			{
 				model: new MockLanguageModelV3({
@@ -1809,6 +1816,8 @@ describe("intelligence agent", () => {
 		"invalid-count",
 		"no-read",
 		"newer-resolution",
+		"referrer-rate",
+		"referrer-count",
 	] as const)("binds verification to the exact measurement: %s", async (scenario) => {
 		const check = {
 			definition: {
@@ -1819,7 +1828,7 @@ describe("intelligence agent", () => {
 				filters: [],
 			},
 			metric:
-				scenario === "failed-rate"
+				scenario === "failed-rate" || scenario === "referrer-rate"
 					? ("overall_conversion_rate" as const)
 					: ("total_users_completed" as const),
 			startDate: "2026-07-05",
@@ -1828,7 +1837,12 @@ describe("intelligence agent", () => {
 			threshold: {
 				anchor: "prior_baseline" as const,
 				comparison: "at_or_above" as const,
-				value: scenario === "failed-rate" ? 80 : 100,
+				value:
+					scenario === "failed-rate"
+						? 80
+						: scenario === "referrer-rate"
+							? 40
+							: 100,
 				evidenceRef: { source: "signal" as const },
 			},
 		};
@@ -1879,7 +1893,12 @@ describe("intelligence agent", () => {
 			asOf: "2026-07-01T00:00:00Z",
 			evidence: [],
 			kind: "investigation" as const,
-			signal: funnelSignal,
+			signal: scenario.startsWith("referrer-")
+				? {
+						...funnelSignal,
+						signalKey: "funnel:checkout:referrer:paid.example",
+					}
+				: funnelSignal,
 			outcome: { ...outcome, next: { ...agentOutcome.next, check } },
 		};
 		const result = await runInsightAgent(
@@ -1894,7 +1913,12 @@ describe("intelligence agent", () => {
 				evidence: [],
 				githubRepository: null,
 				otherOpenWork: [],
-				signal: funnelSignal,
+				signal: scenario.startsWith("referrer-")
+					? {
+							...funnelSignal,
+							signalKey: "funnel:checkout:referrer:paid.example",
+						}
+					: funnelSignal,
 				history:
 					scenario === "newer-resolution"
 						? [
@@ -2700,6 +2724,8 @@ describe("structured revenue evidence", () => {
 					total_revenue: "10000",
 					total_transactions: 100,
 					refund_amount: index === 0 ? "1200" : "200",
+					refund_count: index === 0 ? 12 : 2,
+					attributed_revenue: index === 0 ? 3000 : 9000,
 				},
 			],
 		})
@@ -2711,6 +2737,44 @@ describe("structured revenue evidence", () => {
 	const input = { appContext: appContext(), signal };
 
 	it.each([
+		[
+			"refund_amount:USD",
+			["refund_amount", "refund_count"],
+			"product_outcome",
+			true,
+		],
+		[
+			"refund_amount:EUR",
+			["refund_amount", "refund_count"],
+			"product_outcome",
+			false,
+		],
+		["refund_amount:USD", ["total_revenue"], "product_outcome", false],
+		["refund_amount:USD", ["refund_amount"], "product_outcome", false],
+		[
+			"attribution_rate:USD",
+			["attributed_revenue", "total_revenue"],
+			"measurement_coverage",
+			true,
+		],
+		[
+			"attribution_rate:USD",
+			["attributed_revenue", "total_revenue"],
+			"product_outcome",
+			false,
+		],
+		[
+			"attribution_rate:EUR",
+			["attributed_revenue", "total_revenue"],
+			"measurement_coverage",
+			false,
+		],
+		[
+			"attribution_rate:USD",
+			["attributed_revenue"],
+			"measurement_coverage",
+			false,
+		],
 		["revenue", ["total_revenue"], "product_outcome", false],
 		["revenue:USD", ["total_revenue"], "product_outcome", true],
 		["revenue:EUR", ["total_revenue"], "product_outcome", false],
@@ -2793,7 +2857,116 @@ describe("structured revenue evidence", () => {
 			}
 		);
 		if (accepted) expect((await run).outcome.publish).toBe(true);
-		else await expect(run).rejects.toThrow("not a verified product loss");
+		else
+			await expect(run).rejects.toThrow(
+				signalKey.startsWith("attribution_rate:") &&
+					(signalKey !== "attribution_rate:USD" ||
+						!fields?.some((field) => field === "total_revenue"))
+					? "Attribution findings require native"
+					: "not a verified product loss"
+			);
+	});
+
+	it.each([
+		"snapshot-only",
+		"wrong-currency",
+		"missing-denominator",
+		"private",
+	] as const)("requires native attribution proof despite provided evidence: %s", async (variant) => {
+		const snapshot =
+			"USD attributed settled revenue: 9000 of 10000 gross → 3000 of 10000 gross.";
+		const hasRead =
+			variant === "wrong-currency" || variant === "missing-denominator";
+		const proposal = {
+			findingKind: "measurement_coverage",
+			title: "Revenue attribution coverage declined",
+			summary: "Channel comparisons have incomplete coverage.",
+			rootCause: null,
+			evidence: [
+				snapshot,
+				...(hasRead
+					? [
+							{
+								currency: variant === "wrong-currency" ? "EUR" : "USD",
+								fields:
+									variant === "missing-denominator"
+										? ["attributed_revenue"]
+										: ["attributed_revenue", "total_revenue"],
+							},
+						]
+					: []),
+			],
+			evidenceRefs: [
+				[{ source: "provided", index: 0 }],
+				...(hasRead
+					? [
+							["current", "previous"].map((resultKey) => ({
+								source: "tool",
+								name: "get_data",
+								toolCallId: "get_data-1",
+								resultKey,
+							})),
+						]
+					: []),
+			],
+			publish: variant !== "private",
+			publicationBasis: variant === "private" ? null : "decision_safety",
+			next: { type: "resolve", reason: "No cause has been established." },
+		};
+		const run = runInsightAgent(
+			{
+				...input,
+				signal: {
+					...signal,
+					signalKey: "attribution_rate:USD",
+					entity: {
+						type: "website",
+						id: "website",
+						label: "USD revenue attribution",
+					},
+				},
+				evidence: [snapshot],
+				githubRepository: null,
+				history: [],
+				otherOpenWork: [],
+			},
+			{
+				model: new MockLanguageModelV3({
+					doGenerate: mockValues(
+						...(hasRead ? [toolCallResponse("get_data")] : []),
+						outputResponse(proposal),
+						outputResponse(proposal),
+						outputResponse(proposal)
+					),
+				}),
+				tools: hasRead
+					? {
+							get_data: tool({
+								description: "Native revenue measurement",
+								inputSchema: z.object({}),
+								execute: () => ({
+									results: Object.fromEntries(
+										["current", "previous"].map((key, i) => [
+											key,
+											{
+												...readings[i],
+												data: readings[i].data.map((row) => ({
+													...row,
+													currency:
+														variant === "wrong-currency" ? "EUR" : "USD",
+												})),
+											},
+										])
+									),
+								}),
+							}),
+						}
+					: {},
+			}
+		);
+		if (variant === "private") expect((await run).outcome.publish).toBe(false);
+		else
+			await expect(run).rejects.toThrow("Attribution findings require native");
 	});
 
 	it("binds metrics to their labels and computes a refund delta absent from the source", () => {

--- a/apps/insights/src/investigation.ts
+++ b/apps/insights/src/investigation.ts
@@ -14,6 +14,7 @@ dayjs.extend(timezonePlugin);
 
 interface InvestigationInput {
 	evidence: string[];
+	investigationObjective?: string;
 	signal: InvestigationSignal;
 }
 
@@ -66,6 +67,7 @@ export function normalizedErrorSubject(value: string): string {
 function metricFormat(metric: string): InsightMetric["format"] {
 	if (
 		metric === "bounce_rate" ||
+		metric === "attribution_rate" ||
 		metric.startsWith("funnel:") ||
 		metric.startsWith("goal:")
 	) {
@@ -81,7 +83,9 @@ function metricFormat(metric: string): InsightMetric["format"] {
 }
 
 function isLowerBetter(metric: string): boolean {
-	return ["bounce_rate", "error_count", "lcp", "inp"].includes(metric);
+	return ["bounce_rate", "error_count", "lcp", "inp", "refund_amount"].includes(
+		metric
+	);
 }
 
 const SEVERITY_RANK = { critical: 2, warning: 1, info: 0 } as const;
@@ -111,6 +115,9 @@ function isFunnelStepSignal(signal: DetectedSignal): boolean {
 function isDirectSignal(signal: DetectedSignal): boolean {
 	return (
 		signal.metric === "revenue" ||
+		signal.metric === "refund_amount" ||
+		signal.metric === "attribution_rate" ||
+		signal.subjectKey?.includes(":referrer:") === true ||
 		signal.metric === "error_count" ||
 		signal.metric === "custom_event_count" ||
 		signal.metric === "lcp" ||
@@ -150,7 +157,13 @@ export function isInvestigationCandidate(signal: DetectedSignal): boolean {
 	) {
 		return false;
 	}
-	return isRegression(signal) || signal.metric === "revenue";
+	return (
+		isRegression(signal) ||
+		["revenue", "refund_amount", "attribution_rate"].includes(signal.metric) ||
+		(isConversionDefinitionSignal(signal) &&
+			signal.current - signal.baseline >= 10 &&
+			signal.deltaPercent >= 30)
+	);
 }
 
 function signalBucket(signal: DetectedSignal): number {
@@ -340,6 +353,7 @@ export function prepareInvestigation(
 
 	return {
 		evidence,
+		investigationObjective: candidate.investigationObjective,
 		signal: investigationSignalSchema.parse(signal),
 	};
 }

--- a/apps/insights/src/run-candidate-plan.ts
+++ b/apps/insights/src/run-candidate-plan.ts
@@ -14,6 +14,7 @@ const emptyPlanStatusSchema = z.enum(["deferred", "no_signals"]);
 const plannedCandidateSchema = z
 	.object({
 		evidence: z.array(z.string().max(500)).max(20),
+		investigationObjective: z.string().max(500).optional(),
 		signal: investigationSignalSchema,
 	})
 	.strip();

--- a/packages/ai/src/ai/tools/cohort-read.test.ts
+++ b/packages/ai/src/ai/tools/cohort-read.test.ts
@@ -114,3 +114,89 @@ test("model JSON schema exposes the read capability", () => {
 	expect(JSON.stringify(schema)).toContain('"browser_name"');
 	expect(JSON.stringify(schema)).toContain('"cohort"');
 });
+
+test("model can explicitly request unfiltered analytics without inventing a cohort", async () => {
+	const invoke = spyOn(rpc, "callRPCProcedure").mockResolvedValue({
+		synthetic: true,
+	});
+	const dates = { startDate: "2026-08-22", endDate: "2026-08-28" };
+	const funnelTools = createFunnelTools();
+	try {
+		for (const [definition, id] of [
+			[funnelTools.get_funnel_analytics, { funnelId: "synthetic-funnel" }],
+			[
+				funnelTools.get_funnel_analytics_by_referrer,
+				{ funnelId: "synthetic-funnel" },
+			],
+			[createGoalTools().get_goal_analytics, { goalId: "synthetic-goal" }],
+		] as const) {
+			const schema = asSchema(definition.inputSchema);
+			// Strict model providers need an explicit empty alternative for objects.
+			expect(JSON.stringify(schema.jsonSchema)).toContain('"type":"null"');
+			for (const cohort of [null, undefined]) {
+				const input = { ...id, ...dates, cohort };
+				if (!schema.validate) throw new Error("Missing schema validator");
+				expect((await schema.validate(input)).success).toBe(true);
+			}
+		}
+		if (
+			!funnelTools.get_funnel_analytics.execute ||
+			!funnelTools.get_funnel_analytics_by_referrer.execute
+		)
+			throw new Error("Missing executor");
+		const goal = createGoalTools().get_goal_analytics;
+		if (!goal.execute) throw new Error("Missing executor");
+		await funnelTools.get_funnel_analytics.execute(
+			{ funnelId: "synthetic-funnel", ...dates, cohort: null },
+			options
+		);
+		await funnelTools.get_funnel_analytics_by_referrer.execute(
+			{ funnelId: "synthetic-funnel", ...dates, cohort: null },
+			options
+		);
+		await goal.execute(
+			{ goalId: "synthetic-goal", ...dates, cohort: null },
+			options
+		);
+		expect(
+			invoke.mock.calls.map(([router, method, input]) => ({
+				router,
+				method,
+				input,
+			}))
+		).toEqual([
+			{
+				router: "funnels",
+				method: "getAnalytics",
+				input: {
+					funnelId: "synthetic-funnel",
+					websiteId: "synthetic-site",
+					...dates,
+					cohort: undefined,
+				},
+			},
+			{
+				router: "funnels",
+				method: "getAnalyticsByReferrer",
+				input: {
+					funnelId: "synthetic-funnel",
+					websiteId: "synthetic-site",
+					...dates,
+					cohort: undefined,
+				},
+			},
+			{
+				router: "goals",
+				method: "getAnalytics",
+				input: {
+					goalId: "synthetic-goal",
+					websiteId: "synthetic-site",
+					...dates,
+					cohort: undefined,
+				},
+			},
+		]);
+	} finally {
+		invoke.mockRestore();
+	}
+});

--- a/packages/ai/src/ai/tools/cohort-read.test.ts
+++ b/packages/ai/src/ai/tools/cohort-read.test.ts
@@ -69,6 +69,7 @@ test("cohort rejects tenant and step selectors", () => {
 		"owner_id",
 		"path",
 		"event_name",
+		"referrer",
 		"browser_name OR 1=1",
 	])
 		expect(

--- a/packages/ai/src/ai/tools/funnels.ts
+++ b/packages/ai/src/ai/tools/funnels.ts
@@ -14,7 +14,11 @@ const logger = createToolLogger("Funnels Tools");
 const funnelAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
 	funnelId: z.string(),
 	websiteId: z.string().optional(),
-	cohort: analyticsCohortSchema.optional(),
+	cohort: analyticsCohortSchema
+		.nullish()
+		.describe(
+			"Additional cohort filters, or null to measure the saved definition without extra filtering."
+		),
 });
 
 export function createFunnelTools() {
@@ -59,7 +63,13 @@ export function createFunnelTools() {
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalytics",
-					{ funnelId, websiteId, startDate, endDate, cohort },
+					{
+						funnelId,
+						websiteId,
+						startDate,
+						endDate,
+						cohort: cohort ?? undefined,
+					},
 					context
 				);
 			} catch (error) {
@@ -91,7 +101,13 @@ export function createFunnelTools() {
 				return await callRPCProcedure(
 					"funnels",
 					"getAnalyticsByReferrer",
-					{ funnelId, websiteId, startDate, endDate, cohort },
+					{
+						funnelId,
+						websiteId,
+						startDate,
+						endDate,
+						cohort: cohort ?? undefined,
+					},
 					context
 				);
 			} catch (error) {

--- a/packages/ai/src/ai/tools/goals.ts
+++ b/packages/ai/src/ai/tools/goals.ts
@@ -20,7 +20,11 @@ const goalFilterSchema = z.object({
 const goalAnalyticsInputSchema = analyticsDateRangeSchema.safeExtend({
 	goalId: z.string(),
 	websiteId: z.string().optional(),
-	cohort: analyticsCohortSchema.optional(),
+	cohort: analyticsCohortSchema
+		.nullish()
+		.describe(
+			"Additional cohort filters, or null to measure the saved definition without extra filtering."
+		),
 });
 const createGoalInputSchema = z.object({
 	websiteId: z.string(),
@@ -79,7 +83,13 @@ export function createGoalTools() {
 				return await callRPCProcedure(
 					"goals",
 					"getAnalytics",
-					{ goalId, websiteId, startDate, endDate, cohort },
+					{
+						goalId,
+						websiteId,
+						startDate,
+						endDate,
+						cohort: cohort ?? undefined,
+					},
 					context
 				);
 			} catch (error) {

--- a/packages/rpc/src/lib/analytics-utils.integration.test.ts
+++ b/packages/rpc/src/lib/analytics-utils.integration.test.ts
@@ -1,9 +1,10 @@
-import { beforeAll, describe, expect, it } from "bun:test";
-import { chCommand } from "@databuddy/db/clickhouse";
+import { beforeAll, describe, expect, it, spyOn } from "bun:test";
+import { chCommand, clickHouse } from "@databuddy/db/clickhouse";
 import { randomUUIDv7 } from "bun";
 import {
 	getTotalWebsiteUsers,
 	processFunnelAnalytics,
+	processFunnelAnalyticsByReferrer,
 	processFunnelConversionCounts,
 	processGoalAnalytics,
 	queryLinkVisitorIds,
@@ -359,4 +360,54 @@ describeIntegration("goal and funnel visitor identity", () => {
 			expect(result.total_users_completed).toBe(expected);
 		});
 	}
+});
+
+describe("referrer query cancellation boundary", () => {
+	it.each([
+		false,
+		true,
+	])("forwards cancellation to the actual ClickHouse query (preaborted=%s)", async (preaborted) => {
+		const controller = new AbortController();
+		const reason = new Error("referrer read canceled");
+		let querySignal: AbortSignal | undefined;
+		const query = spyOn(clickHouse, "query").mockImplementation((options) => {
+			querySignal = options.abort_signal;
+			expect(options.query_params?.websiteId).toBe("synthetic-referrer-site");
+			expect(options.query_params?.startDate).toBe(startDate);
+			expect(options.query_params?.endDate).toBe(endDate);
+			return new Promise<never>((_resolve, reject) => {
+				querySignal?.addEventListener(
+					"abort",
+					() => reject(querySignal?.reason),
+					{ once: true }
+				);
+			});
+		});
+		try {
+			if (preaborted) controller.abort(reason);
+			const result = processFunnelAnalyticsByReferrer(
+				[
+					{
+						name: "Start",
+						step_number: 1,
+						target: "/start",
+						type: "PAGE_VIEW",
+					},
+				],
+				[],
+				queryParams("synthetic-referrer-site"),
+				controller.signal
+			);
+			if (!preaborted) {
+				expect(query).toHaveBeenCalledTimes(1);
+				expect(querySignal?.aborted).toBe(false);
+				controller.abort(reason);
+			}
+			await expect(result).rejects.toBe(reason);
+			expect(query).toHaveBeenCalledTimes(preaborted ? 0 : 1);
+			if (!preaborted) expect(querySignal?.reason).toBe(reason);
+		} finally {
+			query.mockRestore();
+		}
+	});
 });

--- a/packages/rpc/src/lib/analytics-utils.ts
+++ b/packages/rpc/src/lib/analytics-utils.ts
@@ -866,7 +866,8 @@ export const processGoalAnalytics = async (
 export const processFunnelAnalyticsByReferrer = async (
 	steps: AnalyticsStep[],
 	filters: Filter[],
-	params: ClickhouseQueryParams
+	params: ClickhouseQueryParams,
+	abortSignal?: AbortSignal
 ): Promise<{ referrer_analytics: ReferrerAnalytics[] }> => {
 	const totalSteps = steps.length;
 	if (totalSteps === 0) {
@@ -887,7 +888,9 @@ FROM step_events
 GROUP BY vid
 HAVING max_step >= 1`;
 
-	const rows = await chQuery<ReferrerRow>(fullQuery, params);
+	const rows = await chQuery<ReferrerRow>(fullQuery, params, {
+		abort_signal: abortSignal,
+	});
 
 	const groups = new Map<
 		string,

--- a/packages/shared/src/analytics-filters.ts
+++ b/packages/shared/src/analytics-filters.ts
@@ -37,7 +37,6 @@ export const analyticsCohortSchema = z
 						"device_type",
 						"os_name",
 						"country",
-						"referrer",
 						"utm_source",
 						"utm_medium",
 						"utm_campaign",
@@ -53,5 +52,5 @@ export const analyticsCohortSchema = z
 			.max(8),
 	})
 	.describe(
-		"Read-only cohort. Funnel filters select first-step visitors; subsequent ordered steps may have different context. Goal filters select page-view visitors and matching completions. Saved filters are ANDed. These are visitors, not attempts."
+		"Read-only cohort. Funnel filters select first-step visitors; subsequent ordered steps may have different context. Goal filters select page-view visitors and matching completions. Saved filters are ANDed. Use the referrer breakdown tool to compare source groups. These are visitors, not attempts."
 	);


### PR DESCRIPTION
Flat gross revenue and flat configured funnel totals prevented useful investigations from starting. Discovery now independently selects currency-scoped refund and attribution changes, probes stable funnels for opposing source changes, and allows material positive conversion changes. A typed machine-selected objective carries the question into the existing agent without pretending to be human context or citable evidence.

On ten frozen warehouse-shaped worlds, the real detector/planner/preparation path changes commercial selection from zero to two subjects, opposing-source selection from zero to two, and positive activation from zero to one. Missing, sparse, small-movement, null and stable-currency controls remain quiet. Fresh automatic model runs with corrected native signed refunds retain the separate refund/attribution risks; source runs retain the decline hidden by a flat total. This establishes synthetic capability, not paying-customer coverage or pricing readiness. Earlier positive-refund fixtures are explicitly invalid for native signed-contract reachability.

Source discovery uses at most six concurrent reads for the first three eligible stable funnels, under one deadline. Cancellation reaches the native ClickHouse client. Optional breakdown failures preserve valid core findings; core failures and parent cancellation retain their fatal behavior. Commercial discovery reuses existing revenue reads. Later funnels can remain unprobed, and scheduled/manual portfolio limits stay two/five.

Independent review caught and fixed snapshot-only attribution publication and false referrer recovery from whole-funnel counts. Attribution publication requires native currency-specific proof. Aggregate referrer checks are rejected; historical ones remain inconclusive. Source-domain groups now use the existing referrer breakdown tool: the new cohort selector no longer accepts ambiguous raw referrer values, while saved-definition filters are unchanged. Native funnel/goal tools accept an explicit null cohort and normalize it to no additional filter at the RPC boundary.

Fresh integration testing retained an invalid source fixture, a corrected-fixture quality failure, and a weak follow-up in the audit. The weak run invented a nonmatching UTM filter and lost source context. With explicit null support, two further runs used four valid unfiltered reads in parallel, retained paid 40% → 20%, direct 10% → 22.5%, and unchanged overall 220/1,000, finishing in two turns at 50/52 words instead of three turns with failed reads. One still omitted dates. Earlier reviewed attribution gathered valid facts but failed on a corrective gateway request; it is retained as a failure, not a successful output. No broad latency or actionability claim is made.

Native contract review caught a release blocker: Stripe refunds and revenue_overview use negative amounts. The detector now compares refund magnitudes, preserves negative/integer count validation, and treats invalid optional fields as unknown without suppressing the independent finding. Same-count material refund increases are eligible; the sample, 2%-of-gross and 30% relative-change gates remain. Invalid gross totals remain inconclusive rather than becoming zero. Permanent controls cover signed numeric strings, worsening/improving/flat rechecks, exact identity, independent missing fields and same-count amount changes. Fresh signed refund and attribution runs both completed (44/30 words, three/four turns); attribution required a headline correction, so this is not a universal turn reduction.

Validation: root lint, all 33 workspace typecheck/build tasks, and all 27 root test/build tasks pass; the insights suite has 423 passing tests. Five direct cohort tool tests verify native filter forwarding, authorization, rejected selectors and explicit null/omission schema and RPC semantics. Independent review separately exercised 108 permanent control-flow scenarios plus an abort cleanup control. Nine earlier isolated ClickHouse tests support the merged native cohort measurement; native server resource reclamation and final production deployment remain unmeasured. A nonisolated ad-hoc cross-package test failure is retained; normal isolated repository suites pass. The runtime diff adds 429 net lines for new detection/capability boundaries; this is not a code-size reduction.

Scope: automatic investigation reachability, source measurement usability, and publication/verification boundaries. No database schema, notification, model or new agent architecture. Based on staging after merged #741; no unmerged dependency or remaining ownership overlap. AI-assisted maintainer contribution.

Nonblocking review dispositions: malformed extra commercial-key suffixes remain rejected by the existing full-key check at the generation boundary; no canonical producer exists, so parser tightening is deferred. The broad referrer-key substring guard also remains a scoped hardening follow-up. Attribution publication reports measured coverage and decision safety, not a proven tracking defect or lost sales. Native cancellation, sequential probes, signed refunds and same-count amount selection are fixed; frozen expected dates and narrowed unknown error boundaries are intentional.
