### PR TITLE
fix(ai): attribute utm_term and utm_content like the rest of the UTM family

### DIFF
--- a/packages/ai/src/query/builders/traffic.ts
+++ b/packages/ai/src/query/builders/traffic.ts
@@ -22,8 +22,6 @@ function utmDimension(options: {
 	noun: string;
 	description: string;
 	tags: string[];
-	requireNotNull?: boolean;
-	sessionAttribution?: boolean;
 }): SimpleQueryConfig {
 	const { column, title, label, noun, description, tags } = options;
 	return {
@@ -70,11 +68,7 @@ function utmDimension(options: {
 			"uniq(anonymous_id) as visitors",
 		],
 		percentageOf: { of: "visitors" },
-		where: [
-			`${column} != ''`,
-			...(options.requireNotNull ? [`${column} IS NOT NULL`] : []),
-			"event_name = 'screen_view'",
-		],
+		where: [`${column} != ''`, "event_name = 'screen_view'"],
 		groupBy: [column],
 		orderBy: "visitors DESC",
 		limit: 100,
@@ -83,9 +77,7 @@ function utmDimension(options: {
 			? UTM_BASE_FILTERS
 			: [...UTM_BASE_FILTERS, column],
 		customizable: true,
-		...(options.sessionAttribution
-			? { plugins: { sessionAttribution: true } }
-			: {}),
+		plugins: { sessionAttribution: true },
 	};
 }
 
@@ -176,7 +168,6 @@ export const TrafficBuilders: Record<string, SimpleQueryConfig> = {
 		description:
 			"Traffic breakdown by UTM source parameters from your marketing campaigns and tracked links.",
 		tags: ["utm", "campaigns", "marketing", "sources"],
-		sessionAttribution: true,
 	}),
 
 	utm_mediums: utmDimension({
@@ -187,7 +178,6 @@ export const TrafficBuilders: Record<string, SimpleQueryConfig> = {
 		description:
 			"Traffic breakdown by UTM medium parameters (e.g. cpc, email, social).",
 		tags: ["utm", "medium", "acquisition"],
-		sessionAttribution: true,
 	}),
 
 	utm_campaigns: utmDimension({
@@ -198,7 +188,6 @@ export const TrafficBuilders: Record<string, SimpleQueryConfig> = {
 		description:
 			"Performance breakdown by UTM campaign parameters to track individual marketing campaign effectiveness.",
 		tags: ["utm", "campaigns", "marketing", "performance"],
-		sessionAttribution: true,
 	}),
 
 	utm_terms: utmDimension({
@@ -209,7 +198,6 @@ export const TrafficBuilders: Record<string, SimpleQueryConfig> = {
 		description:
 			"Traffic breakdown by UTM term parameters, typically used for keyword tracking in paid campaigns.",
 		tags: ["utm", "campaigns", "keywords", "terms"],
-		requireNotNull: true,
 	}),
 
 	utm_content: utmDimension({
@@ -220,7 +208,6 @@ export const TrafficBuilders: Record<string, SimpleQueryConfig> = {
 		description:
 			"Traffic breakdown by UTM content parameters, used to differentiate similar content or links within the same campaign.",
 		tags: ["utm", "campaigns", "content", "creative"],
-		requireNotNull: true,
 	}),
 
 	// SQL output only; parseReferrers plugin adds referrer/source/domain/referrer_type/parsed_referrer at runtime.

--- a/packages/ai/src/query/expressions.ts
+++ b/packages/ai/src/query/expressions.ts
@@ -108,6 +108,8 @@ export const SESSION_ATTRIBUTION_FIELDS = [
 	"utm_source",
 	"utm_medium",
 	"utm_campaign",
+	"utm_term",
+	"utm_content",
 	"country",
 	"device_type",
 	"browser_name",


### PR DESCRIPTION
Follow-up to #743, which surfaced this.

`utm_terms` and `utm_content` reported **event-level** UTM values while `utm_sources`, `utm_mediums` and `utm_campaigns` reported **session-attributed** ones. The same report family answered the same question two different ways.

## Root cause

Not the builder config. `needsSessionAttribution()` only fires for columns listed in `SESSION_ATTRIBUTION_FIELDS`, and `utm_term`/`utm_content` were never in it — so setting the plugin on those builders was a silent no-op. I confirmed that by setting it and watching the generated SQL not change.

## Cost to existing queries: zero

Adding both columns widens the shared `session_attribution` CTE from 8 `argMin`s to 10, which touches every attributed query. Measured on the busiest client:

| | rows read | bytes | time |
|---|---|---|---|
| 8 argMins | 1,459,682 | 144.1 MiB | ~123ms |
| 10 argMins | 1,459,682 | 144.1 MiB | ~104ms |

Byte-identical. ClickHouse prunes aggregates the outer query never references, which is the same behaviour that made an earlier column-pruning attempt a no-op.

## What does change

The two reports gain the attribution join, **13ms → 27ms**, and their numbers rise: **+3.9% pageviews, +0.2% visitors** on the highest-volume `utm_content` client. Pageviews after the landing one now count toward the value that acquired the session, which is what the other three already did.

Flagging that plainly: **these two reports will show slightly higher pageviews after this ships.** That is the intended correction, not a regression.

## Also

Drops `IS NOT NULL` from the generated `where`. All five columns are `Nullable(String)`, but `NULL != ''` is `NULL` and already discarded by `WHERE` — across 1,283,945 null rows both predicates return identical counts (11,881 and 6,910).

With both differences gone, `utmDimension` has **no behavioural flags left**; every call site is purely descriptive.

653 tests pass, typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `utm_terms` and `utm_content` reports so they attribute UTM values to the session like the rest of the UTM family. Previously these two reported event-level values while `utm_sources`, `utm_mediums`, and `utm_campaigns` used session attribution.

**Side effects**
- `utm_terms` and `utm_content` pageviews and visitors will rise slightly after this ships; this is the intended correction.
- Existing session-attributed queries are unaffected; the added fields don't change rows read or bytes scanned.

**Cleanup**
- Drops the `IS NOT NULL` filter from the generated `where` clause; results are identical.

<sup>Written for commit 22f4aaa668b74508eb484c64e5f64ad6ef6d6a67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

