### PR TITLE
feat(insights): find receipt shifts hidden by flat revenue

### DIFF
--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -168,8 +168,12 @@ export function renderRevenueEvidence(
 	const provider = first.filters.find(
 		(filter) => filter.field === "provider" && filter.op === "eq"
 	);
+	const unidentified = first.filters.some(
+		(filter) =>
+			filter.field === "product_id" && filter.op === "eq" && filter.value === ""
+	);
 	const population = description
-		? ` (${provider ? `${String(provider.value)} ` : ""}receipts described ${String(description.value)})`
+		? ` (${provider ? `${String(provider.value)} ` : ""}receipts described ${String(description.value)}${unidentified ? " with no product ID" : ""})`
 		: first.filters.some((filter) => filter.field !== "currency")
 			? " (filtered population)"
 			: "";

--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -60,7 +60,7 @@ const revenueEvidenceSchema = z
 			.max(4),
 	})
 	.describe(
-		"For revenue_overview, select complementary fields: gross revenue, settled transactions, refunds, and attributed revenue when it differs from gross. Select only fields with a non-null value in every cited period. Omit redundant subtotals and diagnostic availability flags. One entry per measured population; a product comparison uses a second entry for the whole-currency control. Cite both complete comparison windows in each evidenceRefs entry. Code supplies labels, values, periods and deltas; preserve supported comparisons when correcting format."
+		"For revenue_overview, select complementary fields: gross revenue, settled transactions, refunds, and attributed revenue when it differs from gross. Select only fields with a non-null value in every cited period. Omit redundant subtotals and diagnostic availability flags. One entry per measured population; a payment-description comparison uses a second entry for the whole-currency control. Cite both complete comparison windows in each evidenceRefs entry. Code supplies labels, values, periods and deltas; preserve supported comparisons when correcting format."
 	);
 const finishSchema = z.object(agentInvestigationOutcomeSchema.shape).extend({
 	evidence: z
@@ -73,7 +73,7 @@ const finishSchema = z.object(agentInvestigationOutcomeSchema.shape).extend({
 		.min(1)
 		.max(2)
 		.describe(
-			"Every revenue_overview entry, including unchanged controls, must be {currency, fields}. Product and whole-currency entries cite separate result pairs. Use text only for other sources. Keep only comparisons that change the interpretation."
+			"Every revenue_overview entry, including unchanged controls, must be {currency, fields}. Receipt-description and whole-currency entries cite separate result pairs. Use text only for other sources. Keep only comparisons that change the interpretation."
 		),
 });
 
@@ -93,7 +93,7 @@ export function renderRevenueEvidence(
 	selection: z.infer<typeof revenueEvidenceSchema>,
 	sources: unknown,
 	input: Pick<InsightAgentInput, "appContext">
-): string {
+) {
 	const readings = z
 		.array(
 			revenueReadingSchema.extend({
@@ -162,30 +162,35 @@ export function renderRevenueEvidence(
 		const delta = values[1] - values[0];
 		return `${field.label ?? name.replaceAll("_", " ")}${field.unit ? ` (${field.unit})` : ""}: ${values.map((value) => format.format(value)).join(" → ")}${delta === 0 ? "" : ` (${delta > 0 ? "+" : ""}${format.format(delta)}${field.unit === "%" ? " pp" : ""})`}`;
 	});
-	const product = first.filters.find(
-		(filter) => filter.field === "product_id" && filter.op === "eq"
+	const description = first.filters.find(
+		(filter) => filter.field === "product_name" && filter.op === "eq"
 	);
 	const provider = first.filters.find(
 		(filter) => filter.field === "provider" && filter.op === "eq"
 	);
-	const population = product
-		? ` (${provider ? `${String(provider.value)} ` : ""}product ${String(product.value)})`
+	const population = description
+		? ` (${provider ? `${String(provider.value)} ` : ""}receipts described ${String(description.value)})`
 		: first.filters.some((filter) => filter.field !== "currency")
 			? " (filtered population)"
 			: "";
-	return `${selection.currency}${population}, ${readings.map((reading) => `${reading.from}–${reading.to}`).join(" → ")} ${first.timezone}: ${facts.join("; ")}.`;
+	return {
+		...selection,
+		readings,
+		rows,
+		text: `${selection.currency}${population}, ${readings.map((reading) => `${reading.from}–${reading.to}`).join(" → ")} ${first.timezone}: ${facts.join("; ")}.`,
+	};
 }
 
 function hasProductRevenueEvidence(
 	signal: InvestigationSignal,
-	evidence: z.infer<typeof finishSchema>["evidence"],
-	sources: unknown[][]
+	evidence: ReturnType<typeof renderRevenueEvidence>[]
 ): boolean {
-	const [, currency, provider] = signal.signalKey.split(":");
+	const [, currency, provider, selector] = signal.signalKey.split(":");
 	if (
+		selector !== "product_name" ||
 		signalKeyForDetectedSignal({
 			metric: "product_revenue",
-			subjectKey: `product_revenue:${currency}:${provider}:${encodeURIComponent(signal.entity.id)}`,
+			subjectKey: `product_revenue:${currency}:${provider}:product_name:${encodeURIComponent(signal.entity.id)}`,
 		}) !== signal.signalKey
 	) {
 		return false;
@@ -194,74 +199,42 @@ function hasProductRevenueEvidence(
 	const productFilters = [
 		...wholeFilters,
 		{ field: "provider", op: "eq", value: provider },
-		{ field: "product_id", op: "eq", value: signal.entity.id },
+		{ field: "product_name", op: "eq", value: signal.entity.id },
+		{ field: "product_id", op: "eq", value: "" },
 	].sort((a, b) => a.field.localeCompare(b.field));
-	let product: z.infer<typeof revenueReadingSchema>[] | undefined;
-	let whole: z.infer<typeof revenueReadingSchema>[] | undefined;
-	for (const [index, entry] of evidence.entries()) {
-		if (
-			typeof entry === "string" ||
-			entry.currency !== currency ||
-			!entry.fields.includes("total_revenue")
-		) {
-			continue;
-		}
-		const parsed = revenueReadingSchema
-			.array()
-			.length(2)
-			.safeParse(sources[index]);
-		if (!parsed.success) {
-			continue;
-		}
-		const pair = parsed.data.sort((a, b) => a.from.localeCompare(b.from));
-		if (
-			!pair.every((reading, position) => {
+	// Reuse the renderer's validated native rows, dates, currency and finite values.
+	const matching = evidence.filter(
+		(entry) =>
+			entry.currency === currency &&
+			entry.fields.includes("total_revenue") &&
+			entry.readings.every((reading, index) => {
 				const period =
-					position === 0 ? signal.period.previous : signal.period.current;
+					index === 0 ? signal.period.previous : signal.period.current;
 				return reading.from === period.from && reading.to === period.to;
 			})
-		) {
-			continue;
-		}
-		if (
-			pair.every((reading) =>
-				isDeepStrictEqual(
-					[...reading.filters].sort((a, b) => a.field.localeCompare(b.field)),
-					productFilters
-				)
+	);
+	const product = matching.find((entry) =>
+		entry.readings.every((reading) =>
+			isDeepStrictEqual(
+				[...reading.filters].sort((a, b) => a.field.localeCompare(b.field)),
+				productFilters
 			)
-		) {
-			product = pair;
-		}
-		if (
-			pair.every(
-				(reading) =>
-					reading.filters.length === 0 ||
-					isDeepStrictEqual(reading.filters, wholeFilters)
-			)
-		) {
-			whole = pair;
-		}
-	}
+		)
+	);
+	const whole = matching.find((entry) =>
+		entry.readings.every(
+			(reading) =>
+				reading.filters.length === 0 ||
+				isDeepStrictEqual(reading.filters, wholeFilters)
+		)
+	);
 	return Boolean(
 		product &&
 			whole &&
-			product.every((reading, index) => {
-				// renderRevenueEvidence already validates finite amounts and one currency row.
-				const amount = Number(
-					reading.data.find((row) => row.currency === currency)?.total_revenue
-				);
-				const total = Number(
-					whole[index].data.find((row) => row.currency === currency)
-						?.total_revenue
-				);
-				return (
-					Number.isFinite(amount) &&
-					Number.isFinite(total) &&
-					amount >= 0 &&
-					total > 0 &&
-					amount <= total
-				);
+			product.rows.every((row, index) => {
+				const amount = Number(row.total_revenue);
+				const total = Number(whole.rows[index].total_revenue);
+				return amount >= 0 && total > 0 && amount <= total;
 			})
 	);
 }
@@ -1126,7 +1099,7 @@ function validateAgentOutcome(
 		!hasNativeRevenueEvidence
 	) {
 		throw new Error(
-			"Product revenue findings require gross revenue evidence for this exact currency, provider and product_id, plus whole-currency gross controls, each from both complete signal windows. Use separate revenue_overview result pairs; a detector snapshot or limited product table cannot replace them."
+			"Receipt-description findings require gross revenue evidence for this exact currency, provider and product_name with product_id=empty string, plus whole-currency controls, each from both complete signal windows. Use separate revenue_overview pairs; a snapshot or limited table cannot replace them."
 		);
 	}
 	if (
@@ -1462,6 +1435,7 @@ export async function runInsightAgent(
 						input,
 						results
 					);
+					const nativeRevenue: ReturnType<typeof renderRevenueEvidence>[] = [];
 					const evidence = candidate.evidence.map((item, index) => {
 						if (typeof item !== "string") {
 							const references = candidate.evidenceRefs[index];
@@ -1474,7 +1448,13 @@ export async function runInsightAgent(
 									"Structured revenue evidence requires exact successful get_data result references."
 								);
 							}
-							return renderRevenueEvidence(item, citedEvidence[index], input);
+							const native = renderRevenueEvidence(
+								item,
+								citedEvidence[index],
+								input
+							);
+							nativeRevenue.push(native);
+							return native.text;
 						}
 						if (
 							citedEvidence[index].some(
@@ -1535,24 +1515,19 @@ export async function runInsightAgent(
 						results,
 						attemptedToolNames,
 						input.signal.signalKey.startsWith("product_revenue:")
-							? hasProductRevenueEvidence(
-									input.signal,
-									candidate.evidence,
-									citedEvidence
-								)
-							: candidate.evidence.some(
+							? hasProductRevenueEvidence(input.signal, nativeRevenue)
+							: nativeRevenue.some(
 									(item) =>
-										typeof item !== "string" &&
-										((item.fields.includes("total_revenue") &&
+										(item.fields.includes("total_revenue") &&
 											input.signal.signalKey === `revenue:${item.currency}`) ||
-											(item.fields.includes("refund_amount") &&
-												item.fields.includes("refund_count") &&
-												input.signal.signalKey ===
-													`refund_amount:${item.currency}`) ||
-											(item.fields.includes("attributed_revenue") &&
-												item.fields.includes("total_revenue") &&
-												input.signal.signalKey ===
-													`attribution_rate:${item.currency}`))
+										(item.fields.includes("refund_amount") &&
+											item.fields.includes("refund_count") &&
+											input.signal.signalKey ===
+												`refund_amount:${item.currency}`) ||
+										(item.fields.includes("attributed_revenue") &&
+											item.fields.includes("total_revenue") &&
+											input.signal.signalKey ===
+												`attribution_rate:${item.currency}`)
 								)
 					);
 					const serialize = (value: unknown) =>

--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -32,6 +32,7 @@ import {
 	ToolLoopAgent,
 } from "ai";
 import type { ErrorCustomerImpact } from "./error-customer-impact";
+import { signalKeyForDetectedSignal } from "./investigation";
 
 const MAX_STEPS = 8;
 const TIMEOUT_MS = 2 * 60_000;
@@ -59,7 +60,7 @@ const revenueEvidenceSchema = z
 			.max(4),
 	})
 	.describe(
-		"For revenue_overview, select complementary fields: gross revenue, settled transactions, refunds, and attributed revenue when it differs from gross. Select only fields with a non-null value in every cited period. Omit redundant subtotals and diagnostic availability flags. One entry per currency; use a second for a useful currency control. Cite both complete comparison windows in each evidenceRefs entry. Code supplies labels, values, periods and deltas; preserve supported comparisons when correcting format."
+		"For revenue_overview, select complementary fields: gross revenue, settled transactions, refunds, and attributed revenue when it differs from gross. Select only fields with a non-null value in every cited period. Omit redundant subtotals and diagnostic availability flags. One entry per measured population; a product comparison uses a second entry for the whole-currency control. Cite both complete comparison windows in each evidenceRefs entry. Code supplies labels, values, periods and deltas; preserve supported comparisons when correcting format."
 	);
 const finishSchema = z.object(agentInvestigationOutcomeSchema.shape).extend({
 	evidence: z
@@ -72,8 +73,20 @@ const finishSchema = z.object(agentInvestigationOutcomeSchema.shape).extend({
 		.min(1)
 		.max(2)
 		.describe(
-			"Every revenue_overview entry, including unchanged controls, must be {currency, fields}. Use text only for other sources. Keep only comparisons that change the interpretation."
+			"Every revenue_overview entry, including unchanged controls, must be {currency, fields}. Product and whole-currency entries cite separate result pairs. Use text only for other sources. Keep only comparisons that change the interpretation."
 		),
+});
+
+const revenueReadingSchema = z.object({
+	type: z.literal("revenue_overview"),
+	websiteId: z.string().min(1),
+	from: z.iso.date(),
+	to: z.iso.date(),
+	timezone: z.string(),
+	filters: z.array(
+		z.object({ field: z.string(), op: z.string(), value: z.unknown() })
+	),
+	data: z.array(z.record(z.string(), z.unknown())),
 });
 
 export function renderRevenueEvidence(
@@ -83,8 +96,7 @@ export function renderRevenueEvidence(
 ): string {
 	const readings = z
 		.array(
-			z.object({
-				type: z.literal("revenue_overview"),
+			revenueReadingSchema.extend({
 				websiteId: z.literal(
 					z
 						.string()
@@ -93,13 +105,7 @@ export function renderRevenueEvidence(
 							input.appContext.websiteId ?? input.appContext.defaultWebsiteId
 						)
 				),
-				from: z.iso.date(),
-				to: z.iso.date(),
 				timezone: z.literal(input.appContext.timezone ?? "UTC"),
-				filters: z.array(
-					z.object({ field: z.string(), op: z.string(), value: z.unknown() })
-				),
-				data: z.array(z.record(z.string(), z.unknown())),
 			})
 		)
 		.length(2)
@@ -156,7 +162,108 @@ export function renderRevenueEvidence(
 		const delta = values[1] - values[0];
 		return `${field.label ?? name.replaceAll("_", " ")}${field.unit ? ` (${field.unit})` : ""}: ${values.map((value) => format.format(value)).join(" → ")}${delta === 0 ? "" : ` (${delta > 0 ? "+" : ""}${format.format(delta)}${field.unit === "%" ? " pp" : ""})`}`;
 	});
-	return `${selection.currency}${first.filters.some((filter) => filter.field !== "currency") ? " (filtered population)" : ""}, ${readings.map((reading) => `${reading.from}–${reading.to}`).join(" → ")} ${first.timezone}: ${facts.join("; ")}.`;
+	const product = first.filters.find(
+		(filter) => filter.field === "product_id" && filter.op === "eq"
+	);
+	const provider = first.filters.find(
+		(filter) => filter.field === "provider" && filter.op === "eq"
+	);
+	const population = product
+		? ` (${provider ? `${String(provider.value)} ` : ""}product ${String(product.value)})`
+		: first.filters.some((filter) => filter.field !== "currency")
+			? " (filtered population)"
+			: "";
+	return `${selection.currency}${population}, ${readings.map((reading) => `${reading.from}–${reading.to}`).join(" → ")} ${first.timezone}: ${facts.join("; ")}.`;
+}
+
+function hasProductRevenueEvidence(
+	signal: InvestigationSignal,
+	evidence: z.infer<typeof finishSchema>["evidence"],
+	sources: unknown[][]
+): boolean {
+	const [, currency, provider] = signal.signalKey.split(":");
+	if (
+		signalKeyForDetectedSignal({
+			metric: "product_revenue",
+			subjectKey: `product_revenue:${currency}:${provider}:${encodeURIComponent(signal.entity.id)}`,
+		}) !== signal.signalKey
+	) {
+		return false;
+	}
+	const wholeFilters = [{ field: "currency", op: "eq", value: currency }];
+	const productFilters = [
+		...wholeFilters,
+		{ field: "provider", op: "eq", value: provider },
+		{ field: "product_id", op: "eq", value: signal.entity.id },
+	].sort((a, b) => a.field.localeCompare(b.field));
+	let product: z.infer<typeof revenueReadingSchema>[] | undefined;
+	let whole: z.infer<typeof revenueReadingSchema>[] | undefined;
+	for (const [index, entry] of evidence.entries()) {
+		if (
+			typeof entry === "string" ||
+			entry.currency !== currency ||
+			!entry.fields.includes("total_revenue")
+		) {
+			continue;
+		}
+		const parsed = revenueReadingSchema
+			.array()
+			.length(2)
+			.safeParse(sources[index]);
+		if (!parsed.success) {
+			continue;
+		}
+		const pair = parsed.data.sort((a, b) => a.from.localeCompare(b.from));
+		if (
+			!pair.every((reading, position) => {
+				const period =
+					position === 0 ? signal.period.previous : signal.period.current;
+				return reading.from === period.from && reading.to === period.to;
+			})
+		) {
+			continue;
+		}
+		if (
+			pair.every((reading) =>
+				isDeepStrictEqual(
+					[...reading.filters].sort((a, b) => a.field.localeCompare(b.field)),
+					productFilters
+				)
+			)
+		) {
+			product = pair;
+		}
+		if (
+			pair.every(
+				(reading) =>
+					reading.filters.length === 0 ||
+					isDeepStrictEqual(reading.filters, wholeFilters)
+			)
+		) {
+			whole = pair;
+		}
+	}
+	return Boolean(
+		product &&
+			whole &&
+			product.every((reading, index) => {
+				// renderRevenueEvidence already validates finite amounts and one currency row.
+				const amount = Number(
+					reading.data.find((row) => row.currency === currency)?.total_revenue
+				);
+				const total = Number(
+					whole[index].data.find((row) => row.currency === currency)
+						?.total_revenue
+				);
+				return (
+					Number.isFinite(amount) &&
+					Number.isFinite(total) &&
+					amount >= 0 &&
+					total > 0 &&
+					amount <= total
+				);
+			})
+	);
 }
 
 function aggregateUsage(usages: LanguageModelUsage[]): LanguageModelUsage {
@@ -1015,6 +1122,15 @@ function validateAgentOutcome(
 	}
 	if (
 		outcome.publish &&
+		signalKey.startsWith("product_revenue:") &&
+		!hasNativeRevenueEvidence
+	) {
+		throw new Error(
+			"Product revenue findings require gross revenue evidence for this exact currency, provider and product_id, plus whole-currency gross controls, each from both complete signal windows. Use separate revenue_overview result pairs; a detector snapshot or limited product table cannot replace them."
+		);
+	}
+	if (
+		outcome.publish &&
 		signalKey.startsWith("attribution_rate:") &&
 		!hasNativeRevenueEvidence
 	) {
@@ -1418,20 +1534,26 @@ export async function runInsightAgent(
 						usedToolNames,
 						results,
 						attemptedToolNames,
-						candidate.evidence.some(
-							(item) =>
-								typeof item !== "string" &&
-								((item.fields.includes("total_revenue") &&
-									input.signal.signalKey === `revenue:${item.currency}`) ||
-									(item.fields.includes("refund_amount") &&
-										item.fields.includes("refund_count") &&
-										input.signal.signalKey ===
-											`refund_amount:${item.currency}`) ||
-									(item.fields.includes("attributed_revenue") &&
-										item.fields.includes("total_revenue") &&
-										input.signal.signalKey ===
-											`attribution_rate:${item.currency}`))
-						)
+						input.signal.signalKey.startsWith("product_revenue:")
+							? hasProductRevenueEvidence(
+									input.signal,
+									candidate.evidence,
+									citedEvidence
+								)
+							: candidate.evidence.some(
+									(item) =>
+										typeof item !== "string" &&
+										((item.fields.includes("total_revenue") &&
+											input.signal.signalKey === `revenue:${item.currency}`) ||
+											(item.fields.includes("refund_amount") &&
+												item.fields.includes("refund_count") &&
+												input.signal.signalKey ===
+													`refund_amount:${item.currency}`) ||
+											(item.fields.includes("attributed_revenue") &&
+												item.fields.includes("total_revenue") &&
+												input.signal.signalKey ===
+													`attribution_rate:${item.currency}`))
+								)
 					);
 					const serialize = (value: unknown) =>
 						JSON.stringify(value, (_key, item) =>

--- a/apps/insights/src/coverage-planner.ts
+++ b/apps/insights/src/coverage-planner.ts
@@ -81,6 +81,9 @@ export function coveragePortfolioLimit(
 }
 
 function signalGroup(signal: DetectedSignal): string {
+	if (signal.subjectKey?.startsWith("product_revenue:")) {
+		return signal.subjectKey.split(":").slice(0, 2).join(":");
+	}
 	if (signal.subjectKey?.includes(":referrer:")) {
 		return signal.subjectKey;
 	}

--- a/apps/insights/src/coverage-planner.ts
+++ b/apps/insights/src/coverage-planner.ts
@@ -81,9 +81,6 @@ export function coveragePortfolioLimit(
 }
 
 function signalGroup(signal: DetectedSignal): string {
-	if (signal.subjectKey?.startsWith("product_revenue:")) {
-		return signal.subjectKey.split(":").slice(0, 2).join(":");
-	}
 	if (signal.subjectKey?.includes(":referrer:")) {
 		return signal.subjectKey;
 	}

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -411,7 +411,7 @@ function makeProductRevenueSignal(
 		entityId: current.name,
 		entityLabel: label,
 		investigationObjective:
-			"Explain the gross receipts change for this recorded payment description against whole-currency revenue. Confirm revenue_overview in both windows with currency, provider, product_name=signal.entity.id and product_id=empty string, plus currency-only controls. These are payment descriptions, not verified catalog products. Do not infer churn, causality or an absent description from a limited table.",
+			"Find material changes in the composition of settled receipts, even when total revenue is flat. A verified material receipt-description shift is a measured business result and can publish with resolve when no cause or repair is known. Confirm revenue_overview for both windows: currency, provider, product_name=signal.entity.id and product_id=empty string, plus a separate currency-only whole control. These are payment descriptions, not verified catalog products. Do not infer churn, causality or absence from a limited table.",
 		definitionEvidence: `${current.provider} receipts described ${JSON.stringify(current.name)} with no product ID, ${current.currency} gross settled revenue excluding refunds: ${previous.revenue} across ${previous.transactions} transactions → ${current.revenue} across ${current.transactions}. Whole-currency gross: ${p.total_revenue} → ${c.total_revenue}; receipt-description share: ${round2(previousShare)}% → ${round2(currentShare)}%. Remaining gross: ${p.total_revenue - previous.revenue} → ${c.total_revenue - current.revenue}. Confirm description and whole controls with native revenue_overview; the snapshot alone cannot support publication.`,
 	};
 }

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -334,7 +334,7 @@ const productRevenueRowSchema = z.object({
 	product_id: z.union([z.null(), z.literal("")]),
 	name: z
 		.string()
-		.refine((value) => value.trim().length > 0 && value !== "Unknown"),
+		.refine((value) => value.trim().length > 0 && value.trim() !== "Unknown"),
 	revenue: commercialNumberSchema.pipe(z.number().nonnegative()),
 	transactions: commercialNumberSchema.pipe(z.number().int().nonnegative()),
 });

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -15,7 +15,7 @@ import {
 	type RouteContinuationComparison,
 } from "./error-customer-impact";
 import { emitInsightsEvent } from "./lib/evlog-insights";
-import { signalKeyForDetectedSignal } from "./investigation";
+import { rankSignals, signalKeyForDetectedSignal } from "./investigation";
 
 dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
@@ -300,7 +300,7 @@ function makeRevenueSignal(
 		),
 		subjectKey: `revenue:${currency}`,
 		investigationObjective:
-			"Find which measured products account for the gross revenue change and what decision that concentration changes. Inspect an available revenue_by_product breakdown; separate missing product coverage from an unchanged product. Do not infer profit, acquisition ROI or subscription churn.",
+			"Find which measured receipt groups account for the gross revenue change and what decision that concentration changes. Inspect revenue_by_product; its names can be payment or invoice descriptions, not verified catalog products. Separate missing coverage from an unchanged group. Do not infer profit, acquisition ROI or subscription churn.",
 		definitionEvidence: `Business meaning: gross settled revenue in ${currency}, excluding refunds. The snapshot alone is not publication evidence: confirm with revenue_overview for this currency across both complete signal windows.`,
 	};
 }
@@ -331,8 +331,10 @@ const commercialOverviewSchema = z.object({
 const productRevenueRowSchema = z.object({
 	currency: z.string().regex(/^[A-Z]{3}$/),
 	provider: z.string().regex(/^[a-z][a-z0-9_-]{0,31}$/),
-	product_id: z.string().min(1),
-	name: z.string(),
+	product_id: z.union([z.null(), z.literal("")]),
+	name: z
+		.string()
+		.refine((value) => value.trim().length > 0 && value !== "Unknown"),
 	revenue: commercialNumberSchema.pipe(z.number().nonnegative()),
 	transactions: commercialNumberSchema.pipe(z.number().int().nonnegative()),
 });
@@ -346,7 +348,7 @@ function productRevenueRows(rows: Record<string, unknown>[]) {
 			continue;
 		}
 		const product = parsed.data;
-		const key = `product_revenue:${product.currency}:${product.provider}:${encodeURIComponent(product.product_id)}`;
+		const key = `product_revenue:${product.currency}:${product.provider}:product_name:${encodeURIComponent(product.name)}`;
 		if (products.has(key)) {
 			ambiguous.add(key);
 		}
@@ -396,22 +398,21 @@ function makeProductRevenueSignal(
 	) {
 		return null;
 	}
-	const label =
-		current.name.trim() || previous.name.trim() || current.product_id;
+	const label = current.name.trim();
 	return {
 		...makeWowSignal(
 			"product_revenue",
-			`${label} ${current.currency} gross revenue`,
+			`${label} ${current.currency} receipts`,
 			current.revenue,
 			previous.revenue,
 			detectedAt
 		),
-		subjectKey: `product_revenue:${current.currency}:${current.provider}:${encodeURIComponent(current.product_id)}`,
-		entityId: current.product_id,
+		subjectKey: `product_revenue:${current.currency}:${current.provider}:product_name:${encodeURIComponent(current.name)}`,
+		entityId: current.name,
 		entityLabel: label,
 		investigationObjective:
-			"Explain this product's gross revenue shift against the whole-currency control, including what offsets or concentrates it. Confirm revenue_overview in both windows with currency, provider and product_id filters, plus currency-only whole controls. Do not infer churn, profit, causality or an absent product from a limited breakdown.",
-		definitionEvidence: `${current.provider} product_id=${current.product_id}, ${current.currency} gross settled revenue excluding refunds: ${previous.revenue} across ${previous.transactions} transactions → ${current.revenue} across ${current.transactions}. Whole-currency gross: ${p.total_revenue} → ${c.total_revenue}; product share: ${round2(previousShare)}% → ${round2(currentShare)}%. Remaining gross: ${p.total_revenue - previous.revenue} → ${c.total_revenue - current.revenue}. Confirm product and whole controls with native revenue_overview; the snapshot alone cannot support publication.`,
+			"Explain the gross receipts change for this recorded payment description against whole-currency revenue. Confirm revenue_overview in both windows with currency, provider, product_name=signal.entity.id and product_id=empty string, plus currency-only controls. These are payment descriptions, not verified catalog products. Do not infer churn, causality or an absent description from a limited table.",
+		definitionEvidence: `${current.provider} receipts described ${JSON.stringify(current.name)} with no product ID, ${current.currency} gross settled revenue excluding refunds: ${previous.revenue} across ${previous.transactions} transactions → ${current.revenue} across ${current.transactions}. Whole-currency gross: ${p.total_revenue} → ${c.total_revenue}; receipt-description share: ${round2(previousShare)}% → ${round2(currentShare)}%. Remaining gross: ${p.total_revenue - previous.revenue} → ${c.total_revenue - current.revenue}. Confirm description and whole controls with native revenue_overview; the snapshot alone cannot support publication.`,
 	};
 }
 
@@ -978,14 +979,15 @@ export async function remeasureMetricSignal(
 	}
 
 	if (prior.signalKey.startsWith("product_revenue:")) {
-		const [, currency, provider] = prior.signalKey.split(":");
+		const [, currency, provider, selector] = prior.signalKey.split(":");
 		if (
 			normalizeCurrencyCode(currency) !== currency ||
+			selector !== "product_name" ||
 			!provider ||
 			!prior.entity.id ||
 			signalKeyForDetectedSignal({
 				metric: "product_revenue",
-				subjectKey: `product_revenue:${currency}:${provider}:${encodeURIComponent(prior.entity.id)}`,
+				subjectKey: `product_revenue:${currency}:${provider}:product_name:${encodeURIComponent(prior.entity.id)}`,
 			}) !== prior.signalKey
 		) {
 			return null;
@@ -996,40 +998,28 @@ export async function remeasureMetricSignal(
 			value: currency,
 		} as const;
 		const [product, whole] = await Promise.all([
-			readPair("revenue", "revenue_overview", [
+			readPair("revenue", "revenue_by_product", [
 				currencyFilter,
 				{ field: "provider", op: "eq", value: provider },
-				{ field: "product_id", op: "eq", value: prior.entity.id },
+				{ field: "product_name", op: "eq", value: prior.entity.id },
+				{ field: "product_id", op: "eq", value: "" },
 			]),
 			readPair("revenue", "revenue_overview", [currencyFilter]),
 		]);
 		if (!(product.value && whole.value)) {
 			return null;
 		}
-		const productRows = product.value.map((rows) =>
-			rows.filter((row) => row.currency === currency)
+		const key = `product_revenue:${currency}:${provider}:product_name:${encodeURIComponent(prior.entity.id)}`;
+		const [current, previous] = product.value.map((rows) =>
+			productRevenueRows(rows).get(key)
 		);
 		const wholeRows = whole.value.map((rows) =>
 			rows.filter((row) => row.currency === currency)
 		);
-		if ([...productRows, ...wholeRows].some((rows) => rows.length !== 1)) {
-			return null;
-		}
-		const readings = productRows.map(([row]) =>
-			productRevenueRowSchema.safeParse({
-				currency,
-				provider,
-				product_id: prior.entity.id,
-				name: prior.entity.label,
-				revenue: row.total_revenue,
-				transactions: row.total_transactions,
-			})
-		);
-		const [current, previous] = readings;
-		return current.success && previous.success
+		return current && previous && wholeRows.every((rows) => rows.length === 1)
 			? makeProductRevenueSignal(
-					current.data,
-					previous.data,
+					current,
+					previous,
 					wholeRows[0][0],
 					wholeRows[1][0],
 					currentTo,
@@ -1433,7 +1423,8 @@ async function detectWow(
 		type: string,
 		from: string,
 		to: string,
-		options: { filters?: Filter[]; limit?: number } = {}
+		options: { filters?: Filter[]; limit?: number } = {},
+		signal = abortSignal
 	) {
 		return queryFn(
 			{
@@ -1446,7 +1437,7 @@ async function detectWow(
 			},
 			undefined,
 			timezone,
-			abortSignal
+			signal
 		);
 	}
 
@@ -1701,7 +1692,6 @@ async function detectWow(
 	}
 
 	// Two bounded discovery reads; a missing top-table row never becomes zero.
-	let productRevenueFailed = false;
 	if (
 		currentRevenue.some(
 			(row) =>
@@ -1714,20 +1704,37 @@ async function detectWow(
 				) >= 20
 		)
 	) {
-		const products = await readDetectorPair({
-			abortSignal,
-			current: () =>
-				query("revenue_by_product", currentFrom, currentTo, { limit: 20 }),
-			family: "revenue",
-			previous: () =>
-				query("revenue_by_product", previousFrom, previousTo, { limit: 20 }),
-			websiteId,
-		});
-		productRevenueFailed = products.failed;
-		if (products.value) {
-			const [currentRows, previousRows] =
-				products.value.map(productRevenueRows);
+		const probeSignal = AbortSignal.any([
+			...(abortSignal ? [abortSignal] : []),
+			AbortSignal.timeout(3000),
+		]);
+		const [currentProbe, previousProbe] = await Promise.allSettled([
+			query(
+				"revenue_by_product",
+				currentFrom,
+				currentTo,
+				{ limit: 20 },
+				probeSignal
+			),
+			query(
+				"revenue_by_product",
+				previousFrom,
+				previousTo,
+				{ limit: 20 },
+				probeSignal
+			),
+		]);
+		abortSignal?.throwIfAborted();
+		if (
+			currentProbe.status === "fulfilled" &&
+			previousProbe.status === "fulfilled"
+		) {
+			const [currentRows, previousRows] = [
+				currentProbe.value,
+				previousProbe.value,
+			].map(productRevenueRows);
 			const currentWhole = mapRowsByStringField(currentRevenue, "currency");
+			const movements: DetectedSignal[] = [];
 			for (const [key, current] of currentRows) {
 				const previous = previousRows.get(key);
 				if (!previous) {
@@ -1741,9 +1748,27 @@ async function detectWow(
 					currentTo
 				);
 				if (productSignal) {
-					signals.push(productSignal);
+					movements.push(productSignal);
 				}
 			}
+			// Keep the same covered movement on an identical next run, rather than rotating to its offset.
+			const coveredCurrencies = new Map<string, DetectedSignal>();
+			movements.sort((a, b) =>
+				(a.subjectKey ?? "").localeCompare(b.subjectKey ?? "")
+			);
+			for (const movement of rankSignals(movements).reverse()) {
+				coveredCurrencies.set(
+					movement.subjectKey?.split(":")[1] ?? "",
+					movement
+				);
+			}
+			signals.push(...coveredCurrencies.values());
+		} else {
+			emitInsightsEvent(
+				"warn",
+				"generation.detection.optional_product_unavailable",
+				{ website_id: websiteId }
+			);
 		}
 	}
 
@@ -1799,9 +1824,7 @@ async function detectWow(
 	return {
 		failedFamilies:
 			[summary, errors, revenue, vitals].filter((result) => result.failed)
-				.length +
-			(customEventsFailed ? 1 : 0) +
-			(productRevenueFailed ? 1 : 0),
+				.length + (customEventsFailed ? 1 : 0),
 		signals,
 		weeklySessions:
 			(Math.max(

--- a/apps/insights/src/detection.ts
+++ b/apps/insights/src/detection.ts
@@ -15,6 +15,7 @@ import {
 	type RouteContinuationComparison,
 } from "./error-customer-impact";
 import { emitInsightsEvent } from "./lib/evlog-insights";
+import { signalKeyForDetectedSignal } from "./investigation";
 
 dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
@@ -326,6 +327,93 @@ const commercialOverviewSchema = z.object({
 		.nullish()
 		.catch(null),
 });
+
+const productRevenueRowSchema = z.object({
+	currency: z.string().regex(/^[A-Z]{3}$/),
+	provider: z.string().regex(/^[a-z][a-z0-9_-]{0,31}$/),
+	product_id: z.string().min(1),
+	name: z.string(),
+	revenue: commercialNumberSchema.pipe(z.number().nonnegative()),
+	transactions: commercialNumberSchema.pipe(z.number().int().nonnegative()),
+});
+
+function productRevenueRows(rows: Record<string, unknown>[]) {
+	const products = new Map<string, z.infer<typeof productRevenueRowSchema>>();
+	const ambiguous = new Set<string>();
+	for (const row of rows) {
+		const parsed = productRevenueRowSchema.safeParse(row);
+		if (!parsed.success) {
+			continue;
+		}
+		const product = parsed.data;
+		const key = `product_revenue:${product.currency}:${product.provider}:${encodeURIComponent(product.product_id)}`;
+		if (products.has(key)) {
+			ambiguous.add(key);
+		}
+		products.set(key, product);
+	}
+	for (const key of ambiguous) {
+		products.delete(key);
+	}
+	return products;
+}
+
+function makeProductRevenueSignal(
+	current: z.infer<typeof productRevenueRowSchema>,
+	previous: z.infer<typeof productRevenueRowSchema>,
+	currentWhole: unknown,
+	previousWhole: unknown,
+	detectedAt: string,
+	applyThreshold = true
+): DetectedSignal | null {
+	const cur = commercialOverviewSchema.safeParse(currentWhole);
+	const prev = commercialOverviewSchema.safeParse(previousWhole);
+	if (!(cur.success && prev.success)) {
+		return null;
+	}
+	const c = cur.data;
+	const p = prev.data;
+	if (
+		normalizeCurrencyCode(current.currency) !== current.currency ||
+		Math.min(c.total_transactions, p.total_transactions) < 20 ||
+		Math.min(c.total_revenue, p.total_revenue) <= 0 ||
+		current.revenue > c.total_revenue ||
+		previous.revenue > p.total_revenue ||
+		current.transactions > c.total_transactions ||
+		previous.transactions > p.total_transactions
+	) {
+		return null;
+	}
+	const currentShare = (100 * current.revenue) / c.total_revenue;
+	const previousShare = (100 * previous.revenue) / p.total_revenue;
+	if (
+		applyThreshold &&
+		(Math.max(current.transactions, previous.transactions) < 10 ||
+			Math.abs(current.revenue - previous.revenue) <
+				0.05 * Math.max(c.total_revenue, p.total_revenue) ||
+			Math.abs(safeDeltaPercent(current.revenue, previous.revenue)) < 30 ||
+			Math.abs(currentShare - previousShare) < 10)
+	) {
+		return null;
+	}
+	const label =
+		current.name.trim() || previous.name.trim() || current.product_id;
+	return {
+		...makeWowSignal(
+			"product_revenue",
+			`${label} ${current.currency} gross revenue`,
+			current.revenue,
+			previous.revenue,
+			detectedAt
+		),
+		subjectKey: `product_revenue:${current.currency}:${current.provider}:${encodeURIComponent(current.product_id)}`,
+		entityId: current.product_id,
+		entityLabel: label,
+		investigationObjective:
+			"Explain this product's gross revenue shift against the whole-currency control, including what offsets or concentrates it. Confirm revenue_overview in both windows with currency, provider and product_id filters, plus currency-only whole controls. Do not infer churn, profit, causality or an absent product from a limited breakdown.",
+		definitionEvidence: `${current.provider} product_id=${current.product_id}, ${current.currency} gross settled revenue excluding refunds: ${previous.revenue} across ${previous.transactions} transactions → ${current.revenue} across ${current.transactions}. Whole-currency gross: ${p.total_revenue} → ${c.total_revenue}; product share: ${round2(previousShare)}% → ${round2(currentShare)}%. Remaining gross: ${p.total_revenue - previous.revenue} → ${c.total_revenue - current.revenue}. Confirm product and whole controls with native revenue_overview; the snapshot alone cannot support publication.`,
+	};
+}
 
 function commercialSignals(
 	currency: string,
@@ -887,6 +975,67 @@ export async function remeasureMetricSignal(
 				: "custom_event_count",
 			prior.signalKey
 		);
+	}
+
+	if (prior.signalKey.startsWith("product_revenue:")) {
+		const [, currency, provider] = prior.signalKey.split(":");
+		if (
+			normalizeCurrencyCode(currency) !== currency ||
+			!provider ||
+			!prior.entity.id ||
+			signalKeyForDetectedSignal({
+				metric: "product_revenue",
+				subjectKey: `product_revenue:${currency}:${provider}:${encodeURIComponent(prior.entity.id)}`,
+			}) !== prior.signalKey
+		) {
+			return null;
+		}
+		const currencyFilter = {
+			field: "currency",
+			op: "eq",
+			value: currency,
+		} as const;
+		const [product, whole] = await Promise.all([
+			readPair("revenue", "revenue_overview", [
+				currencyFilter,
+				{ field: "provider", op: "eq", value: provider },
+				{ field: "product_id", op: "eq", value: prior.entity.id },
+			]),
+			readPair("revenue", "revenue_overview", [currencyFilter]),
+		]);
+		if (!(product.value && whole.value)) {
+			return null;
+		}
+		const productRows = product.value.map((rows) =>
+			rows.filter((row) => row.currency === currency)
+		);
+		const wholeRows = whole.value.map((rows) =>
+			rows.filter((row) => row.currency === currency)
+		);
+		if ([...productRows, ...wholeRows].some((rows) => rows.length !== 1)) {
+			return null;
+		}
+		const readings = productRows.map(([row]) =>
+			productRevenueRowSchema.safeParse({
+				currency,
+				provider,
+				product_id: prior.entity.id,
+				name: prior.entity.label,
+				revenue: row.total_revenue,
+				transactions: row.total_transactions,
+			})
+		);
+		const [current, previous] = readings;
+		return current.success && previous.success
+			? makeProductRevenueSignal(
+					current.data,
+					previous.data,
+					wholeRows[0][0],
+					wholeRows[1][0],
+					currentTo,
+					false
+				)
+			: null;
 	}
 
 	if (
@@ -1551,6 +1700,53 @@ async function detectWow(
 		}
 	}
 
+	// Two bounded discovery reads; a missing top-table row never becomes zero.
+	let productRevenueFailed = false;
+	if (
+		currentRevenue.some(
+			(row) =>
+				Math.min(
+					numberField(row, "total_transactions"),
+					numberField(
+						previousCurrencies.get(String(row.currency)),
+						"total_transactions"
+					)
+				) >= 20
+		)
+	) {
+		const products = await readDetectorPair({
+			abortSignal,
+			current: () =>
+				query("revenue_by_product", currentFrom, currentTo, { limit: 20 }),
+			family: "revenue",
+			previous: () =>
+				query("revenue_by_product", previousFrom, previousTo, { limit: 20 }),
+			websiteId,
+		});
+		productRevenueFailed = products.failed;
+		if (products.value) {
+			const [currentRows, previousRows] =
+				products.value.map(productRevenueRows);
+			const currentWhole = mapRowsByStringField(currentRevenue, "currency");
+			for (const [key, current] of currentRows) {
+				const previous = previousRows.get(key);
+				if (!previous) {
+					continue;
+				}
+				const productSignal = makeProductRevenueSignal(
+					current,
+					previous,
+					currentWhole.get(current.currency),
+					previousCurrencies.get(current.currency),
+					currentTo
+				);
+				if (productSignal) {
+					signals.push(productSignal);
+				}
+			}
+		}
+	}
+
 	const vitalsCurrentMap = mapRowsByStringField(currentVitals, "metric_name");
 	const vitalsPreviousMap = mapRowsByStringField(previousVitals, "metric_name");
 
@@ -1603,7 +1799,9 @@ async function detectWow(
 	return {
 		failedFamilies:
 			[summary, errors, revenue, vitals].filter((result) => result.failed)
-				.length + (customEventsFailed ? 1 : 0),
+				.length +
+			(customEventsFailed ? 1 : 0) +
+			(productRevenueFailed ? 1 : 0),
 		signals,
 		weeklySessions:
 			(Math.max(

--- a/apps/insights/src/generation-sources.test.ts
+++ b/apps/insights/src/generation-sources.test.ts
@@ -2,7 +2,7 @@ import "@databuddy/test/env";
 import { describe, expect, it } from "bun:test";
 import type { InvestigationOutcome } from "@databuddy/shared/insights";
 import { InsightAgentGenerationError } from "./agent";
-import type { DetectedSignal } from "./detection";
+import { detectSignals, type DetectedSignal } from "./detection";
 import {
 	detectFunnelGoalSignals,
 	type FunnelDef,
@@ -1203,6 +1203,85 @@ describe("fixture investigation sources", () => {
 });
 
 describe("native definition detection in portfolio generation", () => {
+	it.each([
+		false,
+		true,
+	])("keeps optional product failure separate from core revenue failure=%s", async (coreFails) => {
+		const seen: string[] = [];
+		let productReads = 0;
+		const sources = fixtureSources({
+			detectMetricSignals: async (
+				params,
+				_query,
+				today,
+				abortSignal,
+				diagnostics
+			) =>
+				detectSignals(
+					params,
+					async (request) => {
+						if (request.type === "revenue_by_product") {
+							productReads += 1;
+							throw new DOMException(
+								"optional product breakdown aborted",
+								"AbortError"
+							);
+						}
+						if (request.type !== "revenue_overview") return [];
+						if (coreFails) throw new Error("core revenue unavailable");
+						return [
+							{
+								currency: "USD",
+								total_revenue: 40000,
+								total_transactions: 400,
+								refund_amount: request.from === "2026-07-05" ? -2500 : -500,
+								refund_count: request.from === "2026-07-05" ? 25 : 5,
+							},
+						];
+					},
+					today,
+					abortSignal,
+					diagnostics
+				),
+			detectDefinitionSignals: async () => [],
+			loadDueInvestigation: async () => null,
+			loadHistory: async () => [],
+			loadObservations: async () => new Map(),
+			fetchAnnotations: async () => [],
+			investigateSignal: async (input) => {
+				seen.push(input.signal.signalKey);
+				return {
+					outcome: {
+						title: "Refund amounts increased",
+						summary: "Refunds changed behind steady receipts.",
+						rootCause: null,
+						evidence: ["Refunds increased in the measured comparison."],
+						publish: false,
+						next: {
+							type: "resolve",
+							reason: "Synthetic generation-boundary control.",
+						},
+					},
+					toolCallCount: 0,
+				};
+			},
+		});
+		const run = investigateFixture(sources, {}, undefined, "scheduled");
+		if (coreFails) {
+			await expect(run).rejects.toThrow(
+				"1 metric families and 0 conversion definitions failed"
+			);
+			expect(seen).toEqual([]);
+		} else {
+			expect(await run).toMatchObject({
+				status: "completed",
+				signal: { signalKey: "refund_amount:USD" },
+			});
+			expect(seen).toEqual(["refund_amount:USD"]);
+			expect(productReads).toBe(2);
+		}
+	});
+
 	it.each([
 		false,
 		true,

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -3283,7 +3283,7 @@ describe("structured revenue evidence", () => {
 			const result = await run;
 			expect(result.outcome.publish).toBe(true);
 			expect(result.outcome.evidence[0]).toContain(
-				"stripe receipts described Team"
+				"stripe receipts described Team with no product ID"
 			);
 			expect(result.outcome.evidence[1]).toContain("40,000 → 40,000");
 		} else if (variant === "private")
@@ -3294,6 +3294,18 @@ describe("structured revenue evidence", () => {
 	it("binds metrics to their labels and computes a refund delta absent from the source", () => {
 		expect(renderRevenueEvidence(selection, readings, input).text).toBe(
 			"USD, 2026-06-28–2026-07-04 → 2026-07-05–2026-07-11 UTC: Gross Revenue: 10,000 → 10,000; Settled Transactions: 100 → 100; Refund Amount: 200 → 1,200 (+1,000)."
+		);
+	});
+	it("does not describe an unrestricted receipt-name population as unidentified", () => {
+		const named = readings.map((reading) => ({
+			...reading,
+			filters: [{ field: "product_name", op: "eq", value: "Team" }],
+		}));
+		expect(renderRevenueEvidence(selection, named, input).text).toContain(
+			"receipts described Team)"
+		);
+		expect(renderRevenueEvidence(selection, named, input).text).not.toContain(
+			"no product ID"
 		);
 	});
 

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -3125,6 +3125,164 @@ describe("structured revenue evidence", () => {
 			await expect(run).rejects.toThrow("Attribution findings require native");
 	});
 
+	it.each([
+		"valid",
+		"missing-control",
+		"snapshot",
+		"wrong-product",
+		"wrong-provider",
+		"wrong-currency",
+		"filtered-control",
+		"wrong-period",
+		"missing-row",
+		"null-amount",
+		"exceeds-control",
+		"private",
+	] as const)("binds product publication to exact native subject and whole controls: %s", async (variant) => {
+		const productSignal: InvestigationSignal = {
+			...signal,
+			signalKey: "product_revenue:USD:stripe:team",
+			entity: { type: "website", id: "team", label: "Team" },
+			metric: {
+				label: "Team USD gross revenue",
+				current: 15000,
+				previous: 30000,
+				format: "number",
+			},
+		};
+		const productReadings = readings.map((reading, index) => ({
+			...reading,
+			...(variant === "wrong-period"
+				? {
+						from: index === 0 ? "2026-06-14" : "2026-06-07",
+						to: index === 0 ? "2026-06-20" : "2026-06-13",
+					}
+				: {}),
+			filters: [
+				{
+					field: "currency",
+					op: "eq",
+					value: variant === "wrong-currency" ? "EUR" : "USD",
+				},
+				{
+					field: "provider",
+					op: "eq",
+					value: variant === "wrong-provider" ? "paddle" : "stripe",
+				},
+				{
+					field: "product_id",
+					op: "eq",
+					value: variant === "wrong-product" ? "solo" : "team",
+				},
+			],
+			data:
+				variant === "missing-row"
+					? []
+					: [
+							{
+								currency: "USD",
+								total_revenue:
+									variant === "null-amount"
+										? null
+										: variant === "exceeds-control"
+											? 50000
+											: index === 0
+												? 15000
+												: 30000,
+							},
+						],
+		}));
+		const wholeReadings = readings.map((reading) => ({
+			...reading,
+			filters:
+				variant === "filtered-control"
+					? [{ field: "country", op: "eq", value: "US" }]
+					: [],
+			data: [{ currency: "USD", total_revenue: 40000 }],
+		}));
+		const pairs = [productReadings, wholeReadings];
+		const snapshot = variant === "snapshot" || variant === "private";
+		const proposal = {
+			findingKind: snapshot ? "measurement_coverage" : "product_outcome",
+			title: "Team receipts fell behind the stable total",
+			summary: "Other products offset the decline in Team receipts.",
+			rootCause: null,
+			evidence: snapshot
+				? ["Team receipts fell behind stable gross."]
+				: [
+						{ currency: "USD", fields: ["total_revenue"] },
+						...(variant === "missing-control"
+							? []
+							: [{ currency: "USD", fields: ["total_revenue"] }]),
+					],
+			evidenceRefs: snapshot
+				? [{ source: "provided", index: 0 }]
+				: [0, ...(variant === "missing-control" ? [] : [1])].map((pair) =>
+						[0, 1].map((period) => ({
+							source: "tool",
+							name: "get_data",
+							toolCallId: "get_data-1",
+							resultKey: `${pair}-${period}`,
+						}))
+					),
+			publish: variant !== "private",
+			publicationBasis:
+				variant === "private"
+					? null
+					: snapshot
+						? "decision_safety"
+						: "measured_impact",
+			next: {
+				type: "resolve",
+				reason: "An inspected cause is not established.",
+			},
+		};
+		const run = runInsightAgent(
+			{
+				...input,
+				signal: productSignal,
+				githubRepository: null,
+				history: [],
+				otherOpenWork: [],
+				evidence: ["Team receipts fell behind stable gross."],
+			},
+			{
+				model: new MockLanguageModelV3({
+					doGenerate: snapshot
+						? outputResponse(proposal)
+						: mockValues(
+								toolCallResponse("get_data"),
+								outputResponse(proposal)
+							),
+				}),
+				tools: {
+					get_data: tool({
+						description: "Native revenue measurement",
+						inputSchema: z.object({}),
+						execute: () => ({
+							results: Object.fromEntries(
+								pairs.flatMap((pair, pairIndex) =>
+									pair.map((reading, period) => [
+										`${pairIndex}-${period}`,
+										reading,
+									])
+								)
+							),
+						}),
+					}),
+				},
+			}
+		);
+		if (variant === "valid") {
+			const result = await run;
+			expect(result.outcome.publish).toBe(true);
+			expect(result.outcome.evidence[0]).toContain("stripe product team");
+			expect(result.outcome.evidence[1]).toContain("40,000 → 40,000");
+		} else if (variant === "private")
+			expect((await run).outcome.publish).toBe(false);
+		else await expect(run).rejects.toThrow();
+	});
+
 	it("binds metrics to their labels and computes a refund delta absent from the source", () => {
 		expect(renderRevenueEvidence(selection, readings, input)).toBe(
 			"USD, 2026-06-28–2026-07-04 → 2026-07-05–2026-07-11 UTC: Gross Revenue: 10,000 → 10,000; Settled Transactions: 100 → 100; Refund Amount: 200 → 1,200 (+1,000)."

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -3128,6 +3128,7 @@ describe("structured revenue evidence", () => {
 	it.each([
 		"valid",
 		"missing-control",
+		"identified-population",
 		"snapshot",
 		"wrong-product",
 		"wrong-provider",
@@ -3141,10 +3142,10 @@ describe("structured revenue evidence", () => {
 	] as const)("binds product publication to exact native subject and whole controls: %s", async (variant) => {
 		const productSignal: InvestigationSignal = {
 			...signal,
-			signalKey: "product_revenue:USD:stripe:team",
-			entity: { type: "website", id: "team", label: "Team" },
+			signalKey: "product_revenue:USD:stripe:product_name:Team",
+			entity: { type: "website", id: "Team", label: "Team" },
 			metric: {
-				label: "Team USD gross revenue",
+				label: "Team USD receipts",
 				current: 15000,
 				previous: 30000,
 				format: "number",
@@ -3170,9 +3171,14 @@ describe("structured revenue evidence", () => {
 					value: variant === "wrong-provider" ? "paddle" : "stripe",
 				},
 				{
+					field: "product_name",
+					op: "eq",
+					value: variant === "wrong-product" ? "Solo" : "Team",
+				},
+				{
 					field: "product_id",
 					op: "eq",
-					value: variant === "wrong-product" ? "solo" : "team",
+					value: variant === "identified-population" ? "identified-team" : "",
 				},
 			],
 			data:
@@ -3276,7 +3282,9 @@ describe("structured revenue evidence", () => {
 		if (variant === "valid") {
 			const result = await run;
 			expect(result.outcome.publish).toBe(true);
-			expect(result.outcome.evidence[0]).toContain("stripe product team");
+			expect(result.outcome.evidence[0]).toContain(
+				"stripe receipts described Team"
+			);
 			expect(result.outcome.evidence[1]).toContain("40,000 → 40,000");
 		} else if (variant === "private")
 			expect((await run).outcome.publish).toBe(false);
@@ -3284,7 +3292,7 @@ describe("structured revenue evidence", () => {
 	});
 
 	it("binds metrics to their labels and computes a refund delta absent from the source", () => {
-		expect(renderRevenueEvidence(selection, readings, input)).toBe(
+		expect(renderRevenueEvidence(selection, readings, input).text).toBe(
 			"USD, 2026-06-28–2026-07-04 → 2026-07-05–2026-07-11 UTC: Gross Revenue: 10,000 → 10,000; Settled Transactions: 100 → 100; Refund Amount: 200 → 1,200 (+1,000)."
 		);
 	});
@@ -3304,7 +3312,7 @@ describe("structured revenue evidence", () => {
 				selection,
 				[{ ...readings[0], ...changed }, readings[1]],
 				input
-			)
+			).text
 		).toThrow();
 	});
 
@@ -3320,7 +3328,7 @@ describe("structured revenue evidence", () => {
 					...input.appContext,
 					currentDateTime: "2026-07-19T00:00:00Z",
 				},
-			})
+			}).text
 		).toContain("2026-07-05–2026-07-11 → 2026-07-12–2026-07-18 UTC");
 		expect(() =>
 			renderRevenueEvidence(
@@ -3336,7 +3344,7 @@ describe("structured revenue evidence", () => {
 						currentDateTime: "2026-07-19T00:00:00Z",
 					},
 				}
-			)
+			).text
 		).toThrow();
 	});
 
@@ -3345,7 +3353,7 @@ describe("structured revenue evidence", () => {
 			...reading,
 			data: [...reading.data, { currency: "EUR", total_revenue: 5000 }],
 		}));
-		expect(renderRevenueEvidence(selection, both, input)).toContain(
+		expect(renderRevenueEvidence(selection, both, input).text).toContain(
 			"Refund Amount: 200 → 1,200 (+1,000)"
 		);
 		expect(
@@ -3353,7 +3361,7 @@ describe("structured revenue evidence", () => {
 				{ currency: "EUR", fields: ["total_revenue"] },
 				both,
 				input
-			)
+			).text
 		).toContain(
 			"EUR, 2026-06-28–2026-07-04 → 2026-07-05–2026-07-11 UTC: Gross Revenue: 5,000 → 5,000."
 		);
@@ -3369,7 +3377,7 @@ describe("structured revenue evidence", () => {
 						defaultWebsiteId: undefined,
 					},
 				}
-			)
+			).text
 		).toThrow();
 	});
 
@@ -3384,7 +3392,7 @@ describe("structured revenue evidence", () => {
 				currentDateTime: "2026-07-12T00:01:00Z",
 			},
 		};
-		expect(() => renderRevenueEvidence(selection, local, context)).toThrow();
+		expect(() => renderRevenueEvidence(selection, local, context).text).toThrow();
 		expect(
 			renderRevenueEvidence(selection, local, {
 				...context,
@@ -3392,7 +3400,7 @@ describe("structured revenue evidence", () => {
 					...context.appContext,
 					currentDateTime: "2026-07-12T04:00:00Z",
 				},
-			})
+			}).text
 		).toContain(timezone);
 		expect(() =>
 			renderRevenueEvidence(
@@ -3402,7 +3410,7 @@ describe("structured revenue evidence", () => {
 					...input,
 					appContext: { ...input.appContext, timezone: "invalid-zone" },
 				}
-			)
+			).text
 		).toThrow();
 	});
 
@@ -3422,17 +3430,17 @@ describe("structured revenue evidence", () => {
 				{ currency: "USD", fields: ["payment_failure_rate"] },
 				filtered,
 				input
-			)
+			).text
 		).toContain("USD (filtered population)");
 		expect(
 			renderRevenueEvidence(
 				{ currency: "USD", fields: ["payment_failure_rate"] },
 				filtered,
 				input
-			)
+			).text
 		).toContain("Payment Failure Rate (%): 2 → 12 (+10 pp)");
 		expect(() =>
-			renderRevenueEvidence(selection, [readings[0]], input)
+			renderRevenueEvidence(selection, [readings[0]], input).text
 		).toThrow();
 	});
 
@@ -3446,9 +3454,9 @@ describe("structured revenue evidence", () => {
 				{ currency: "USD", fields: ["failed_payment_attempts"] },
 				partial,
 				input
-			)
+			).text
 		).toThrow("failed_payment_attempts is unavailable");
-		expect(renderRevenueEvidence(selection, partial, input)).toContain(
+		expect(renderRevenueEvidence(selection, partial, input).text).toContain(
 			"Refund Amount: 200 → 1,200 (+1,000)"
 		);
 	});
@@ -3466,20 +3474,20 @@ describe("structured revenue evidence", () => {
 					data: [{ ...reading.data[0], [field]: 1 }],
 				})),
 				input
-			)
+			).text
 		).toThrow("declared numeric field");
 	});
 
 	it("rejects repeated periods and unmeasured fields", () => {
 		expect(() =>
-			renderRevenueEvidence(selection, [readings[0], readings[0]], input)
+			renderRevenueEvidence(selection, [readings[0], readings[0]], input).text
 		).toThrow();
 		expect(() =>
 			renderRevenueEvidence(
 				{ ...selection, fields: ["active_subscribers"] },
 				readings,
 				input
-			)
+			).text
 		).toThrow();
 		expect(() =>
 			renderRevenueEvidence(selection, readings, {
@@ -3488,7 +3496,7 @@ describe("structured revenue evidence", () => {
 					...input.appContext,
 					currentDateTime: "2026-07-10T00:00:00Z",
 				},
-			})
+			}).text
 		).toThrow();
 	});
 
@@ -3542,7 +3550,7 @@ describe("structured revenue evidence", () => {
 			}
 		);
 		expect(result.outcome.evidence).toEqual([
-			renderRevenueEvidence(selection, readings, input),
+			renderRevenueEvidence(selection, readings, input).text,
 		]);
 		expect(JSON.stringify(model.doGenerateCalls[2])).toContain(
 			"code binds every value to its field"

--- a/apps/insights/src/investigation.ts
+++ b/apps/insights/src/investigation.ts
@@ -160,7 +160,12 @@ export function isInvestigationCandidate(signal: DetectedSignal): boolean {
 	}
 	return (
 		isRegression(signal) ||
-		["revenue", "refund_amount", "attribution_rate"].includes(signal.metric) ||
+		[
+			"revenue",
+			"product_revenue",
+			"refund_amount",
+			"attribution_rate",
+		].includes(signal.metric) ||
 		(isConversionDefinitionSignal(signal) &&
 			signal.current - signal.baseline >= 10 &&
 			signal.deltaPercent >= 30)
@@ -245,6 +250,13 @@ function entity(signal: DetectedSignal): InvestigationSignal["entity"] {
 			// their entity must stay the configured definition so goal actions and
 			// funnel links continue to resolve the real ID.
 			id: boundedKey(idParts[0]?.trim() || rawId),
+			label: (signal.entityLabel ?? signal.label).slice(0, 120),
+		};
+	}
+	if (prefix === "product_revenue" && signal.entityId) {
+		return {
+			type: "website",
+			id: signal.entityId,
 			label: (signal.entityLabel ?? signal.label).slice(0, 120),
 		};
 	}

--- a/apps/insights/src/product-revenue.test.ts
+++ b/apps/insights/src/product-revenue.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
 import dayjs from "dayjs";
-import { planCoveragePortfolio } from "./coverage-planner";
 import {
 	detectSignals,
 	remeasureMetricSignal,
@@ -11,7 +10,7 @@ import { prepareInvestigation } from "./investigation";
 import { eligibleSignalsForInvestigation } from "./observations";
 
 const params = {
-	websiteId: "synthetic-products",
+	websiteId: "synthetic-receipts",
 	timezone: "UTC",
 	lookbackDays: 7,
 };
@@ -25,13 +24,13 @@ const whole = {
 	refund_count: 0,
 	attributed_revenue: 40_000,
 };
-const product = (
-	product_id: string,
+const receipt = (
+	name: string,
 	revenue: number,
 	overrides: Record<string, unknown> = {}
 ) => ({
-	product_id,
-	name: product_id,
+	product_id: null,
+	name,
 	provider: "stripe",
 	currency: "USD",
 	revenue,
@@ -40,8 +39,8 @@ const product = (
 	percentage: revenue / 400,
 	...overrides,
 });
-const before = [product("team", 30_000), product("solo", 10_000)];
-const after = [product("team", 15_000), product("solo", 25_000)];
+const before = [receipt("Team", 30_000), receipt("Solo", 10_000)];
+const after = [receipt("Team", 15_000), receipt("Solo", 25_000)];
 
 function queries(
 	current: Record<string, unknown>[] = after,
@@ -53,52 +52,53 @@ function queries(
 	const query: QueryFn = async (request) => {
 		calls.push(request);
 		const isCurrent = request.from === windows.currentFrom;
-		if (request.type === "revenue_by_product")
-			return isCurrent ? current : previous;
+		const selected = (isCurrent ? current : previous).filter(
+			(row) =>
+				request.filters?.every((filter) => {
+					const actual =
+						filter.field === "product_id"
+							? (row.product_id ?? "")
+							: filter.field === "product_name"
+								? row.name
+								: row[filter.field];
+					return actual === filter.value;
+				}) ?? true
+		);
+		if (request.type === "revenue_by_product") return selected;
 		if (request.type !== "revenue_overview") return [];
-		const productId = request.filters?.find(
-			(filter) => filter.field === "product_id"
-		)?.value;
-		const rows = productId
-			? (isCurrent ? current : previous)
-					.filter((row) => row.product_id === productId)
-					.map((row) => ({
-						...whole,
-						currency: row.currency,
-						provider: row.provider,
-						total_revenue: row.revenue,
-						total_transactions: row.transactions,
-					}))
-			: isCurrent
-				? currentWhole
-				: previousWhole;
-		return rows.filter(
+		if (request.filters?.some((filter) => filter.field === "product_name")) {
+			return selected.map((row) => ({
+				currency: row.currency,
+				total_revenue: row.revenue,
+				total_transactions: row.transactions,
+			}));
+		}
+		return (isCurrent ? currentWhole : previousWhole).filter(
 			(row) =>
 				request.filters?.every(
-					(filter) =>
-						filter.field === "product_id" || row[filter.field] === filter.value
+					(filter) => row[filter.field] === filter.value
 				) ?? true
 		);
 	};
 	return { calls, query };
 }
-
 async function signals(...args: Parameters<typeof queries>) {
 	const mock = queries(...args);
 	const detected = await detectSignals(params, mock.query, today);
 	return {
 		...mock,
 		detected,
-		products: detected.filter((signal) => signal.metric === "product_revenue"),
+		descriptions: detected.filter(
+			(signal) => signal.metric === "product_revenue"
+		),
 	};
 }
 
-describe("product revenue discovery without funnels", () => {
-	it("finds opposing product shifts behind flat gross, selects the decline once, and remeasures the exact identity", async () => {
-		const { detected, products, calls, query } = await signals();
-		expect(products.map((signal) => signal.subjectKey).sort()).toEqual([
-			"product_revenue:USD:stripe:solo",
-			"product_revenue:USD:stripe:team",
+describe("native unidentified payment-description discovery", () => {
+	it("selects the hidden receipt decline and stays quiet on the entire identical next detector run", async () => {
+		const { detected, descriptions, calls, query } = await signals();
+		expect(descriptions.map((signal) => signal.subjectKey)).toEqual([
+			"product_revenue:USD:stripe:product_name:Team",
 		]);
 		expect(detected.some((signal) => signal.metric === "revenue")).toBe(false);
 		expect(
@@ -106,42 +106,40 @@ describe("product revenue discovery without funnels", () => {
 				.filter((call) => call.type === "revenue_by_product")
 				.map((call) => call.limit)
 		).toEqual([20, 20]);
-		const selected = planCoveragePortfolio(products, { reason: "scheduled" });
-		expect(selected).toHaveLength(1);
-		const [team] = selected;
+		const [team] = descriptions;
 		expect(team).toMatchObject({
-			current: 15_000,
-			baseline: 30_000,
-			deltaPercent: -50,
-			entityId: "team",
+			current: 15000,
+			baseline: 30000,
+			entityId: "Team",
 		});
 		const prepared = prepareInvestigation(team, 7);
-		expect(prepared.signal.entity.id).toBe("team");
 		expect(prepared.evidence.join(" ")).toContain(
 			"Whole-currency gross: 40000 → 40000"
 		);
 		expect(prepared.evidence.join(" ")).toContain(
 			"Remaining gross: 10000 → 25000"
 		);
+		expect(prepared.investigationObjective).toContain(
+			"payment descriptions, not verified catalog products"
+		);
 		expect(
 			await remeasureMetricSignal(params, prepared.signal, query, today)
 		).toMatchObject({
 			subjectKey: team.subjectKey,
-			current: 15_000,
-			baseline: 30_000,
+			current: 15000,
+			baseline: 30000,
 		});
 		expect(
 			calls
 				.slice(-4)
-				.filter((call) =>
-					call.filters?.some((filter) => filter.field === "product_id")
-				)
+				.filter((call) => call.type === "revenue_by_product")
 				.map((call) => call.filters)
 		).toEqual(
 			Array(2).fill([
 				{ field: "currency", op: "eq", value: "USD" },
 				{ field: "provider", op: "eq", value: "stripe" },
-				{ field: "product_id", op: "eq", value: "team" },
+				{ field: "product_name", op: "eq", value: "Team" },
+				{ field: "product_id", op: "eq", value: "" },
 			])
 		);
 		const observations = new Map([
@@ -151,8 +149,8 @@ describe("product revenue discovery without funnels", () => {
 					signal: prepared.signal,
 					recheckAt: new Date("2026-10-07T12:00:00Z"),
 					outcome: {
-						title: "Team receipts fell",
-						summary: "Solo receipts offset the change.",
+						title: "Team-described receipts fell",
+						summary: "Other receipts offset the change.",
 						evidence: [],
 						rootCause: null,
 						next: {
@@ -164,129 +162,123 @@ describe("product revenue discovery without funnels", () => {
 			],
 		]);
 		expect(
-			eligibleSignalsForInvestigation([team], observations, today.toDate())
-		).toEqual([]);
-	});
-
-	it("does not infer zero when a product falls out of a truncated top table", async () => {
-		const { products } = await signals([product("solo", 40_000)]);
-		expect(products.some((signal) => signal.entityId === "team")).toBe(false);
-		const [team] = (await signals()).products.filter(
-			(signal) => signal.entityId === "team"
-		);
-		expect(
-			await remeasureMetricSignal(
-				params,
-				prepareInvestigation(team, 7).signal,
-				queries([product("solo", 40_000)]).query,
-				today
+			eligibleSignalsForInvestigation(
+				(await signals()).detected,
+				observations,
+				today.toDate()
 			)
-		).toBeNull();
+		).toEqual([]);
+		expect(
+			(await signals([...after].reverse(), [...before].reverse())).descriptions
+		).toEqual(descriptions);
 	});
-
-	it("accepts an explicit measured zero with a real product row and keeps a zero recheck", async () => {
-		const { products, query } = await signals([
-			product("team", 0),
-			product("solo", 40_000),
+	it("keeps renamed and missing labels unknown instead of substituting zero", async () => {
+		const [team] = (await signals()).descriptions;
+		for (const current of [
+			[after[1]],
+			[receipt("Team Plus", 15000), after[1]],
+		]) {
+			expect(
+				(await signals(current)).descriptions.some(
+					(signal) => signal.entityId === "Team"
+				)
+			).toBe(false);
+			expect(
+				await remeasureMetricSignal(
+					params,
+					prepareInvestigation(team, 7).signal,
+					queries(current).query,
+					today
+				)
+			).toBeNull();
+		}
+		const measured = await signals([
+			receipt("Team", 0),
+			receipt("Solo", 40000),
 		]);
-		const team = products.find((signal) => signal.entityId === "team");
-		expect(team?.current).toBe(0);
-		if (!team) throw new Error("Expected team");
+		expect(measured.descriptions[0].current).toBe(0);
+	});
+	it("does not mix the same label from identified receipts, another provider or another currency", async () => {
+		const other = [
+			receipt("Team", 40000, { product_id: "identified-team" }),
+			receipt("Team", 10000, { provider: "paddle" }),
+			receipt("Team", 10000, { currency: "EUR" }),
+		];
+		const totals = [
+			{ ...whole, total_revenue: 90000, total_transactions: 900 },
+			{
+				...whole,
+				currency: "EUR",
+				total_revenue: 10000,
+				total_transactions: 100,
+			},
+		];
+		const { descriptions, query } = await signals(
+			[...after, ...other],
+			[...before, ...other],
+			totals,
+			totals
+		);
+		expect(descriptions).toHaveLength(1);
+		expect(descriptions[0]).toMatchObject({
+			entityId: "Team",
+			current: 15000,
+			baseline: 30000,
+		});
 		expect(
 			await remeasureMetricSignal(
 				params,
-				prepareInvestigation(team, 7).signal,
+				prepareInvestigation(descriptions[0], 7).signal,
 				query,
 				today
 			)
-		).toMatchObject({ current: 0, baseline: 30_000 });
+		).toMatchObject({ current: 15000, baseline: 30000 });
 	});
-
-	it("does not confuse a rename with an absent product or accept split duplicate IDs", async () => {
-		expect(
-			(
-				await signals([
-					product("team", 15_000, { name: "Team Plus" }),
-					after[1],
-				])
-			).products.find((signal) => signal.entityId === "team")?.entityLabel
-		).toBe("Team Plus");
-		expect(
-			(
-				await signals([
-					product("team", 10_000),
-					product("team", 5_000, { name: "Team Plus" }),
-					after[1],
-				])
-			).products.some((signal) => signal.entityId === "team")
-		).toBe(false);
-	});
-
-	it("does not merge matching product IDs across currency or provider", async () => {
-		const { products } = await signals(
-			[
-				...after,
-				product("team", 15_000, { currency: "EUR" }),
-				product("team", 30_000, { provider: "paddle" }),
-			],
-			[
-				...before,
-				product("team", 15_000, { currency: "EUR" }),
-				product("team", 30_000, { provider: "paddle" }),
-			],
-			[
-				{ ...whole, total_revenue: 70_000, total_transactions: 700 },
-				{ ...whole, currency: "EUR" },
-			],
-			[
-				{ ...whole, total_revenue: 70_000, total_transactions: 700 },
-				{ ...whole, currency: "EUR" },
-			]
-		);
-		expect(products.map((signal) => signal.subjectKey).sort()).toEqual([
-			"product_revenue:USD:stripe:solo",
-			"product_revenue:USD:stripe:team",
-		]);
-	});
-
-	it("keeps proportional whole growth quiet and ignores null identities and invalid amounts", async () => {
-		const growth = after.map((row, i) => ({
-			...row,
-			revenue: before[i].revenue * 2,
-			transactions: before[i].transactions * 2,
-		}));
-		expect(
-			(
-				await signals(growth, before, [
-					{ ...whole, total_revenue: 80_000, total_transactions: 800 },
-				])
-			).products
-		).toEqual([]);
-		for (const overrides of [
-			{ product_id: null },
+	it("does not fabricate label meaning or accept invalid, ambiguous and unidentified source fields", async () => {
+		for (const override of [
+			{ product_id: "catalog-team" },
+			{ product_id: undefined },
+			{ name: "Unknown" },
+			{ name: " " },
 			{ revenue: null },
 			{ revenue: -1 },
 			{ transactions: -1 },
 			{ currency: "usd" },
 		]) {
 			expect(
-				(await signals([product("team", 15_000, overrides)], [before[0]]))
-					.products
+				(await signals([receipt("Team", 15000, override)], [before[0]]))
+					.descriptions
 			).toEqual([]);
 		}
+		expect(
+			(
+				await signals(
+					[receipt("Team", 10000), receipt("Team", 5000)],
+					[before[0]]
+				)
+			).descriptions
+		).toEqual([]);
+		expect(
+			(
+				await signals(
+					[receipt("Team", 60000), receipt("Solo", 20000)],
+					before,
+					[{ ...whole, total_revenue: 80000, total_transactions: 800 }]
+				)
+			).descriptions
+		).toEqual([]);
 	});
-
-	it("preserves full long and delimiter-bearing product IDs through recheck", async () => {
-		const id = `team:/ ${"long".repeat(70)}`;
-		const { products, query } = await signals(
-			[product(id, 15_000)],
-			[product(id, 30_000)]
+	it("preserves full labels with delimiters across the bounded subject key and exact recheck", async () => {
+		const label = `Team:/ ${"long".repeat(70)}`;
+		const { descriptions, query } = await signals(
+			[receipt(label, 15000)],
+			[receipt(label, 30000)]
 		);
-		const prepared = prepareInvestigation(products[0], 7);
+		const prepared = prepareInvestigation(descriptions[0], 7);
 		expect(prepared.signal.signalKey.length).toBeLessThanOrEqual(160);
-		expect(prepared.signal.entity.id).toBe(id);
+		expect(prepared.signal.entity.id).toBe(label);
 		expect(
 			await remeasureMetricSignal(params, prepared.signal, query, today)
-		).toMatchObject({ entityId: id });
+		).toMatchObject({ entityId: label });
 	});
 });

--- a/apps/insights/src/product-revenue.test.ts
+++ b/apps/insights/src/product-revenue.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import { investigationOutcomeSchema } from "@databuddy/shared/insights";
 import dayjs from "dayjs";
 import {
 	detectSignals,
@@ -148,16 +149,21 @@ describe("native unidentified payment-description discovery", () => {
 				{
 					signal: prepared.signal,
 					recheckAt: new Date("2026-10-07T12:00:00Z"),
-					outcome: {
+					outcome: investigationOutcomeSchema.parse({
 						title: "Team-described receipts fell",
 						summary: "Other receipts offset the change.",
-						evidence: [],
+						evidence: [
+							"Team-described receipts fell from 30000 to 15000 while whole USD gross stayed 40000.",
+						],
+						publish: true,
+						findingKind: "product_outcome",
+						publicationBasis: "measured_impact",
 						rootCause: null,
 						next: {
 							type: "resolve" as const,
 							reason: "The cause is unmeasured.",
 						},
-					},
+					}),
 				},
 			],
 		]);

--- a/apps/insights/src/product-revenue.test.ts
+++ b/apps/insights/src/product-revenue.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, it } from "bun:test";
+import dayjs from "dayjs";
+import { planCoveragePortfolio } from "./coverage-planner";
+import {
+	detectSignals,
+	remeasureMetricSignal,
+	wowWindow,
+	type QueryFn,
+} from "./detection";
+import { prepareInvestigation } from "./investigation";
+import { eligibleSignalsForInvestigation } from "./observations";
+
+const params = {
+	websiteId: "synthetic-products",
+	timezone: "UTC",
+	lookbackDays: 7,
+};
+const today = dayjs("2026-09-07T12:00:00Z");
+const windows = wowWindow(today, 7);
+const whole = {
+	currency: "USD",
+	total_revenue: 40_000,
+	total_transactions: 400,
+	refund_amount: 0,
+	refund_count: 0,
+	attributed_revenue: 40_000,
+};
+const product = (
+	product_id: string,
+	revenue: number,
+	overrides: Record<string, unknown> = {}
+) => ({
+	product_id,
+	name: product_id,
+	provider: "stripe",
+	currency: "USD",
+	revenue,
+	transactions: revenue / 100,
+	customers: revenue / 100,
+	percentage: revenue / 400,
+	...overrides,
+});
+const before = [product("team", 30_000), product("solo", 10_000)];
+const after = [product("team", 15_000), product("solo", 25_000)];
+
+function queries(
+	current: Record<string, unknown>[] = after,
+	previous: Record<string, unknown>[] = before,
+	currentWhole: Record<string, unknown>[] = [whole],
+	previousWhole: Record<string, unknown>[] = [whole]
+) {
+	const calls: Parameters<QueryFn>[0][] = [];
+	const query: QueryFn = async (request) => {
+		calls.push(request);
+		const isCurrent = request.from === windows.currentFrom;
+		if (request.type === "revenue_by_product")
+			return isCurrent ? current : previous;
+		if (request.type !== "revenue_overview") return [];
+		const productId = request.filters?.find(
+			(filter) => filter.field === "product_id"
+		)?.value;
+		const rows = productId
+			? (isCurrent ? current : previous)
+					.filter((row) => row.product_id === productId)
+					.map((row) => ({
+						...whole,
+						currency: row.currency,
+						provider: row.provider,
+						total_revenue: row.revenue,
+						total_transactions: row.transactions,
+					}))
+			: isCurrent
+				? currentWhole
+				: previousWhole;
+		return rows.filter(
+			(row) =>
+				request.filters?.every(
+					(filter) =>
+						filter.field === "product_id" || row[filter.field] === filter.value
+				) ?? true
+		);
+	};
+	return { calls, query };
+}
+
+async function signals(...args: Parameters<typeof queries>) {
+	const mock = queries(...args);
+	const detected = await detectSignals(params, mock.query, today);
+	return {
+		...mock,
+		detected,
+		products: detected.filter((signal) => signal.metric === "product_revenue"),
+	};
+}
+
+describe("product revenue discovery without funnels", () => {
+	it("finds opposing product shifts behind flat gross, selects the decline once, and remeasures the exact identity", async () => {
+		const { detected, products, calls, query } = await signals();
+		expect(products.map((signal) => signal.subjectKey).sort()).toEqual([
+			"product_revenue:USD:stripe:solo",
+			"product_revenue:USD:stripe:team",
+		]);
+		expect(detected.some((signal) => signal.metric === "revenue")).toBe(false);
+		expect(
+			calls
+				.filter((call) => call.type === "revenue_by_product")
+				.map((call) => call.limit)
+		).toEqual([20, 20]);
+		const selected = planCoveragePortfolio(products, { reason: "scheduled" });
+		expect(selected).toHaveLength(1);
+		const [team] = selected;
+		expect(team).toMatchObject({
+			current: 15_000,
+			baseline: 30_000,
+			deltaPercent: -50,
+			entityId: "team",
+		});
+		const prepared = prepareInvestigation(team, 7);
+		expect(prepared.signal.entity.id).toBe("team");
+		expect(prepared.evidence.join(" ")).toContain(
+			"Whole-currency gross: 40000 → 40000"
+		);
+		expect(prepared.evidence.join(" ")).toContain(
+			"Remaining gross: 10000 → 25000"
+		);
+		expect(
+			await remeasureMetricSignal(params, prepared.signal, query, today)
+		).toMatchObject({
+			subjectKey: team.subjectKey,
+			current: 15_000,
+			baseline: 30_000,
+		});
+		expect(
+			calls
+				.slice(-4)
+				.filter((call) =>
+					call.filters?.some((filter) => filter.field === "product_id")
+				)
+				.map((call) => call.filters)
+		).toEqual(
+			Array(2).fill([
+				{ field: "currency", op: "eq", value: "USD" },
+				{ field: "provider", op: "eq", value: "stripe" },
+				{ field: "product_id", op: "eq", value: "team" },
+			])
+		);
+		const observations = new Map([
+			[
+				prepared.signal.signalKey,
+				{
+					signal: prepared.signal,
+					recheckAt: new Date("2026-10-07T12:00:00Z"),
+					outcome: {
+						title: "Team receipts fell",
+						summary: "Solo receipts offset the change.",
+						evidence: [],
+						rootCause: null,
+						next: {
+							type: "resolve" as const,
+							reason: "The cause is unmeasured.",
+						},
+					},
+				},
+			],
+		]);
+		expect(
+			eligibleSignalsForInvestigation([team], observations, today.toDate())
+		).toEqual([]);
+	});
+
+	it("does not infer zero when a product falls out of a truncated top table", async () => {
+		const { products } = await signals([product("solo", 40_000)]);
+		expect(products.some((signal) => signal.entityId === "team")).toBe(false);
+		const [team] = (await signals()).products.filter(
+			(signal) => signal.entityId === "team"
+		);
+		expect(
+			await remeasureMetricSignal(
+				params,
+				prepareInvestigation(team, 7).signal,
+				queries([product("solo", 40_000)]).query,
+				today
+			)
+		).toBeNull();
+	});
+
+	it("accepts an explicit measured zero with a real product row and keeps a zero recheck", async () => {
+		const { products, query } = await signals([
+			product("team", 0),
+			product("solo", 40_000),
+		]);
+		const team = products.find((signal) => signal.entityId === "team");
+		expect(team?.current).toBe(0);
+		if (!team) throw new Error("Expected team");
+		expect(
+			await remeasureMetricSignal(
+				params,
+				prepareInvestigation(team, 7).signal,
+				query,
+				today
+			)
+		).toMatchObject({ current: 0, baseline: 30_000 });
+	});
+
+	it("does not confuse a rename with an absent product or accept split duplicate IDs", async () => {
+		expect(
+			(
+				await signals([
+					product("team", 15_000, { name: "Team Plus" }),
+					after[1],
+				])
+			).products.find((signal) => signal.entityId === "team")?.entityLabel
+		).toBe("Team Plus");
+		expect(
+			(
+				await signals([
+					product("team", 10_000),
+					product("team", 5_000, { name: "Team Plus" }),
+					after[1],
+				])
+			).products.some((signal) => signal.entityId === "team")
+		).toBe(false);
+	});
+
+	it("does not merge matching product IDs across currency or provider", async () => {
+		const { products } = await signals(
+			[
+				...after,
+				product("team", 15_000, { currency: "EUR" }),
+				product("team", 30_000, { provider: "paddle" }),
+			],
+			[
+				...before,
+				product("team", 15_000, { currency: "EUR" }),
+				product("team", 30_000, { provider: "paddle" }),
+			],
+			[
+				{ ...whole, total_revenue: 70_000, total_transactions: 700 },
+				{ ...whole, currency: "EUR" },
+			],
+			[
+				{ ...whole, total_revenue: 70_000, total_transactions: 700 },
+				{ ...whole, currency: "EUR" },
+			]
+		);
+		expect(products.map((signal) => signal.subjectKey).sort()).toEqual([
+			"product_revenue:USD:stripe:solo",
+			"product_revenue:USD:stripe:team",
+		]);
+	});
+
+	it("keeps proportional whole growth quiet and ignores null identities and invalid amounts", async () => {
+		const growth = after.map((row, i) => ({
+			...row,
+			revenue: before[i].revenue * 2,
+			transactions: before[i].transactions * 2,
+		}));
+		expect(
+			(
+				await signals(growth, before, [
+					{ ...whole, total_revenue: 80_000, total_transactions: 800 },
+				])
+			).products
+		).toEqual([]);
+		for (const overrides of [
+			{ product_id: null },
+			{ revenue: null },
+			{ revenue: -1 },
+			{ transactions: -1 },
+			{ currency: "usd" },
+		]) {
+			expect(
+				(await signals([product("team", 15_000, overrides)], [before[0]]))
+					.products
+			).toEqual([]);
+		}
+	});
+
+	it("preserves full long and delimiter-bearing product IDs through recheck", async () => {
+		const id = `team:/ ${"long".repeat(70)}`;
+		const { products, query } = await signals(
+			[product(id, 15_000)],
+			[product(id, 30_000)]
+		);
+		const prepared = prepareInvestigation(products[0], 7);
+		expect(prepared.signal.signalKey.length).toBeLessThanOrEqual(160);
+		expect(prepared.signal.entity.id).toBe(id);
+		expect(
+			await remeasureMetricSignal(params, prepared.signal, query, today)
+		).toMatchObject({ entityId: id });
+	});
+});

--- a/apps/insights/src/product-revenue.test.ts
+++ b/apps/insights/src/product-revenue.test.ts
@@ -241,6 +241,12 @@ describe("native unidentified payment-description discovery", () => {
 		).toMatchObject({ current: 15000, baseline: 30000 });
 	});
 	it("does not fabricate label meaning or accept invalid, ambiguous and unidentified source fields", async () => {
+		for (const name of ["Unknown", " Unknown ", "\tUnknown\n", " "]) {
+			expect(
+				(await signals([receipt(name, 15000)], [receipt(name, 30000)]))
+					.descriptions
+			).toEqual([]);
+		}
 		for (const override of [
 			{ product_id: "catalog-team" },
 			{ product_id: undefined },

--- a/packages/ai/src/query/builders/revenue.integration.test.ts
+++ b/packages/ai/src/query/builders/revenue.integration.test.ts
@@ -126,6 +126,107 @@ function attributionEvent(
 }
 
 describeIntegration("revenue query builders against ClickHouse", () => {
+	it("collapses product renames without mixing providers and keeps absent products unknown", async () => {
+		const websiteId = `revenue-product-${randomUUIDv7()}`;
+		await clickHouse.insert({
+			table: "analytics.revenue",
+			format: "JSONEachRow",
+			values: [
+				revenueRow(
+					websiteId,
+					"team-old",
+					100,
+					"sale",
+					"completed",
+					"{}",
+					"2026-08-01 12:00:00",
+					{ product_id: "team", product_name: "Team" }
+				),
+				revenueRow(
+					websiteId,
+					"team-new",
+					200,
+					"sale",
+					"completed",
+					"{}",
+					"2026-08-02 12:00:00",
+					{ product_id: "team", product_name: "Team Plus" }
+				),
+				revenueRow(
+					websiteId,
+					"team-refund",
+					-50,
+					"refund",
+					"completed",
+					"{}",
+					"2026-08-02 12:00:00",
+					{ product_id: "team", product_name: "Team Plus" }
+				),
+				revenueRow(
+					websiteId,
+					"other-provider",
+					700,
+					"sale",
+					"completed",
+					"{}",
+					"2026-08-02 12:00:00",
+					{ provider: "paddle", product_id: "team", product_name: "Team" }
+				),
+				revenueRow(websiteId, "unknown", 20, "sale", "completed"),
+			],
+		});
+		const query = new SimpleQueryBuilder(RevenueBuilders.revenue_by_product, {
+			projectId: websiteId,
+			type: "revenue_by_product",
+			from: "2026-08-01",
+			to: "2026-08-03",
+			limit: 20,
+		}).compile();
+		const products = await chQuery<Record<string, unknown>>(
+			query.sql,
+			query.params
+		);
+		expect(products.filter((row) => row.product_id === "team")).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					provider: "stripe",
+					product_id: "team",
+					name: "Team Plus",
+					revenue: 300,
+					transactions: 2,
+				}),
+				expect.objectContaining({
+					provider: "paddle",
+					product_id: "team",
+					name: "Team",
+					revenue: 700,
+					transactions: 1,
+				}),
+			])
+		);
+		expect(products.filter((row) => row.product_id === "team")).toHaveLength(2);
+		const filters: Filter[] = [
+			{ field: "currency", op: "eq", value: "USD" },
+			{ field: "provider", op: "eq", value: "stripe" },
+			{ field: "product_id", op: "eq", value: "team" },
+		];
+		const [measured] = await revenueOverview(
+			websiteId,
+			"2026-08-01",
+			"2026-08-03",
+			filters
+		);
+		expect(Number(measured.total_revenue)).toBe(300);
+		expect(Number(measured.refund_amount)).toBe(-50);
+		expect(Number(measured.payment_diagnostics_available)).toBe(0);
+		expect(
+			await revenueOverview(websiteId, "2026-08-01", "2026-08-03", [
+				...filters.slice(0, 2),
+				{ field: "product_id", op: "eq", value: "absent" },
+			])
+		).toEqual([]);
+	}, 15_000);
+
 	it("counts canonical Stripe records and keeps payment diagnostics separate", async () => {
 		const websiteId = `revenue-cutover-${randomUUIDv7()}`;
 		const cutoverRevenueRow = (

--- a/packages/ai/src/query/builders/revenue.integration.test.ts
+++ b/packages/ai/src/query/builders/revenue.integration.test.ts
@@ -167,7 +167,7 @@ describeIntegration("revenue query builders against ClickHouse", () => {
 					"refund",
 					-50,
 					"refund",
-					"completed",
+					"refunded",
 					"{}",
 					"2026-08-02 12:00:00",
 					{ product_id: null, product_name: "Refund" }

--- a/packages/ai/src/query/builders/revenue.integration.test.ts
+++ b/packages/ai/src/query/builders/revenue.integration.test.ts
@@ -126,53 +126,62 @@ function attributionEvent(
 }
 
 describeIntegration("revenue query builders against ClickHouse", () => {
-	it("collapses product renames without mixing providers and keeps absent products unknown", async () => {
-		const websiteId = `revenue-product-${randomUUIDv7()}`;
+	it("preserves null-ID payment descriptions and excludes identified receipts with the same label", async () => {
+		const websiteId = `revenue-descriptions-${randomUUIDv7()}`;
 		await clickHouse.insert({
 			table: "analytics.revenue",
 			format: "JSONEachRow",
 			values: [
 				revenueRow(
 					websiteId,
-					"team-old",
+					"team-a",
 					100,
 					"sale",
 					"completed",
 					"{}",
 					"2026-08-01 12:00:00",
-					{ product_id: "team", product_name: "Team" }
+					{ product_id: null, product_name: "Team" }
 				),
 				revenueRow(
 					websiteId,
-					"team-new",
+					"team-b",
 					200,
 					"sale",
 					"completed",
 					"{}",
 					"2026-08-02 12:00:00",
-					{ product_id: "team", product_name: "Team Plus" }
+					{ product_id: null, product_name: "Team" }
 				),
 				revenueRow(
 					websiteId,
-					"team-refund",
+					"solo",
+					400,
+					"sale",
+					"completed",
+					"{}",
+					"2026-08-02 12:00:00",
+					{ product_id: null, product_name: "Solo" }
+				),
+				revenueRow(
+					websiteId,
+					"refund",
 					-50,
 					"refund",
 					"completed",
 					"{}",
 					"2026-08-02 12:00:00",
-					{ product_id: "team", product_name: "Team Plus" }
+					{ product_id: null, product_name: "Refund" }
 				),
 				revenueRow(
 					websiteId,
-					"other-provider",
+					"identified",
 					700,
 					"sale",
 					"completed",
 					"{}",
 					"2026-08-02 12:00:00",
-					{ provider: "paddle", product_id: "team", product_name: "Team" }
+					{ product_id: "identified-team", product_name: "Team" }
 				),
-				revenueRow(websiteId, "unknown", 20, "sale", "completed"),
 			],
 		});
 		const query = new SimpleQueryBuilder(RevenueBuilders.revenue_by_product, {
@@ -182,33 +191,48 @@ describeIntegration("revenue query builders against ClickHouse", () => {
 			to: "2026-08-03",
 			limit: 20,
 		}).compile();
-		const products = await chQuery<Record<string, unknown>>(
+		const groups = await chQuery<Record<string, unknown>>(
 			query.sql,
 			query.params
 		);
-		expect(products.filter((row) => row.product_id === "team")).toEqual(
+		expect(groups).toHaveLength(4);
+		expect(groups).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
 					provider: "stripe",
-					product_id: "team",
-					name: "Team Plus",
+					product_id: null,
+					name: "Team",
 					revenue: 300,
 					transactions: 2,
 				}),
 				expect.objectContaining({
-					provider: "paddle",
-					product_id: "team",
+					provider: "stripe",
+					product_id: null,
+					name: "Solo",
+					revenue: 400,
+					transactions: 1,
+				}),
+				expect.objectContaining({
+					provider: "stripe",
+					product_id: null,
+					name: "Refund",
+					revenue: 0,
+					transactions: 0,
+				}),
+				expect.objectContaining({
+					provider: "stripe",
+					product_id: "identified-team",
 					name: "Team",
 					revenue: 700,
 					transactions: 1,
 				}),
 			])
 		);
-		expect(products.filter((row) => row.product_id === "team")).toHaveLength(2);
 		const filters: Filter[] = [
 			{ field: "currency", op: "eq", value: "USD" },
 			{ field: "provider", op: "eq", value: "stripe" },
-			{ field: "product_id", op: "eq", value: "team" },
+			{ field: "product_name", op: "eq", value: "Team" },
+			{ field: "product_id", op: "eq", value: "" },
 		];
 		const [measured] = await revenueOverview(
 			websiteId,
@@ -217,12 +241,16 @@ describeIntegration("revenue query builders against ClickHouse", () => {
 			filters
 		);
 		expect(Number(measured.total_revenue)).toBe(300);
-		expect(Number(measured.refund_amount)).toBe(-50);
+		expect(Number(measured.refund_amount)).toBe(0);
 		expect(Number(measured.payment_diagnostics_available)).toBe(0);
+		const [all] = await revenueOverview(websiteId, "2026-08-01", "2026-08-03");
+		expect(Number(all.total_revenue)).toBe(1400);
+		expect(Number(all.refund_amount)).toBe(-50);
 		expect(
 			await revenueOverview(websiteId, "2026-08-01", "2026-08-03", [
 				...filters.slice(0, 2),
-				{ field: "product_id", op: "eq", value: "absent" },
+				{ field: "product_name", op: "eq", value: "absent" },
+				filters[3],
 			])
 		).toEqual([]);
 	}, 15_000);

--- a/packages/ai/src/query/builders/revenue.ts
+++ b/packages/ai/src/query/builders/revenue.ts
@@ -21,12 +21,13 @@ const REVENUE_FILTER_COLUMNS: Record<string, string> = {
 	referrer: "referrer_domain",
 	path: "entry_path",
 	provider: "revenue_provider",
+	product_id: "product_id",
 	type: "type",
 	currency: "currency",
 };
 
 const REVENUE_ALLOWED_FILTERS = ["currency", "provider", "type"];
-const REVENUE_OVERVIEW_ALLOWED_FILTERS = ["currency", "provider"];
+const REVENUE_OVERVIEW_ALLOWED_FILTERS = ["currency", "provider", "product_id"];
 
 function fixedValueMatchesFilter(value: string, filter: Filter): boolean {
 	const values = (
@@ -955,12 +956,14 @@ const revenueBuilderDefinitions: Record<string, SimpleQueryConfig> = {
 	revenue_by_product: {
 		meta: {
 			title: "Revenue by Product",
-			description: "Revenue breakdown by product.",
+			description:
+				"Gross settled revenue by stable product ID and provider, excluding refunds. Product names are the latest observed label; a limited table cannot establish absence.",
 			category: "Revenue",
 			tags: ["revenue", "product"],
 			output_fields: [
 				{ name: "name", type: "string", label: "Product" },
 				{ name: "product_id", type: "string", label: "Product ID" },
+				{ name: "provider", type: "string", label: "Provider" },
 				{ name: "currency", type: "string", label: "Currency" },
 				{ name: "revenue", type: "number", label: "Revenue" },
 				{ name: "transactions", type: "number", label: "Transactions" },
@@ -973,9 +976,10 @@ const revenueBuilderDefinitions: Record<string, SimpleQueryConfig> = {
 		customSql: makeRevenueBuilder(
 			(limit) => ({
 				select: `SELECT
-				coalesce(product_name, 'Unknown') as name,
+				coalesce(argMax(product_name, created), 'Unknown') as name,
+				revenue_provider as provider,
 				product_id,${REVENUE_METRICS}`,
-				groupBy: "product_name, product_id, currency",
+				groupBy: "revenue_provider, product_id, currency",
 				orderBy: "revenue DESC",
 				limit,
 			}),
@@ -1352,7 +1356,9 @@ export const RevenueBuilders: Record<string, SimpleQueryConfig> =
 				allowedFilters:
 					name === "revenue_overview"
 						? REVENUE_OVERVIEW_ALLOWED_FILTERS
-						: REVENUE_ALLOWED_FILTERS,
+						: name === "revenue_by_product"
+							? [...REVENUE_ALLOWED_FILTERS, "product_id"]
+							: REVENUE_ALLOWED_FILTERS,
 			},
 		])
 	);

--- a/packages/ai/src/query/builders/revenue.ts
+++ b/packages/ai/src/query/builders/revenue.ts
@@ -983,8 +983,8 @@ const revenueBuilderDefinitions: Record<string, SimpleQueryConfig> = {
 			(limit) => ({
 				select: `SELECT
 				coalesce(product_name, 'Unknown') as name,
-				revenue_provider as provider,
-				product_id,${REVENUE_METRICS}`,
+				product_id,
+				revenue_provider as provider,${REVENUE_METRICS}`,
 				groupBy: "revenue_provider, product_name, product_id, currency",
 				orderBy: "revenue DESC",
 				limit,

--- a/packages/ai/src/query/builders/revenue.ts
+++ b/packages/ai/src/query/builders/revenue.ts
@@ -21,13 +21,19 @@ const REVENUE_FILTER_COLUMNS: Record<string, string> = {
 	referrer: "referrer_domain",
 	path: "entry_path",
 	provider: "revenue_provider",
-	product_id: "product_id",
+	product_id: "ifNull(product_id, '')",
+	product_name: "product_name",
 	type: "type",
 	currency: "currency",
 };
 
 const REVENUE_ALLOWED_FILTERS = ["currency", "provider", "type"];
-const REVENUE_OVERVIEW_ALLOWED_FILTERS = ["currency", "provider", "product_id"];
+const REVENUE_OVERVIEW_ALLOWED_FILTERS = [
+	"currency",
+	"provider",
+	"product_id",
+	"product_name",
+];
 
 function fixedValueMatchesFilter(value: string, filter: Filter): boolean {
 	const values = (
@@ -957,7 +963,7 @@ const revenueBuilderDefinitions: Record<string, SimpleQueryConfig> = {
 		meta: {
 			title: "Revenue by Product",
 			description:
-				"Gross settled revenue by stable product ID and provider, excluding refunds. Product names are the latest observed label; a limited table cannot establish absence.",
+				"Gross settled revenue grouped by recorded name, ID and provider, excluding refunds. Names may be payment descriptions rather than catalog products; a limited table cannot establish absence.",
 			category: "Revenue",
 			tags: ["revenue", "product"],
 			output_fields: [
@@ -976,10 +982,10 @@ const revenueBuilderDefinitions: Record<string, SimpleQueryConfig> = {
 		customSql: makeRevenueBuilder(
 			(limit) => ({
 				select: `SELECT
-				coalesce(argMax(product_name, created), 'Unknown') as name,
+				coalesce(product_name, 'Unknown') as name,
 				revenue_provider as provider,
 				product_id,${REVENUE_METRICS}`,
-				groupBy: "revenue_provider, product_id, currency",
+				groupBy: "revenue_provider, product_name, product_id, currency",
 				orderBy: "revenue DESC",
 				limit,
 			}),
@@ -1357,7 +1363,7 @@ export const RevenueBuilders: Record<string, SimpleQueryConfig> =
 					name === "revenue_overview"
 						? REVENUE_OVERVIEW_ALLOWED_FILTERS
 						: name === "revenue_by_product"
-							? [...REVENUE_ALLOWED_FILTERS, "product_id"]
+							? [...REVENUE_ALLOWED_FILTERS, "product_id", "product_name"]
 							: REVENUE_ALLOWED_FILTERS,
 			},
 		])

--- a/packages/ai/src/query/simple-builder.test.ts
+++ b/packages/ai/src/query/simple-builder.test.ts
@@ -969,47 +969,47 @@ describe("SimpleQueryBuilder.compile", () => {
 		expect(params.rf0).toBe("EUR");
 	});
 
-	it("measures stable product IDs across renames and enforces exact product filters", () => {
+	it("preserves named product groups and compiles an exact unidentified payment description", () => {
+		const filters = [
+			{ field: "currency", op: "eq" as const, value: "USD" },
+			{ field: "provider", op: "eq" as const, value: "stripe" },
+			{ field: "product_name", op: "eq" as const, value: "Team" },
+			{ field: "product_id", op: "eq" as const, value: "" },
+		];
 		const product = compileBuilder(
 			"revenue_by_product",
 			QueryBuilders.revenue_by_product,
-			{
-				limit: 20,
-				filters: [
-					{ field: "currency", op: "eq", value: "USD" },
-					{ field: "provider", op: "eq", value: "stripe" },
-					{ field: "product_id", op: "eq", value: "team:annual" },
-				],
-			}
+			{ limit: 20, filters }
 		);
 		expect(product.sql).toContain(
-			"GROUP BY revenue_provider, product_id, currency"
+			"GROUP BY revenue_provider, product_name, product_id, currency"
 		);
-		expect(product.sql).not.toContain("GROUP BY product_name");
-		expect(product.sql).toContain("argMax(product_name, created)");
+		expect(product.sql).toContain("coalesce(product_name, 'Unknown') as name");
+		expect(product.sql).not.toContain("argMax(product_name, created)");
 		expect(product.sql).toContain("sumIf(amount, type != 'refund') as revenue");
 		expect(product.sql).toContain(
-			"currency = {rf0:String} AND revenue_provider = {rf1:String} AND product_id = {rf2:String}"
+			"currency = {rf0:String} AND revenue_provider = {rf1:String} AND product_name = {rf2:String} AND ifNull(product_id, '') = {rf3:String}"
 		);
 		expect(product.params).toMatchObject({
 			rf0: "USD",
 			rf1: "stripe",
-			rf2: "team:annual",
+			rf2: "Team",
+			rf3: "",
 			limit: 20,
 		});
 		const overview = compileBuilder(
 			"revenue_overview",
 			QueryBuilders.revenue_overview,
-			{
-				filters: [{ field: "product_id", op: "eq", value: "team:annual" }],
-			}
+			{ filters }
 		);
 		expect(overview.sql).toContain(
-			"revenue_attributed WHERE product_id = {rf0:String}"
+			"AND product_name = {rf2:String} AND ifNull(product_id, '') = {rf3:String}"
 		);
 		expect(overview.sql).toContain("toUInt8(0) AS payment_metrics_in_scope");
-		expect(overview.sql).toContain("FROM stripe_payment_attempts WHERE 0");
-		expect(overview.params.rf0).toBe("team:annual");
+		expect(overview.sql).toContain(
+			"FROM stripe_payment_attempts WHERE currency = {rf0:String} AND 0"
+		);
+		expect(overview.params.rf3).toBe("");
 	});
 
 	it("keeps error_fingerprints private", () => {

--- a/packages/ai/src/query/simple-builder.test.ts
+++ b/packages/ai/src/query/simple-builder.test.ts
@@ -969,6 +969,49 @@ describe("SimpleQueryBuilder.compile", () => {
 		expect(params.rf0).toBe("EUR");
 	});
 
+	it("measures stable product IDs across renames and enforces exact product filters", () => {
+		const product = compileBuilder(
+			"revenue_by_product",
+			QueryBuilders.revenue_by_product,
+			{
+				limit: 20,
+				filters: [
+					{ field: "currency", op: "eq", value: "USD" },
+					{ field: "provider", op: "eq", value: "stripe" },
+					{ field: "product_id", op: "eq", value: "team:annual" },
+				],
+			}
+		);
+		expect(product.sql).toContain(
+			"GROUP BY revenue_provider, product_id, currency"
+		);
+		expect(product.sql).not.toContain("GROUP BY product_name");
+		expect(product.sql).toContain("argMax(product_name, created)");
+		expect(product.sql).toContain("sumIf(amount, type != 'refund') as revenue");
+		expect(product.sql).toContain(
+			"currency = {rf0:String} AND revenue_provider = {rf1:String} AND product_id = {rf2:String}"
+		);
+		expect(product.params).toMatchObject({
+			rf0: "USD",
+			rf1: "stripe",
+			rf2: "team:annual",
+			limit: 20,
+		});
+		const overview = compileBuilder(
+			"revenue_overview",
+			QueryBuilders.revenue_overview,
+			{
+				filters: [{ field: "product_id", op: "eq", value: "team:annual" }],
+			}
+		);
+		expect(overview.sql).toContain(
+			"revenue_attributed WHERE product_id = {rf0:String}"
+		);
+		expect(overview.sql).toContain("toUInt8(0) AS payment_metrics_in_scope");
+		expect(overview.sql).toContain("FROM stripe_payment_attempts WHERE 0");
+		expect(overview.params.rf0).toBe("team:annual");
+	});
+
 	it("keeps error_fingerprints private", () => {
 		expect(QueryBuilders.error_fingerprints?.publicAccess).not.toBe(true);
 	});


### PR DESCRIPTION
A material shift in settled payment receipts can be hidden by unchanged total revenue. For example, Stripe receipts described “Team reports” fall from USD30,000 to15,000 while other receipts offset the decline and total USD revenue stays40,000. This adds discovery and exact investigation of that recorded description, without requiring a saved goal or funnel.

The scope follows current ingestion: recorded payment/invoice descriptions with no product ID. These are not verified catalog products, subscription churn, or allocated line-item revenue. Native queries preserve provider/name/ID/currency groups and add exact name/no-ID filters. Publication requires both complete windows for the exact description and a separate whole-currency control. Code renders the scope and numbers from validated reads, including “with no product ID.” A material verified receipt shift can be a useful observation even when total revenue is flat and its cause or repair is unknown.

Discovery adds two optional limit20 reads with a three-second abort deadline. Their failure cannot discard a valid core revenue/refund finding. Existing ranking selects one description per currency before cooldown so identical scans do not rotate between offsetting subjects. Missing/renamed/tail labels remain inconclusive. The top20 intersection can miss a material label that falls below the current cutoff; one-per-currency selection can defer smaller movements. No ingestion, storage, dependency, new model tool, or extra agent loop changes. Net runtime growth is346 lines; this adds capability rather than achieving the overall LoC-reduction target.

Based on staging after #745 and #746, including the independent stored-goal-filter correction9f629750d. No unmerged dependency. Overlap with those merged slices was independently reviewed after rebase.

Validation: root lint, check-types, and test commands pass. Combined independent review covers exact receipt/event identity, scope proof, optional failure isolation, repeated-run suppression, native SQL/filter compilation, and batch output column order. A full-suite column-order failure was fixed before push. The new gated ClickHouse integration fixture was reviewed but could not run locally; compiler tests are not live warehouse proof.

Fresh native-compiled synthetic model evals exposed an integrated regression: both material receipt findings were suppressed because totals were flat/no repair was known. After the scoped observation-rule correction, both exact cases publish, and a stable stored receipt recheck remains private. All attempts, including that failed batch and rejected prototypes, remain in the audit. Outputs still have redundant facts and62–71words; production coverage, broad precision/recall, and pricing readiness are not established. No customer writes or notifications were performed.

AI-assisted implementation and independent review under maintainer authorization.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds detection of material receipt description shifts that are hidden by flat total revenue. For example, Stripe "Team" receipts falling from $30,000 to $15,000 while other receipts keep total USD revenue at $40,000 now surfaces as a publishable observation without requiring a saved goal or funnel.

**New Features**
- Introduces a `product_revenue` signal for recorded payment and invoice descriptions with no product ID, grouped per provider and currency.
- Discovery uses two optional limit-20 reads with a 3-second abort deadline; their failure never discards a valid core revenue or refund finding.
- Publication requires native `revenue_overview` evidence for the exact description and a separate whole-currency control, both covering complete signal windows.
- Exact matching uses `product_name` and `product_id` (empty string) filters; same-label identified receipts, other providers, and currencies are excluded.
- One description per currency is retained so an identical next run reports the same movement instead of rotating to its offset.
- `@hono`-style package references kept in backticks: `SimpleQueryBuilder`, `RevenueBuilders`, and the shared insights schema remain unchanged in behavior for existing signals.

Side effects: `revenue_by_product` now groups by provider as well as name, ID, and currency. Missing, renamed, or tail labels stay inconclusive; whitespace-padded `Unknown` labels are rejected; top-20 intersection can miss material labels below the cutoff. No storage, dependency, model, or agent-loop changes beyond the added reads.

<sup>Written for commit 87f035bcbf25ee4ef734c366490ce09addc1e438. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

