### PR TITLE
fix(ai): let investigations read beyond truncated source files

### DIFF
--- a/packages/ai/src/ai/tools/github-tools.test.ts
+++ b/packages/ai/src/ai/tools/github-tools.test.ts
@@ -294,3 +294,303 @@ describe("GitHub release and PR evidence", () => {
 		expect(JSON.stringify(result)).not.toContain("private");
 	});
 });
+
+describe("GitHub bounded file evidence", () => {
+	const path = "src/tracking status.ts";
+	const oldSha = "a".repeat(40);
+	const newSha = "b".repeat(40);
+	const predicate = "return { tracking_setup: historicalPageviews > 0 };";
+	const oldContent = `${"// setup documentation\n".repeat(800)}${predicate}`;
+	const newContent = oldContent.replace(
+		"historicalPageviews",
+		"recentPageviews"
+	);
+	const resultSchema = z.object({
+		content: z.string(),
+		offset: z.number(),
+		nextOffset: z.number().nullable(),
+		totalCharacters: z.number(),
+		truncated: z.boolean(),
+		ref: z.string().nullable(),
+		blobSha: z.string().nullable(),
+	});
+
+	function fileTools(content = oldContent, sha: string | null = oldSha) {
+		return createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () => "fixture-token",
+				request: async () => ({
+					content: Buffer.from(content).toString("base64"),
+					encoding: "base64",
+					size: Buffer.byteLength(content),
+					sha,
+				}),
+			}
+		);
+	}
+
+	async function read(tools: ToolSet, input: Record<string, unknown>) {
+		return executeTool(
+			tools,
+			"github_read_file",
+			schema(tools, "github_read_file").parse({ path, ...input })
+		);
+	}
+
+	test("continues beyond the old cutoff to the deciding tracking predicate", async () => {
+		const tools = fileTools();
+		const first = resultSchema.parse(await read(tools, {}));
+		expect(first).toMatchObject({
+			content: `${oldContent.slice(0, 15_000)}\n…[truncated at 15KB]`,
+			offset: 0,
+			nextOffset: 15_000,
+			totalCharacters: oldContent.length,
+			truncated: true,
+			ref: null,
+			blobSha: oldSha,
+		});
+		expect(first.content).not.toContain(predicate);
+		const next = resultSchema.parse(
+			await read(tools, {
+				offset: first.nextOffset,
+			})
+		);
+		expect(next).toMatchObject({
+			content: oldContent.slice(15_000),
+			offset: 15_000,
+			nextOffset: null,
+			truncated: false,
+		});
+		expect(next.content).toContain(predicate);
+	});
+
+	test("keeps exact refs and blob identities separate in focused reads", async () => {
+		const calls: string[] = [];
+		const tools = createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () => "fixture-token",
+				request: async (url, token) => {
+					expect(token).toBe("fixture-token");
+					calls.push(url);
+					const old = url.endsWith("ref=release%2Fold");
+					return {
+						content: Buffer.from(old ? oldContent : newContent).toString(
+							"base64"
+						),
+						encoding: "base64",
+						sha: old ? oldSha : newSha,
+					};
+				},
+			}
+		);
+		const offset = oldContent.indexOf(predicate);
+		for (const [ref, sha, content] of [
+			["release/old", oldSha, oldContent],
+			["abcdef1234567890", newSha, newContent],
+		]) {
+			await read(tools, { ref });
+			expect(
+				resultSchema.parse(await read(tools, { ref, offset, length: 100 }))
+			).toMatchObject({
+				content: content.slice(offset),
+				ref,
+				blobSha: sha,
+				nextOffset: null,
+			});
+		}
+		expect(calls).toEqual([
+			"/repos/example/web-app/contents/src/tracking%20status.ts?ref=release%2Fold",
+			"/repos/example/web-app/contents/src/tracking%20status.ts?ref=release%2Fold",
+			"/repos/example/web-app/contents/src/tracking%20status.ts?ref=abcdef1234567890",
+			"/repos/example/web-app/contents/src/tracking%20status.ts?ref=abcdef1234567890",
+		]);
+		expect(
+			resultSchema.parse(await read(tools, { offset, ref: "release/old" }))
+				.content
+		).toContain(predicate);
+	});
+
+	test("rejects changed identities until a fresh first window and recovers", async () => {
+		let sha: string | null = oldSha;
+		const tools = createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () => "fixture-token",
+				request: async () => ({
+					encoding: "base64",
+					content: Buffer.from(
+						sha === oldSha ? oldContent : newContent
+					).toString("base64"),
+					sha,
+				}),
+			}
+		);
+		expect(await read(tools, { offset: 15_000 })).toHaveProperty("error");
+		await read(tools, {});
+		sha = newSha;
+		for (let attempt = 0; attempt < 2; attempt++) {
+			expect(await read(tools, { offset: 15_000 })).toMatchObject({
+				error: expect.stringContaining("offset 0"),
+			});
+		}
+		await read(tools, { offset: 0 });
+		expect(
+			resultSchema.parse(await read(tools, { offset: 15_000 })).content
+		).toContain("recentPageviews");
+		sha = null;
+		expect(await read(tools, { offset: 15_000 })).toHaveProperty("error");
+	});
+
+	test("isolates file identities by repo, path, ref and tool instance", async () => {
+		const tools = createGitHubTools(
+			{ organizationId: "org_1" },
+			{
+				getToken: async () => "fixture-token",
+				request: async (url) => ({
+					encoding: "base64",
+					content: Buffer.from(oldContent).toString("base64"),
+					sha: url.includes("/other/") ? newSha : oldSha,
+				}),
+			}
+		);
+		const initial = { ...repository, ref: "staging" };
+		await read(tools, initial);
+		for (const change of [
+			{ owner: "other" },
+			{ repo: "other" },
+			{ path: "other/source.ts" },
+			{ ref: "other" },
+		]) {
+			const input = { ...initial, ...change };
+			expect(await read(tools, { ...input, offset: 15_000 })).toHaveProperty(
+				"error"
+			);
+			await read(tools, input);
+			expect(
+				resultSchema.parse(await read(tools, { ...input, offset: 15_000 }))
+					.content
+			).toContain(predicate);
+		}
+		expect(
+			resultSchema.parse(await read(tools, { ...initial, offset: 15_000 }))
+				.content
+		).toContain(predicate);
+		expect(await read(fileTools(), { offset: 15_000 })).toHaveProperty("error");
+	});
+
+	test("rejects an old in-flight continuation after another first read changes identity", async () => {
+		let finishContinuation: (value: unknown) => void = () => {};
+		let startContinuation: () => void = () => {};
+		const started = new Promise<void>((resolve) => {
+			startContinuation = resolve;
+		});
+		const response = (sha: string) => ({
+			encoding: "base64",
+			content: Buffer.from(oldContent).toString("base64"),
+			sha,
+		});
+		let requests = 0;
+		const tools = createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () => "fixture-token",
+				request: () => {
+					requests++;
+					if (requests === 2) {
+						startContinuation();
+						return new Promise((resolve) => {
+							finishContinuation = resolve;
+						});
+					}
+					return Promise.resolve(response(requests === 1 ? oldSha : newSha));
+				},
+			}
+		);
+		await read(tools, {});
+		const pending = read(tools, { offset: 15_000 });
+		await started;
+		await read(tools, { offset: 0 });
+		finishContinuation(response(oldSha));
+		expect(await pending).toHaveProperty("error");
+	});
+
+	test("bounds windows, preserves UTF-16 offsets and handles EOF", async () => {
+		const text = "a😀\r\nbé";
+		const tools = fileTools(text);
+		expect(resultSchema.parse(await read(tools, {})).content).toBe(text);
+		expect(
+			resultSchema.parse(await read(tools, { offset: 3, length: 2 }))
+		).toMatchObject({
+			content: "\r\n",
+			offset: 3,
+			nextOffset: 5,
+			truncated: true,
+		});
+		for (const offset of [text.length, text.length + 1]) {
+			expect(resultSchema.parse(await read(tools, { offset }))).toMatchObject({
+				content: "",
+				nextOffset: null,
+				truncated: false,
+			});
+		}
+		expect(resultSchema.parse(await read(fileTools(""), {}))).toMatchObject({
+			content: "",
+			offset: 0,
+			nextOffset: null,
+			totalCharacters: 0,
+			truncated: false,
+		});
+		const unversioned = fileTools("source", null);
+		expect(await read(unversioned, {})).toMatchObject({ blobSha: null });
+		expect(await read(unversioned, { offset: 1 })).toHaveProperty("error");
+		const inputSchema = schema(tools, "github_read_file");
+		expect(z.toJSONSchema(inputSchema, { io: "input" })).not.toHaveProperty(
+			"properties.expectedBlobSha"
+		);
+		for (const input of [
+			{ offset: -1 },
+			{ offset: 0.5 },
+			{ offset: Number.MAX_SAFE_INTEGER + 1 },
+			{ length: 0 },
+			{ length: 15_001 },
+			{ length: 1.5 },
+			{ expectedBlobSha: oldSha },
+			{ path: "../secret", offset: 15_000 },
+			{ owner: "other", repo: "escape", offset: 15_000 },
+		]) {
+			expect(inputSchema.safeParse({ path, ...input }).success).toBe(false);
+		}
+	});
+
+	test("does not bypass auth, API failures or unavailable content for a later window", async () => {
+		let requests = 0;
+		const tools = createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () => null,
+				request: async () => {
+					requests++;
+					return {};
+				},
+			}
+		);
+		expect(await read(tools, { offset: 15_000 })).toEqual({
+			error: "No GitHub account connected",
+		});
+		expect(requests).toBe(0);
+		for (const response of [
+			{ error: "GitHub API 403: Forbidden" },
+			{ encoding: "none", content: "" },
+		]) {
+			const unavailable = createGitHubTools(
+				{ organizationId: "org_1", repository },
+				{ getToken: async () => "fixture-token", request: async () => response }
+			);
+			expect(await read(unavailable, { offset: 15_000 })).toHaveProperty(
+				"error"
+			);
+		}
+	});
+});

--- a/packages/ai/src/ai/tools/github-tools.ts
+++ b/packages/ai/src/ai/tools/github-tools.ts
@@ -17,6 +17,7 @@ const MAX_RESULTS = 10;
 const DEPLOY_FETCH_SIZE = 50;
 const MAX_DEPLOY_PAGES = 5;
 const MAX_COMMITS = 50;
+const MAX_FILE_CHARACTERS = 15_000;
 const SEARCH_SCOPE = /\b(?:repo|org|user):\S+/i;
 const DEPLOYMENT_RESULT_STATES = new Set(["error", "failure", "success"]);
 const DEPLOYMENT_TIMESTAMP = z
@@ -171,6 +172,8 @@ export function createGitHubTools(
 		dependencies.getToken ??
 		createInstallationFirstTokenFn(params.organizationId, params.userId);
 	const request = dependencies.request ?? githubFetch;
+	// Toolkits are created per agent run; never share file identities across runs.
+	const fileShas = new Map<string, string | null>();
 	const deploymentInput = createRepositorySchema(repository, {
 		environment: z
 			.string()
@@ -632,7 +635,7 @@ export function createGitHubTools(
 
 	const readFileTool = tool({
 		description:
-			"Read a file from a GitHub repo. Use to inspect source code when investigating a bug or tracking issue. Returns the file content as text.",
+			"Read source code to inspect a bug, tracking predicate or event meaning. Start at offset 0, then follow nextOffset with the same path/ref instead of repeating the prefix. Returns at most 15,000 UTF-16 source characters. The tool checks file identity across windows in this run; if it changes or is unavailable, restart at offset 0. truncated means more content follows this window. ref is the requested branch/tag/commit (null means default branch); blobSha identifies file content, not a deployed commit. Pin a known deployed commit for historical claims.",
 		inputSchema: createRepositorySchema(repository, {
 			path: REPOSITORY_PATH.describe(
 				"File path in the repo (e.g. 'src/components/navbar.tsx')"
@@ -643,6 +646,21 @@ export function createGitHubTools(
 				.describe(
 					"Branch, tag, or commit SHA. Defaults to the default branch."
 				),
+			offset: z
+				.number()
+				.int()
+				.nonnegative()
+				.optional()
+				.describe(
+					"Zero-based UTF-16 character offset; defaults to 0. Use nextOffset to continue."
+				),
+			length: z
+				.number()
+				.int()
+				.min(1)
+				.max(MAX_FILE_CHARACTERS)
+				.optional()
+				.describe("Maximum UTF-16 characters to return; defaults to 15,000."),
 		}),
 		execute: async (input) => {
 			const token = await getToken();
@@ -652,10 +670,10 @@ export function createGitHubTools(
 			const repo = resolveRepository(repository, input);
 
 			const refParam = input.ref ? `?ref=${encodeURIComponent(input.ref)}` : "";
-			const data = await request(
-				`/repos/${repositoryPath(repo)}/contents/${filePath(input.path)}${refParam}`,
-				token
-			);
+			const requestPath = `/repos/${repositoryPath(repo)}/contents/${filePath(input.path)}${refParam}`;
+			const previousSha = fileShas.get(requestPath);
+			const continuation = (input.offset ?? 0) > 0;
+			const data = await request(requestPath, token);
 
 			if (data && typeof data === "object" && "error" in data) {
 				return data;
@@ -666,19 +684,47 @@ export function createGitHubTools(
 				encoding?: string;
 				size?: number;
 				name?: string;
+				sha?: string;
 			};
-			if (!file.content || file.encoding !== "base64") {
+			if (typeof file?.content !== "string" || file.encoding !== "base64") {
 				return { error: "File not found or not a regular file" };
+			}
+			const blobSha = file.sha?.toLowerCase() || null;
+			const currentSha = fileShas.get(requestPath);
+			if (
+				(continuation && (!previousSha || previousSha !== blobSha)) ||
+				(currentSha !== previousSha && currentSha !== blobSha)
+			) {
+				return {
+					error:
+						"File identity changed or is unavailable for continuation. Read this path/ref again at offset 0, then follow the new nextOffset.",
+				};
+			}
+			if (!continuation) {
+				fileShas.set(requestPath, blobSha);
 			}
 
 			const decoded = Buffer.from(file.content, "base64").toString("utf-8");
+			const offset = Math.min(input.offset ?? 0, decoded.length);
+			const end = Math.min(
+				offset + (input.length ?? MAX_FILE_CHARACTERS),
+				decoded.length
+			);
+			const content = decoded.slice(offset, end);
+			const truncated = end < decoded.length;
 			return {
 				path: input.path,
 				size: file.size,
+				ref: input.ref ?? null,
+				blobSha,
+				offset,
+				nextOffset: truncated ? end : null,
+				totalCharacters: decoded.length,
+				truncated,
 				content:
-					decoded.length > 15_000
-						? `${decoded.slice(0, 15_000)}\n…[truncated at 15KB]`
-						: decoded,
+					truncated && input.offset === undefined && input.length === undefined
+						? `${content}\n…[truncated at 15KB]`
+						: content,
 			};
 		},
 	});


### PR DESCRIPTION
The agent could only read the first 15,000 characters of a repository file, so relevant tracking predicates or failure mechanisms later in the file were inaccessible. Add bounded continuation to the existing GitHub reader with offset/length and nextOffset metadata.

File-version checks stay inside the per-run tool closure, scoped by repository/path/ref. Changed or missing identities and stale concurrent windows reject with a restart path. The model does not supply hashes. Default prefix behavior, authorization and path restrictions remain; blob identity is explicitly distinguished from a deployed commit.

Validation: root lint, all 33 workspace typechecks and 215 relevant native tests pass. A fresh live native investigation read offsets 0 then 15,000, found the synthetic null-payment predicate and proposed its documented fallback in a 60-word brief (three model calls, 12.06 seconds, no repeated reads). The fixed-prefix baseline could only publish measured reliability without a verified mechanism. One earlier candidate failed because it invented a hash; that result is preserved, and the model-facing hash parameter was removed before the successful run. This is one paired synthetic capability demonstration, not a general quality benchmark or production incident claim.

Scope: existing GitHub read tool and its tests. No database, business-profile, planner or deployment dependency. No overlap with #751's modified files. AI-assisted implementation, native evaluation and independent review; maintainer-directed work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub source file reads so investigations can continue past the previous 15,000-character cutoff and reach logic later in the file.

- Adds `offset`/`length` inputs and `nextOffset`, `totalCharacters`, and `truncated` metadata to `github_read_file`.
- Tracks file identity per repo/path/ref within a run; changed or missing identities reject continuations and require a fresh read at offset 0.
- Keeps default prefix behavior, authorization, and path restrictions unchanged. The model never supplies blob hashes.

<sup>Written for commit 0bfceeaaeecefa831fe784eaf6d2f5c69fa0dce6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

