### PR TITLE
fix(ai): bind source identity before asynchronous auth

### DIFF
--- a/packages/ai/src/ai/tools/github-tools.test.ts
+++ b/packages/ai/src/ai/tools/github-tools.test.ts
@@ -516,6 +516,46 @@ describe("GitHub bounded file evidence", () => {
 		expect(await pending).toHaveProperty("error");
 	});
 
+	test("rejects a continuation paused in auth when another first read changes identity", async () => {
+		let releaseToken!: (value: string) => void;
+		const pendingToken = new Promise<string>((resolve) => {
+			releaseToken = resolve;
+		});
+		let tokens = 0;
+		let requests = 0;
+		let sha = oldSha;
+		const tools = createGitHubTools(
+			{ organizationId: "org_1", repository },
+			{
+				getToken: async () =>
+					++tokens === 2 ? pendingToken : "fixture-token",
+				request: async () => {
+					requests++;
+					return {
+						encoding: "base64",
+						content: Buffer.from(
+							sha === oldSha ? oldContent : newContent
+						).toString("base64"),
+						sha,
+					};
+				},
+			}
+		);
+		await read(tools, {});
+		const pending = read(tools, { offset: 15_000 });
+		expect(tokens).toBe(2);
+		expect(requests).toBe(1);
+		sha = newSha;
+		await read(tools, { offset: 0 });
+		releaseToken("fixture-token");
+		const rejected = await pending;
+		expect(rejected).toHaveProperty("error");
+		expect(rejected).not.toHaveProperty("content");
+		expect(
+			resultSchema.parse(await read(tools, { offset: 15_000 })).content
+		).toContain("recentPageviews");
+	});
+
 	test("bounds windows, preserves UTF-16 offsets and handles EOF", async () => {
 		const text = "a😀\r\nbé";
 		const tools = fileTools(text);

--- a/packages/ai/src/ai/tools/github-tools.test.ts
+++ b/packages/ai/src/ai/tools/github-tools.test.ts
@@ -517,10 +517,8 @@ describe("GitHub bounded file evidence", () => {
 	});
 
 	test("rejects a continuation paused in auth when another first read changes identity", async () => {
-		let releaseToken!: (value: string) => void;
-		const pendingToken = new Promise<string>((resolve) => {
-			releaseToken = resolve;
-		});
+		const { promise: pendingToken, resolve: releaseToken } =
+			Promise.withResolvers<string>();
 		let tokens = 0;
 		let requests = 0;
 		let sha = oldSha;

--- a/packages/ai/src/ai/tools/github-tools.ts
+++ b/packages/ai/src/ai/tools/github-tools.ts
@@ -663,16 +663,16 @@ export function createGitHubTools(
 				.describe("Maximum UTF-16 characters to return; defaults to 15,000."),
 		}),
 		execute: async (input) => {
+			const repo = resolveRepository(repository, input);
+			const refParam = input.ref ? `?ref=${encodeURIComponent(input.ref)}` : "";
+			const requestPath = `/repos/${repositoryPath(repo)}/contents/${filePath(input.path)}${refParam}`;
+			// Bind this read before auth can yield to a concurrent first-window read.
+			const previousSha = fileShas.get(requestPath);
+			const continuation = (input.offset ?? 0) > 0;
 			const token = await getToken();
 			if (!token) {
 				return { error: "No GitHub account connected" };
 			}
-			const repo = resolveRepository(repository, input);
-
-			const refParam = input.ref ? `?ref=${encodeURIComponent(input.ref)}` : "";
-			const requestPath = `/repos/${repositoryPath(repo)}/contents/${filePath(input.path)}${refParam}`;
-			const previousSha = fileShas.get(requestPath);
-			const continuation = (input.offset ?? 0) > 0;
 			const data = await request(requestPath, token);
 
 			if (data && typeof data === "object" && "error" in data) {


### PR DESCRIPTION
A file continuation paused during authentication could accept a newer suffix after a concurrent first-window read changed the remembered file identity. Capture the requested file identity synchronously before awaiting authentication; authorization remains required before the GitHub request.

The deterministic native regression fails on #754 and passes after this ordering fix: hold the continuation in token resolution, restart with a changed file, release auth, reject the stale suffix, then accept a continuation of the new prefix. Root lint, all 33 workspace typechecks and 216 relevant tests pass. No model, tool-schema, storage or other runtime change. Follow-up to merged #754; independently reviewed, no unmerged dependency. AI-assisted maintainer-directed implementation and review.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race where a file continuation paused during authentication could accept a newer suffix after a concurrent first-window read changed the remembered file identity. The file identity is now captured synchronously before awaiting auth; authorization is still required before the GitHub request.

**Bug Fixes**
- Rejects a stale continuation when a first-window read changes the file identity while auth is pending.
- Adds a regression test reproducing that ordering.

<sup>Written for commit 0c07fd60d4fed4c736d413a5ae86e0cc3b3aa529. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

