### PR TITLE
fix(ci): break the deadlock between the soak gate and the basket deploy

### DIFF
--- a/.github/workflows/promote-gate.yml
+++ b/.github/workflows/promote-gate.yml
@@ -8,7 +8,7 @@ jobs:
   staging-soak:
     name: Staging Soak Gate
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    timeout-minutes: 50
+    timeout-minutes: 15
     steps:
       - name: Pass through for non-staging heads
         if: github.head_ref != 'staging'
@@ -20,8 +20,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          required=("Databuddy - API Staging" "Databuddy - Staging Basket")
-          attempts=90
+          required=("Databuddy - API Staging")
+          attempts=20
           for attempt in $(seq 1 "$attempts"); do
             statuses=$(gh api "repos/${{ github.repository }}/commits/$SHA/status" --jq '.statuses[] | "\(.context)=\(.state)"')
             ok=0
@@ -38,7 +38,7 @@ jobs:
             echo "Waiting for staging deploys ($ok/${#required[@]} green, attempt $attempt/$attempts)"
             sleep 30
           done
-          echo "Staging deploys did not go green within 45 minutes"; exit 1
+          echo "Staging deploys did not go green within 10 minutes"; exit 1
 
       - name: Probe staging service health
         if: github.head_ref == 'staging'


### PR DESCRIPTION
Staging basket was never slow. The gate and the deploy were waiting on each other.

Railway holds the basket deploy until **every GitHub check on the commit completes**. The Staging Soak Gate is one of those checks, and it was waiting on the basket status. So basket only deployed once the gate timed out.

## Evidence

Basket's latency tracked my gate budget, plus about a minute, every time I changed it:

| gate budget | basket landed at |
|---|---|
| 12 min | 12.9 min |
| 25 min | 25.9, 27.1 min |
| 45 min | 46 min |

On `df0eed6a0` the gate finished at **13:33:38** and basket posted its first status at **13:33:42** — four seconds later.

And on the two commits where basket did post a `pending` status, the deploy itself took **49 and 68 seconds**, which is exactly what API Staging takes (35-73s). API posts `pending` then `success`; basket posts only the terminal state, which is why it looked absent rather than in-progress.

So the three budget increases I made earlier today each widened the deadlock rather than accommodating a slow deploy. This reverts that reasoning.

## The fix

The gate now waits only on `Databuddy - API Staging` and still probes **both** health endpoints, including `staging-basket.databuddy.cc/health/status`. That probe is the check that actually proves basket is serving; waiting on its commit status was both redundant and the cause of the stall.

Budget back to 10 minutes against API's observed 35-73 seconds, timeout 15, message matching.

## Follow-up worth considering

Railway's "wait for CI" on the basket service is the underlying trigger. If that is intentional, any future check that waits on a Railway status will deadlock the same way. Worth deciding deliberately rather than leaving as a trap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CI deadlock where the staging soak gate and the basket deploy waited on each other, so basket only deployed once the gate timed out.

**Bug Fixes**
- Railway holds the basket deploy until every GitHub check completes, and the gate was one of those checks waiting on basket's status.
- The gate now waits only on `Databuddy - API Staging` and still probes both health endpoints, which is the check that actually proves basket is serving.
- The budget is back to 10 minutes against API's observed 35-73 second deploy time.

<sup>Written for commit 7b26314fa761eb1408b351ec0addf7971b4e220f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

