### PR TITLE
fix(insights): verify unfiltered native analytics reads

### DIFF
--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -964,7 +964,10 @@ function verificationFor(
 			typeof item.input === "object" &&
 			isDeepStrictEqual(
 				Object.fromEntries(
-					Object.entries(item.input).filter(([key]) => key !== "websiteId")
+					Object.entries(item.input).filter(
+						([key, value]) =>
+							key !== "websiteId" && !(key === "cohort" && value == null)
+					)
 				),
 				{
 					[`${input.signal.entity.type}Id`]: input.signal.entity.id,

--- a/apps/insights/src/evals/quality.test.ts
+++ b/apps/insights/src/evals/quality.test.ts
@@ -292,3 +292,25 @@ it("rejects an activation definition lookup for another website", () => {
 		)
 	).toThrow();
 });
+
+it.each([
+	{ offset: 0, length: 15000, valid: true },
+	{ offset: 1, length: 1, valid: false },
+	{ offset: 0, length: 1, valid: false },
+])("source fixture honors its supported read window: %j", async ({
+	offset,
+	length,
+	valid,
+}) => {
+	const read = qualityCases.find(
+		(entry) => entry.id === "available-repository-mechanism"
+	)?.tools.github_read_file;
+	if (!read?.execute) throw new Error("Missing repository fixture");
+	const output = await read.execute(
+		{ path: "src/checkout.ts", ref: "abcdef1", offset, length },
+		{ toolCallId: "source-window", messages: [] }
+	);
+	expect(output).toMatchObject(
+		valid ? { content: expect.any(String) } : { error: expect.any(String) }
+	);
+});

--- a/apps/insights/src/evals/quality.ts
+++ b/apps/insights/src/evals/quality.ts
@@ -847,10 +847,12 @@ qualityCases.push({
 		...(calls.some(
 			(call) =>
 				call.name === "github_read_file" &&
-				isDeepStrictEqual(call.input, {
-					path: "src/checkout.ts",
-					ref: "abcdef1",
-				}) &&
+				z
+					.object({
+						path: z.literal("src/checkout.ts"),
+						ref: z.literal("abcdef1"),
+					})
+					.safeParse(call.input).success &&
 				call.output &&
 				typeof call.output === "object" &&
 				!("error" in call.output) &&
@@ -981,19 +983,16 @@ for (const repaired of [false, true]) {
 					!("error" in call.output) &&
 					"total_users_completed" in call.output &&
 					call.output.total_users_completed === (repaired ? 120 : 40) &&
-					isDeepStrictEqual(
-						{
-							goalId: goal.id,
-							startDate: period.current.from,
-							endDate: period.current.to,
-							...(call.input &&
-							typeof call.input === "object" &&
-							"websiteId" in call.input
-								? { websiteId: appContext.websiteId }
-								: {}),
-						},
-						call.input
-					)
+					z
+						.object({
+							goalId: z.literal(goal.id),
+							startDate: z.literal(period.current.from),
+							endDate: z.literal(period.current.to),
+							websiteId: z.literal(appContext.websiteId).optional(),
+							cohort: z.null().optional(),
+						})
+						.strict()
+						.safeParse(call.input).success
 			)
 				? []
 				: ["Accepted a reported repair without remeasuring"]),

--- a/apps/insights/src/evals/quality.ts
+++ b/apps/insights/src/evals/quality.ts
@@ -826,10 +826,15 @@ qualityCases.push({
 		github_read_file: {
 			...repositoryTools.github_read_file,
 			execute: (query) => {
-				if (query.path !== "src/checkout.ts" || query.ref !== "abcdef1") {
+				if (
+					query.path !== "src/checkout.ts" ||
+					query.ref !== "abcdef1" ||
+					(query.offset ?? 0) !== 0 ||
+					(query.length ?? 15_000) !== 15_000
+				) {
 					return {
 						error:
-							"Read the observed deployed file and revision; no other synthetic source is available.",
+							"This fixture supports the observed deployed file and revision with offset 0 and default length 15000 only.",
 					};
 				}
 				return {
@@ -851,6 +856,8 @@ qualityCases.push({
 					.object({
 						path: z.literal("src/checkout.ts"),
 						ref: z.literal("abcdef1"),
+						offset: z.literal(0).optional(),
+						length: z.literal(15_000).optional(),
 					})
 					.safeParse(call.input).success &&
 				call.output &&

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -1957,6 +1957,7 @@ describe("intelligence agent", () => {
 		"wrong-measured-id",
 		"passed",
 		"passed-explicit",
+		"passed-null-cohort",
 		"passed-domain",
 		"passed-cosmetic",
 		"failed-rate",
@@ -1966,6 +1967,7 @@ describe("intelligence agent", () => {
 		"wrong-start",
 		"wrong-end",
 		"extra-filter",
+		"extra-cohort",
 		"small-sample",
 		"unfinished-window",
 		"failed-read",
@@ -2005,6 +2007,7 @@ describe("intelligence agent", () => {
 		const status = [
 			"passed",
 			"passed-explicit",
+			"passed-null-cohort",
 			"passed-domain",
 			"passed-cosmetic",
 		].includes(scenario)
@@ -2021,6 +2024,16 @@ describe("intelligence agent", () => {
 			...(scenario === "wrong-website" ? { websiteId: "another-site" } : {}),
 			...(scenario === "passed-domain" ? { websiteId: "example.com" } : {}),
 			...(scenario === "extra-filter" ? { filter: "paid-only" } : {}),
+			...(scenario === "passed-null-cohort" ? { cohort: null } : {}),
+			...(scenario === "extra-cohort"
+				? {
+						cohort: {
+							filters: [
+								{ field: "browser_name", operator: "equals", value: "Chrome" },
+							],
+						},
+					}
+				: {}),
 		};
 		const candidate = {
 			...agentOutcome,


### PR DESCRIPTION
Native goal and funnel reads can include `cohort: null` to request the saved definition without additional filtering. Recovery verification compared the raw input object with an omitted-cohort query, so correctly measured repairs were reported as inconclusive. Treat only null/undefined cohort as omission; retain every non-null cohort and all other exact subject, definition, population, date, sample and threshold checks.

Fresh synthetic investigations reproduced the problem with both Terra and Astra. After the fix, 14 native Terra runs verified passed/failed conditions correctly and retained inconclusive verdicts for insufficient samples, unfinished windows, changed populations and clipped dates. Two stale eval checks now accept normal native parameters: nullable unfiltered cohorts and GitHub source-read offset/length.

Validation: 503 Insights tests passed (six live tests skipped), repository lint passed, and all 33 typecheck/build tasks passed. Added regression coverage for explicit null cohort and rejection of a real filtered cohort. No database, billing, delivery or schema changes. Independent review completed with no remaining blockers. Its fixture-window finding was fixed and covered by three bounded read-window cases; the 207 targeted flow/eval tests passed.
