### PR TITLE
feat(insights): retain supplied business context on investigations

### DIFF
--- a/apps/dashboard/app/(main)/insights/[id]/page.tsx
+++ b/apps/dashboard/app/(main)/insights/[id]/page.tsx
@@ -30,6 +30,7 @@ import {
 	StatusDot,
 	Textarea,
 } from "@databuddy/ui";
+import { ContextUsed } from "../_components/context-used";
 import { ExecuteDefinitionAction } from "../_components/investigation-row";
 
 type TimelineItem = InsightByIdResponse["timeline"][number];
@@ -470,6 +471,8 @@ function InvestigationActivity({
 						: (sourceLink?.href ?? null)
 				}
 			/>
+
+			<ContextUsed snapshot={outcome.contextSnapshot} />
 
 			<NextStep
 				hideAction={executable}

--- a/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
@@ -71,14 +71,25 @@ describe("Business context disclosure", () => {
 		expect(html).toContain("Priority: completed downloads");
 		expect(html.match(/Revision 4/g)).toHaveLength(2);
 	});
-	it("does not invent provenance for legacy results and explains unavailable context", () => {
+	it("does not invent provenance for legacy results", () => {
 		expect(renderToStaticMarkup(<ContextUsed />)).toBe("");
+	});
+	it.each([
+		"unavailable",
+		"disabled",
+		"ready",
+		"partial",
+	] as const)("does not claim background was available for an empty %s snapshot", (status) => {
 		const html = renderToStaticMarkup(
-			<ContextUsed
-				snapshot={{ ...snapshot, status: "unavailable", sources: [] }}
-			/>
+			<ContextUsed snapshot={{ ...snapshot, status, sources: [] }} />
 		);
-		expect(html).toContain("Business context was unavailable for this update.");
+		expect(html).toContain(
+			status === "unavailable"
+				? "Business context was unavailable for this update."
+				: "No business context sources were supplied for this update."
+		);
+		expect(html).not.toContain("Background available for this update.");
+		expect(html).not.toContain("which facts influenced individual claims");
 		expect(html).not.toContain("Revision");
 	});
 	it("does not turn non-web source URLs into clickable links", () => {

--- a/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import type { BusinessContext } from "@databuddy/shared/insights";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ContextUsed } from "./context-used";
+
+const snapshot: BusinessContext = {
+	capturedAt: "2026-09-08T12:00:00Z",
+	status: "ready",
+	issues: [],
+	sources: [
+		{
+			id: "profile-example",
+			kind: "organization_profile",
+			origin: "team",
+			content: "Preparation starts a draft. <script>unsafe()</script>",
+			observedAt: "2026-09-08T11:00:00Z",
+			profileVersion: { revision: 3, updatedAt: "2026-09-08T11:00:00Z" },
+			references: [
+				{ title: "Report guide", url: "https://example.com/reports" },
+			],
+		},
+	],
+};
+
+describe("Context used disclosure", () => {
+	it("shows supplied text and revision without claiming fact-to-claim attribution", () => {
+		const html = renderToStaticMarkup(<ContextUsed snapshot={snapshot} />);
+		expect(html).toContain("Context used");
+		expect(html).toContain('aria-expanded="false"');
+		expect(html).toContain("Business context supplied to the model");
+		expect(html).toContain(
+			"does not identify which facts influenced individual claims"
+		);
+		expect(html).toContain("Revision 3");
+		expect(html).toContain('dateTime="2026-09-08T11:00:00Z"');
+		expect(html).toContain('href="https://example.com/reports"');
+		expect(html).toContain("Report guide");
+		expect(html).toContain("Preparation starts a draft.");
+		expect(html).not.toContain("<script>");
+	});
+	it("distinguishes mixed background from named team priorities at the supplied revision", () => {
+		const html = renderToStaticMarkup(
+			<ContextUsed
+				snapshot={{
+					...snapshot,
+					sources: [
+						{
+							id: "mixed-background",
+							kind: "organization_profile",
+							origin: "mixed",
+							content: "Edited public background",
+							author: "Edited website background",
+							observedAt: snapshot.capturedAt,
+							profileVersion: { revision: 4, updatedAt: snapshot.capturedAt },
+						},
+						{
+							id: "team-context",
+							kind: "organization_profile",
+							origin: "team",
+							content: "Priority: completed downloads",
+							author: "Team priorities and definitions",
+							observedAt: snapshot.capturedAt,
+							profileVersion: { revision: 4, updatedAt: snapshot.capturedAt },
+						},
+					],
+				}}
+			/>
+		);
+		expect(html).toContain("Website background with team edits");
+		expect(html).toContain("Team priorities and definitions");
+		expect(html).toContain("Priority: completed downloads");
+		expect(html.match(/Revision 4/g)).toHaveLength(2);
+	});
+	it("does not invent provenance for legacy results and explains unavailable context", () => {
+		expect(renderToStaticMarkup(<ContextUsed />)).toBe("");
+		const html = renderToStaticMarkup(
+			<ContextUsed
+				snapshot={{ ...snapshot, status: "unavailable", sources: [] }}
+			/>
+		);
+		expect(html).toContain("Business context was unavailable for this update.");
+		expect(html).not.toContain("Revision");
+	});
+	it("does not turn non-web source URLs into clickable links", () => {
+		const source = snapshot.sources[0];
+		if (!source) {
+			throw new Error("Expected source fixture");
+		}
+		const html = renderToStaticMarkup(
+			<ContextUsed
+				snapshot={{
+					...snapshot,
+					sources: [
+						{
+							...source,
+							references: [
+								{ title: "Untrusted link", url: "javascript:alert(1)" },
+							],
+						},
+					],
+				}}
+			/>
+		);
+		expect(html).toContain("Untrusted link");
+		expect(html).not.toContain('href="javascript:');
+	});
+});

--- a/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.test.tsx
@@ -22,12 +22,12 @@ const snapshot: BusinessContext = {
 	],
 };
 
-describe("Context used disclosure", () => {
+describe("Business context disclosure", () => {
 	it("shows supplied text and revision without claiming fact-to-claim attribution", () => {
 		const html = renderToStaticMarkup(<ContextUsed snapshot={snapshot} />);
-		expect(html).toContain("Context used");
+		expect(html).toContain("Business context");
 		expect(html).toContain('aria-expanded="false"');
-		expect(html).toContain("Business context supplied to the model");
+		expect(html).toContain("Background available for this update.");
 		expect(html).toContain(
 			"does not identify which facts influenced individual claims"
 		);

--- a/apps/dashboard/app/(main)/insights/_components/context-used.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.tsx
@@ -17,10 +17,12 @@ export function ContextUsed({ snapshot }: { snapshot?: BusinessContext }) {
 				Business context
 			</Accordion.Trigger>
 			<Accordion.Content className="space-y-3 px-2 text-muted-foreground text-xs">
-				<p>
-					Background available for this update. This snapshot does not identify
-					which facts influenced individual claims.
-				</p>
+				{snapshot.sources.length > 0 && (
+					<p>
+						Background available for this update. This snapshot does not
+						identify which facts influenced individual claims.
+					</p>
+				)}
 				<p>
 					Captured{" "}
 					<time dateTime={snapshot.capturedAt}>

--- a/apps/dashboard/app/(main)/insights/_components/context-used.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.tsx
@@ -14,12 +14,12 @@ export function ContextUsed({ snapshot }: { snapshot?: BusinessContext }) {
 	return (
 		<Accordion>
 			<Accordion.Trigger className="bg-transparent px-2">
-				Context used
+				Business context
 			</Accordion.Trigger>
 			<Accordion.Content className="space-y-3 px-2 text-muted-foreground text-xs">
 				<p>
-					Business context supplied to the model for this update. This snapshot
-					does not identify which facts influenced individual claims.
+					Background available for this update. This snapshot does not identify
+					which facts influenced individual claims.
 				</p>
 				<p>
 					Captured{" "}
@@ -66,10 +66,7 @@ export function ContextUsed({ snapshot }: { snapshot?: BusinessContext }) {
 							{source.url && <SourceLink url={source.url} title={source.url} />}
 							{Boolean(source.references?.length) && (
 								<div className="space-y-1 pt-1">
-									<p>
-										Links recorded with this source; not citations for
-										individual claims.
-									</p>
+									<p>Source links</p>
 									<ul className="space-y-1">
 										{source.references?.map((reference) => (
 											<li key={reference.url}>

--- a/apps/dashboard/app/(main)/insights/_components/context-used.tsx
+++ b/apps/dashboard/app/(main)/insights/_components/context-used.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import type {
+	BusinessContext,
+	BusinessSource,
+} from "@databuddy/shared/insights";
+import { formatDateTime } from "@databuddy/ui";
+import { Accordion } from "@databuddy/ui/client";
+
+export function ContextUsed({ snapshot }: { snapshot?: BusinessContext }) {
+	if (!snapshot) {
+		return null;
+	}
+	return (
+		<Accordion>
+			<Accordion.Trigger className="bg-transparent px-2">
+				Context used
+			</Accordion.Trigger>
+			<Accordion.Content className="space-y-3 px-2 text-muted-foreground text-xs">
+				<p>
+					Business context supplied to the model for this update. This snapshot
+					does not identify which facts influenced individual claims.
+				</p>
+				<p>
+					Captured{" "}
+					<time dateTime={snapshot.capturedAt}>
+						{formatDateTime(snapshot.capturedAt)}
+					</time>
+				</p>
+				{snapshot.status === "partial" && (
+					<p>Some context was unavailable or omitted.</p>
+				)}
+				{snapshot.sources.length === 0 && (
+					<p>
+						{snapshot.status === "unavailable"
+							? "Business context was unavailable for this update."
+							: "No business context sources were supplied for this update."}
+					</p>
+				)}
+				<ul className="space-y-4">
+					{snapshot.sources.map((source) => (
+						<li className="min-w-0 space-y-1" key={source.id}>
+							<p className="font-medium text-foreground">
+								{sourceName(source)}
+							</p>
+							{source.kind === "organization_profile" && source.author && (
+								<p>{source.author}</p>
+							)}
+							<p>
+								{source.profileVersion
+									? `Revision ${source.profileVersion.revision} · Saved `
+									: "Recorded "}
+								<time
+									dateTime={
+										source.profileVersion?.updatedAt ?? source.observedAt
+									}
+								>
+									{formatDateTime(
+										source.profileVersion?.updatedAt ?? source.observedAt
+									)}
+								</time>
+							</p>
+							<p className="whitespace-pre-wrap break-words text-foreground/80 leading-relaxed">
+								{source.content}
+							</p>
+							{source.url && <SourceLink url={source.url} title={source.url} />}
+							{Boolean(source.references?.length) && (
+								<div className="space-y-1 pt-1">
+									<p>
+										Links recorded with this source; not citations for
+										individual claims.
+									</p>
+									<ul className="space-y-1">
+										{source.references?.map((reference) => (
+											<li key={reference.url}>
+												<SourceLink {...reference} />
+											</li>
+										))}
+									</ul>
+								</div>
+							)}
+						</li>
+					))}
+				</ul>
+			</Accordion.Content>
+		</Accordion>
+	);
+}
+
+function sourceName(source: BusinessSource) {
+	if (source.kind === "organization_profile") {
+		return source.origin === "website"
+			? "Organization brief · Website background"
+			: source.origin === "mixed"
+				? "Organization brief · Website background with team edits"
+				: source.origin === "team"
+					? "Organization brief · Team supplied or edited"
+					: "Organization brief";
+	}
+	return source.kind === "team_reply"
+		? `Team reply${source.author ? ` · ${source.author}` : ""}`
+		: "Website excerpt";
+}
+
+function SourceLink({ url, title }: { url: string; title: string }) {
+	const protocol = new URL(url).protocol;
+	if (protocol !== "https:" && protocol !== "http:") {
+		return <span className="break-all">{title || url}</span>;
+	}
+	return (
+		<a
+			className="break-all underline underline-offset-2 hover:text-foreground"
+			href={url}
+			rel="noopener noreferrer"
+			target="_blank"
+			title={url}
+		>
+			{title || url}
+		</a>
+	);
+}

--- a/apps/insights/src/agent.ts
+++ b/apps/insights/src/agent.ts
@@ -1417,17 +1417,20 @@ export async function runInsightAgent(
 		repository: input.githubRepository,
 		investigationObjective: input.investigationObjective,
 		evidence: input.evidence,
-		history: input.history.map((item) =>
-			item.kind === "investigation"
-				? {
-						asOf: item.asOf,
-						evidence: item.evidence,
-						kind: item.kind,
-						outcome: item.outcome,
-						signal: promptSignal(item.signal),
-					}
-				: item
-		),
+		history: input.history.map((item) => {
+			if (item.kind !== "investigation") {
+				return item;
+			}
+			// Prior snapshots remain inspectable history, not fresh model context.
+			const { contextSnapshot: _snapshot, ...outcome } = item.outcome;
+			return {
+				asOf: item.asOf,
+				evidence: item.evidence,
+				kind: item.kind,
+				outcome,
+				signal: promptSignal(item.signal),
+			};
+		}),
 		otherOpenWork: input.otherOpenWork,
 		...(input.request
 			? {

--- a/apps/insights/src/business-context-generation.test.ts
+++ b/apps/insights/src/business-context-generation.test.ts
@@ -62,6 +62,7 @@ const profile: BusinessContext = {
 
 describe("freezing investigation business context", () => {
 	it("retains the captured canonical revision when the saved profile changes after freezing", () => {
+		const reference = { title: "Report guide", url: "https://example.com/reports" };
 		const saved = {
 			content: "Preparation starts a draft.",
 			origin: "team" as const,
@@ -69,7 +70,7 @@ describe("freezing investigation business context", () => {
 			updatedAt: "2026-07-11T11:00:00.000Z",
 			updatedBy: "example-editor",
 			sourceWebsiteId: null,
-			sources: [{ title: "Report guide", url: "https://example.com/reports" }],
+			sources: [reference],
 		};
 		const context = organizationProfileContext(
 			saved,
@@ -84,7 +85,7 @@ describe("freezing investigation business context", () => {
 		});
 		saved.revision = 4;
 		saved.content = "New operational priority.";
-		saved.sources[0]!.title = "Changed source";
+		reference.title = "Changed source";
 		const frozen = parseFrozenInvestigationPlan(
 			JSON.parse(stored),
 			"manual",

--- a/apps/insights/src/business-context-generation.test.ts
+++ b/apps/insights/src/business-context-generation.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@databuddy/ai/lib/business-context";
 import {
 	loadWebsiteBusinessProfile,
+	organizationProfileContext,
 	recallWebsiteBusinessContext,
 } from "./business-context";
 import { planInvestigationsWithBusinessContext } from "./generation";
@@ -60,6 +61,43 @@ const profile: BusinessContext = {
 };
 
 describe("freezing investigation business context", () => {
+	it("retains the captured canonical revision when the saved profile changes after freezing", () => {
+		const saved = {
+			content: "Preparation starts a draft.",
+			origin: "team" as const,
+			revision: 3,
+			updatedAt: "2026-07-11T11:00:00.000Z",
+			updatedBy: "example-editor",
+			sourceWebsiteId: null,
+			sources: [{ title: "Report guide", url: "https://example.com/reports" }],
+		};
+		const context = organizationProfileContext(
+			saved,
+			input.organizationId,
+			new Date(input.asOf)
+		);
+		const stored = JSON.stringify({
+			asOf: input.asOf,
+			reason: "manual",
+			businessScope,
+			candidates: [{ ...candidates[0], businessContext: context }],
+		});
+		saved.revision = 4;
+		saved.content = "New operational priority.";
+		saved.sources[0]!.title = "Changed source";
+		const frozen = parseFrozenInvestigationPlan(
+			JSON.parse(stored),
+			"manual",
+			businessScope
+		);
+		expect(frozen.candidates[0]?.businessContext?.sources[0]).toMatchObject({
+			content: "Preparation starts a draft.",
+			profileVersion: { revision: 3, updatedAt: "2026-07-11T11:00:00.000Z" },
+			references: [
+				{ title: "Report guide", url: "https://example.com/reports" },
+			],
+		});
+	});
 	it("loads shared context once and recalls each exact subject before freezing", async () => {
 		let profileReads = 0;
 		const recalled: string[] = [];

--- a/apps/insights/src/business-context.integration.test.ts
+++ b/apps/insights/src/business-context.integration.test.ts
@@ -152,7 +152,7 @@ integration("persisted business reply scope", () => {
 		let supplied: BusinessContext | undefined;
 		let models = 0;
 		const billingKey = process.env.AUTUMN_SECRET_KEY;
-		delete process.env.AUTUMN_SECRET_KEY;
+		Reflect.deleteProperty(process.env, "AUTUMN_SECRET_KEY");
 		try {
 			expect(
 				await resumeInsightReply(
@@ -198,7 +198,7 @@ integration("persisted business reply scope", () => {
 				})
 			).toBe("succeeded");
 		} finally {
-			if (billingKey === undefined) delete process.env.AUTUMN_SECRET_KEY;
+			if (billingKey === undefined) Reflect.deleteProperty(process.env, "AUTUMN_SECRET_KEY");
 			else process.env.AUTUMN_SECRET_KEY = billingKey;
 		}
 		const rows = await db()

--- a/apps/insights/src/business-context.integration.test.ts
+++ b/apps/insights/src/business-context.integration.test.ts
@@ -21,6 +21,8 @@ import * as memory from "@databuddy/services/business-memory";
 import { randomUUIDv7 } from "bun";
 import {
 	loadCurrentBusinessScope,
+	organizationProfileContext,
+	withBusinessContextSnapshot,
 	readPersistedBusinessReplies,
 } from "./business-context";
 
@@ -28,7 +30,9 @@ import type {
 	BusinessContext,
 	BusinessScope,
 } from "@databuddy/ai/lib/business-context";
+import { parseInvestigationOutcome } from "@databuddy/shared/insights";
 import type { InvestigationOutcome } from "@databuddy/shared/insights";
+import type { OrganizationBusinessProfile } from "@databuddy/shared/organization-business-context";
 import { generateWebsiteInsights } from "./generation";
 import { prepareInvestigation } from "./investigation";
 import { persistInvestigation } from "./persistence";
@@ -95,6 +99,140 @@ integration("persisted business reply scope", () => {
 	});
 	afterAll(async () => {
 		await closePostgres();
+	});
+
+	it("persists the original revision and appends the newly supplied revision on resume", async () => {
+		const { org, website, scope } = await scopeFixture();
+		const saved: OrganizationBusinessProfile = {
+			content: "Report preparation starts a draft.",
+			origin: "mixed",
+			teamContext: { priority: "Report preparation", successDefinition: "A draft is prepared", exclusions: "Employee traffic" },
+			revision: 3,
+			updatedAt: "2026-09-04T00:00:00.000Z",
+			updatedBy: "example-editor",
+			sourceWebsiteId: null,
+			sources: [{ title: "Report guide", url: "https://example.com/reports" }],
+		};
+		const capturedAt = new Date("2026-09-05T12:00:00.000Z");
+		const firstContext = organizationProfileContext(saved, org.id, capturedAt);
+		const original = withBusinessContextSnapshot(outcome, firstContext);
+		const runId = randomUUIDv7();
+		await db()
+			.insert(insightRuns)
+			.values({ id: runId, organizationId: org.id, status: "running" });
+		const investigation = await persistInvestigation({
+			businessScope: scope,
+			organizationId: org.id,
+			runId,
+			timezone: "UTC",
+			notNewerThan: capturedAt,
+			recheckAt: new Date("2026-09-08T12:00:00.000Z"),
+			investigation: {
+				id: randomUUIDv7(),
+				outcome: original,
+				signal: prepared.signal,
+				websiteDomain: website.domain,
+				websiteId: website.id,
+				websiteName: website.name,
+			},
+		});
+		if (!investigation) throw new Error("Expected a durable investigation");
+		const replyId = randomUUIDv7();
+		await db().insert(insightReplies).values({
+			id: replyId,
+			insightId: investigation.id,
+			authorName: "Example teammate",
+			body: "Please check the revised business priority.",
+			status: "queued",
+		});
+		saved.revision = 4;
+		saved.content = "Completed downloads are the current priority.";
+		saved.teamContext = { priority: "Completed downloads", successDefinition: "A download completes", exclusions: "Employee traffic" };
+		saved.updatedAt = "2026-09-06T00:00:00.000Z";
+		let supplied: BusinessContext | undefined;
+		let models = 0;
+		const billingKey = process.env.AUTUMN_SECRET_KEY;
+		delete process.env.AUTUMN_SECRET_KEY;
+		try {
+			expect(
+				await resumeInsightReply(
+					replyId,
+					async (input) => {
+						models += 1;
+						supplied = input.businessContext;
+						expect(supplied?.sources[0]?.profileVersion?.revision).toBe(4);
+						// A save during the model turn must not rewrite the supplied snapshot.
+						saved.revision = 5;
+						saved.content = "Later priority, never supplied to this turn.";
+						saved.teamContext = { priority: "Later priority", successDefinition: "", exclusions: "" };
+						return {
+							outcome: { ...original, title: "Revised priority checked" },
+							toolCallCount: 0,
+						};
+					},
+					async () => {},
+					async () => prepared,
+					{
+						loadCurrentBusinessScope,
+						loadBusinessProfile: async (input) => {
+							expect(input.scope).toEqual(scope);
+							return organizationProfileContext(
+								saved,
+								input.scope.organizationId,
+								input.asOf
+							);
+						},
+						recallBusinessContext: async (input) => ({
+							capturedAt: input.asOf.toISOString(),
+							status: "disabled",
+							sources: [],
+							issues: [],
+						}),
+					}
+				)
+			).toBe("succeeded");
+			// Completed retries do not load the newly edited profile or append a turn.
+			expect(
+				await resumeInsightReply(replyId, async () => {
+					throw new Error("A completed reply must not run the model again");
+				})
+			).toBe("succeeded");
+		} finally {
+			if (billingKey === undefined) delete process.env.AUTUMN_SECRET_KEY;
+			else process.env.AUTUMN_SECRET_KEY = billingKey;
+		}
+		const rows = await db()
+			.select({ outcome: insightObservations.outcome })
+			.from(insightObservations)
+			.where(eq(insightObservations.insightId, investigation.id))
+			.orderBy(insightObservations.asOf);
+		expect(rows).toHaveLength(2);
+		expect(models).toBe(1);
+		expect(
+			parseInvestigationOutcome(rows[0]?.outcome)?.contextSnapshot
+		).toEqual(firstContext);
+		expect(
+			parseInvestigationOutcome(rows[1]?.outcome)?.contextSnapshot
+		).toEqual(supplied);
+		expect(
+			parseInvestigationOutcome(rows[1]?.outcome)?.contextSnapshot?.sources[1]
+		).toMatchObject({
+			origin: "mixed",
+			content: "Completed downloads are the current priority.",
+			profileVersion: { revision: 4, updatedAt: "2026-09-06T00:00:00.000Z" },
+			references: [
+				{ title: "Report guide", url: "https://example.com/reports" },
+			],
+		});
+		const persistedTeam = parseInvestigationOutcome(rows[1]?.outcome)?.contextSnapshot?.sources[0];
+		expect(persistedTeam).toMatchObject({
+			origin: "team",
+			author: "Team priorities and definitions",
+			profileVersion: { revision: 4, updatedAt: "2026-09-06T00:00:00.000Z" },
+		});
+		expect(persistedTeam?.content).toContain("Completed downloads");
+		expect(persistedTeam?.content).toContain("A download completes");
+		expect(persistedTeam?.content).not.toContain("Later priority");
 	});
 
 	it("bounds recent replies but can recover exact-subject context while excluding other scopes and unsafe dates", async () => {
@@ -520,15 +658,10 @@ integration("persisted business reply scope", () => {
 							sources: [],
 						});
 					} else {
-						expect(input).toMatchObject({
-							businessContext: {
-								sources: [
-									expect.objectContaining({
-										id: replyId,
-										content: "Preparation is not download completion.",
-									}),
-								],
-							},
+						expect(input.businessContext?.sources).toHaveLength(1);
+						expect(input.businessContext?.sources[0]).toMatchObject({
+							id: replyId,
+							content: "Preparation is not download completion.",
 						});
 						// This completes inside the model callback: there is no website lock
 						// held across the model. Commit must notice the actual DB epoch change.

--- a/apps/insights/src/business-context.test.ts
+++ b/apps/insights/src/business-context.test.ts
@@ -618,39 +618,70 @@ describe("saved organization business context", () => {
 			undefined,
 		]);
 		for (const source of chunks) {
-			expect(source).toMatchObject({ origin, observedAt: profile.updatedAt });
+			expect(source).toMatchObject({
+				origin,
+				observedAt: profile.updatedAt,
+				profileVersion: {
+					revision: profile.revision,
+					updatedAt: profile.updatedAt,
+				},
+			});
 		}
 		expect(result.sources).toContainEqual(page);
 		expect(result.sources).toContainEqual(statement);
 	});
 
 
-    it("supplies team-only priorities and definitions before bounded public background", async () => {
-        const teamContext = { priority: "Prioritize activation", successDefinition: "Activation requires a production event", exclusions: "Exclude employee traffic" };
-        for (const content of ["", "Public background ".repeat(650)]) {
-            const result = await loadWebsiteBusinessProfile(input, dependencies({
-                readOrganization: async () => ({ profile: { ...profile, content, origin: "mixed", teamContext }, generation: null }),
-            }));
-            expect(businessContextSchema.parse(result)).toEqual(result);
-            const sources = result.sources.filter((source) => source.kind === "organization_profile");
-            expect(sources[0]).toMatchObject({ origin: "team" });
-            expect(sources[0]?.content).toContain(teamContext.successDefinition);
-            expect(sources[0]?.content).toContain(teamContext.exclusions);
-            if (content) expect(sources[1]?.origin).toBe("mixed");
-        }
-    });
+	it("supplies team-only priorities and definitions before bounded public background", async () => {
+		const teamContext = {
+			priority: "Prioritize activation",
+			successDefinition: "Activation requires a production event",
+			exclusions: "Exclude employee traffic",
+		};
+		for (const content of ["", "Public background ".repeat(650)]) {
+			const result = await loadWebsiteBusinessProfile(input, dependencies({
+				readOrganization: async () => ({ profile: { ...profile, content, origin: "mixed", teamContext }, generation: null }),
+			}));
+			expect(businessContextSchema.parse(result)).toEqual(result);
+			const sources = result.sources.filter((source) => source.kind === "organization_profile");
+			expect(sources[0]).toMatchObject({ origin: "team" });
+			expect(sources[0]?.content).toContain(teamContext.successDefinition);
+			expect(sources[0]?.content).toContain(teamContext.exclusions);
+			for (const source of sources) {
+				expect(source.profileVersion).toEqual({ revision: profile.revision, updatedAt: profile.updatedAt });
+			}
+			if (content) expect(sources[1]?.origin).toBe("mixed");
+		}
+	});
 
-    it("retains the complete maximum brief and all three maximum team inputs", async () => {
-        const content = "B".repeat(11990) + " END BRIEF";
-        const teamContext = { priority: "P".repeat(2000), successDefinition: "D".repeat(2000), exclusions: "E".repeat(2000) };
-        const result = await loadWebsiteBusinessProfile(input, dependencies({ readOrganization: async () => ({ profile: { ...profile, content, teamContext }, generation: null }) }));
-        const sources = result.sources.filter((source) => source.kind === "organization_profile");
-        const supplied = sources.map((source) => source.content).join("");
-        expect(supplied).toContain(content);
-        expect(supplied).toContain(teamContext.priority);
-        expect(supplied).toContain(teamContext.successDefinition);
-        expect(supplied).toContain(teamContext.exclusions);
-    });
+	it("retains the maximum brief, all team fields and a correction with profile revisions", async () => {
+		const content = "B".repeat(11990) + " END BRIEF";
+		const teamContext = {
+			priority: "P".repeat(2000),
+			successDefinition: "D".repeat(2000),
+			exclusions: "E".repeat(2000),
+		};
+		const correction = { ...statement, content: "Correction: ".padEnd(4000, "R") };
+		const result = await loadWebsiteBusinessProfile(input, dependencies({
+			readOrganization: async () => ({ profile: { ...profile, content, origin: "mixed", teamContext }, generation: null }),
+			readReplies: async () => [correction],
+			loadProfile: async () => context([{ ...page, content: "Public page ".padEnd(4000, "W") }]),
+		}));
+		const sources = result.sources.filter((source) => source.kind === "organization_profile");
+		const supplied = sources.map((source) => source.content).join("");
+		expect(sources).toHaveLength(5);
+		expect(sources.map((source) => source.origin)).toEqual(["team", "team", "mixed", "mixed", "mixed"]);
+		expect(supplied).toContain(content);
+		for (const value of Object.values(teamContext)) expect(supplied).toContain(value);
+		for (const source of sources) {
+			expect(source.profileVersion).toEqual({ revision: profile.revision, updatedAt: profile.updatedAt });
+		}
+		expect(result.sources).toContainEqual(correction);
+		expect(result.sources.some((source) => source.kind === "website")).toBe(false);
+		expect(result.sources.reduce((total, source) => total + source.content.length, 0)).toBeLessThanOrEqual(24_000);
+		expect(businessContextSchema.parse(JSON.parse(JSON.stringify(result)))).toEqual(result);
+	});
+
 	it.each([
 		null,
 		profile,

--- a/apps/insights/src/business-context.ts
+++ b/apps/insights/src/business-context.ts
@@ -37,6 +37,10 @@ import {
 	formatBusinessTeamContext,
 	type OrganizationBusinessProfile,
 } from "@databuddy/shared/organization-business-context";
+import {
+	businessContextSchema,
+	type InvestigationOutcome,
+} from "@databuddy/shared/insights";
 
 type ProfileInput = Parameters<typeof loadBusinessProfile>[0];
 type RecallInput = Parameters<typeof recallBusinessContext>[0] & {
@@ -384,6 +388,10 @@ export function organizationProfileContext(
 				observedAt: profile.updatedAt,
 				author: "Team priorities and definitions",
 				origin: "team",
+				profileVersion: {
+					revision: profile.revision,
+					updatedAt: profile.updatedAt,
+				},
 			});
 		}
 		// Keep the source contract and the complete editable document; no semantic
@@ -399,6 +407,10 @@ export function organizationProfileContext(
 						? "Edited website background"
 						: "Organization settings",
 				origin: profile.origin,
+				profileVersion: {
+					revision: profile.revision,
+					updatedAt: profile.updatedAt,
+				},
 				...(offset === 0 ? { references: profile.sources } : {}),
 			});
 		}
@@ -432,4 +444,16 @@ export async function recallWebsiteBusinessContext(
 	} catch (error) {
 		return unavailableBusinessContext(error, input.scope, input.asOf);
 	}
+}
+
+// Attach only the bounded context supplied for this turn. Parsing copies the
+// snapshot and strips extra fields; model-authored or prior snapshots cannot win.
+export function withBusinessContextSnapshot(
+	outcome: InvestigationOutcome,
+	context: BusinessContext | undefined
+): InvestigationOutcome {
+	const { contextSnapshot: _previous, ...result } = outcome;
+	return context
+		? { ...result, contextSnapshot: businessContextSchema.parse(context) }
+		: result;
 }

--- a/apps/insights/src/generation-sources.test.ts
+++ b/apps/insights/src/generation-sources.test.ts
@@ -14,6 +14,8 @@ import {
 	type InvestigationSources,
 	investigateWebsitePortfolioWithSources,
 } from "./generation";
+import { organizationProfileContext } from "./business-context";
+import { parseInvestigationOutcome } from "@databuddy/shared/insights";
 import { prepareInvestigation } from "./investigation";
 
 const trafficDrop: DetectedSignal = {
@@ -113,6 +115,64 @@ async function investigateFixture(
 }
 
 describe("fixture investigation sources", () => {
+	it("retains exactly the supplied context in the generated durable outcome", async () => {
+		const context = organizationProfileContext(
+			{
+				content: "Paid report preparation is the current priority.",
+				origin: "team",
+				revision: 3,
+				updatedAt: "2026-07-11T11:00:00Z",
+				updatedBy: "example-editor",
+				sourceWebsiteId: null,
+				sources: [
+					{ title: "Report guide", url: "https://example.com/reports" },
+				],
+			},
+			fixtureInput.organizationId,
+			new Date(fixtureInput.asOf)
+		);
+		let modelCalls = 0;
+		const artifact = await investigateFixture(
+			fixtureSources({
+				detectDefinitionSignals: async () => [],
+				detectMetricSignals: async () => [trafficDrop],
+				fetchAnnotations: async () => [],
+				loadDueInvestigation: async () => null,
+				loadObservations: async () => new Map(),
+				loadHistory: async () => [],
+				loadBusinessProfile: async () => context,
+				investigateSignal: async (input) => {
+					modelCalls += 1;
+					expect(input.businessContext).toEqual(context);
+					return {
+						outcome: {
+							title: "Traffic changed",
+							summary: "Traffic needs a closer look.",
+							impact: null,
+							rootCause: null,
+							evidence: ["Visitors fell from 1000 to 300."],
+							next: {
+								type: "resolve",
+								reason: "No material action established.",
+							},
+							contextSnapshot: { ...context, sources: [] },
+						},
+						toolCallCount: 0,
+					};
+				},
+			})
+		);
+		expect(artifact.status).toBe("completed");
+		expect(modelCalls).toBe(1);
+		expect(
+			parseInvestigationOutcome(JSON.parse(JSON.stringify(artifact.outcome)))
+				?.contextSnapshot
+		).toEqual(context);
+		context.sources[0]!.content = "Changed after the turn.";
+		expect(artifact.outcome?.contextSnapshot?.sources[0]?.content).toBe(
+			"Paid report preparation is the current priority."
+		);
+	});
 	it("passes a completed sibling ask to later candidates as open work", async () => {
 		const errorSignal: DetectedSignal = {
 			...trafficDrop,

--- a/apps/insights/src/generation-sources.test.ts
+++ b/apps/insights/src/generation-sources.test.ts
@@ -168,7 +168,11 @@ describe("fixture investigation sources", () => {
 			parseInvestigationOutcome(JSON.parse(JSON.stringify(artifact.outcome)))
 				?.contextSnapshot
 		).toEqual(context);
-		context.sources[0]!.content = "Changed after the turn.";
+		const source = context.sources[0];
+		if (!source) {
+			throw new Error("Expected a supplied context source");
+		}
+		source.content = "Changed after the turn.";
 		expect(artifact.outcome?.contextSnapshot?.sources[0]?.content).toBe(
 			"Paid report preparation is the current priority."
 		);

--- a/apps/insights/src/generation.ts
+++ b/apps/insights/src/generation.ts
@@ -9,6 +9,7 @@ import {
 	loadWebsiteBusinessProfile,
 	recallWebsiteBusinessContext,
 	unavailableBusinessContext,
+	withBusinessContextSnapshot,
 } from "./business-context";
 import type { AppContext } from "@databuddy/ai/config/context";
 import {
@@ -938,7 +939,10 @@ async function investigatePlannedCandidate(
 	return {
 		asOf: asOf.toISOString(),
 		evidence,
-		outcome: investigationResult.outcome,
+		outcome: withBusinessContextSnapshot(
+			investigationResult.outcome,
+			candidate.businessContext
+		),
 		signal: candidate.signal,
 		status: "completed",
 	};

--- a/apps/insights/src/investigation-flow.test.ts
+++ b/apps/insights/src/investigation-flow.test.ts
@@ -232,6 +232,50 @@ function outputModel(value: unknown = agentOutcome) {
 }
 
 describe("intelligence agent", () => {
+	it("does not resupply prior context snapshots or offer model-authored provenance", async () => {
+		const model = outputModel();
+		await runInsightAgent(
+			{
+				appContext: appContext(),
+				evidence,
+				githubRepository: null,
+				otherOpenWork: [],
+				signal,
+				history: [
+					{
+						kind: "investigation",
+						asOf: "2026-07-10T00:00:00Z",
+						evidence: [],
+						signal,
+						outcome: {
+							...outcome,
+							contextSnapshot: {
+								capturedAt: "2026-07-10T00:00:00Z",
+								status: "ready",
+								issues: [],
+								sources: [
+									{
+										id: "old-profile",
+										kind: "organization_profile",
+										content: "Superseded private business context",
+										observedAt: "2026-07-09T00:00:00Z",
+									},
+								],
+							},
+						},
+					},
+				],
+			},
+			{ model, tools: {} }
+		);
+		expect(JSON.stringify(model.doGenerateCalls[0]?.prompt)).not.toContain(
+			"Superseded private business context"
+		);
+		expect(JSON.stringify(model.doGenerateCalls[0]?.tools)).not.toContain(
+			"contextSnapshot"
+		);
+		expect(model.doGenerateCalls).toHaveLength(1);
+	});
 	it("preserves manual repairs while omitting definition-only choices", async () => {
 		const model = outputModel();
 		const availableRead = tool({

--- a/apps/insights/src/resume.ts
+++ b/apps/insights/src/resume.ts
@@ -5,6 +5,7 @@ import {
 	loadWebsiteBusinessProfile,
 	recallWebsiteBusinessContext,
 	unavailableBusinessContext,
+	withBusinessContextSnapshot,
 } from "./business-context";
 import type { AppContext } from "@databuddy/ai/config/context";
 import {
@@ -279,6 +280,7 @@ export async function resumeInsightReply(
 		},
 		signal: currentMeasurement.signal,
 	});
+	const outcome = withBusinessContextSnapshot(result.outcome, businessContext);
 	const committed = await db.transaction(async (tx) => {
 		await assertBusinessScopeCurrent(currentScope, tx);
 		const [locked] = await tx
@@ -318,7 +320,7 @@ export async function resumeInsightReply(
 			throw new Error("The investigation changed while the reply was running");
 		}
 
-		const next = result.outcome.next.type;
+		const next = outcome.next.type;
 		const shouldUpdateInvestigation =
 			current.status === "open" || next === "act" || next === "ask";
 		if (shouldUpdateInvestigation) {
@@ -326,7 +328,7 @@ export async function resumeInsightReply(
 				.update(analyticsInsights)
 				.set(
 					caseValues(
-						{ outcome: result.outcome, signal: currentMeasurement.signal },
+						{ outcome, signal: currentMeasurement.signal },
 						trigger.timezone,
 						committedAt
 					)
@@ -341,8 +343,8 @@ export async function resumeInsightReply(
 			id: observationId,
 			insightId: current.id,
 			organizationId: trigger.organizationId,
-			outcome: result.outcome,
-			recheckAt: nextRecheckAt(committedAt, result.outcome.next),
+			outcome,
+			recheckAt: nextRecheckAt(committedAt, outcome.next),
 			runId: null,
 			signal: currentMeasurement.signal,
 			signalKey: currentMeasurement.signal.signalKey,

--- a/packages/ai/src/lib/business-context.ts
+++ b/packages/ai/src/lib/business-context.ts
@@ -1,3 +1,8 @@
+import {
+	businessSourceSchema,
+	type BusinessContext,
+	type BusinessSource,
+} from "@databuddy/shared/insights";
 import { createHash } from "node:crypto";
 import { z } from "zod";
 import type Supermemory from "supermemory";
@@ -20,34 +25,15 @@ const timestamp = z.iso
 	.datetime({ offset: true })
 	.refine((value) => Number.isFinite(Date.parse(value)));
 
-export const businessSourceSchema = z.object({
-	id: z.string().min(1).max(500),
-	kind: z.enum(["website", "team_reply", "organization_profile"]),
-	content: z.string().min(1).max(4000),
-	observedAt: timestamp,
-	url: z.url().max(2048).optional(),
-	references: z
-		.array(z.object({ url: z.url().max(2048), title: z.string().max(512) }))
-		.max(8)
-		.optional(),
-	internalLinks: z.array(z.string().max(300)).max(10).optional(),
-	subjectKey: z.string().max(500).optional(),
-	author: z.string().max(200).optional(),
-	origin: z.enum(["team", "website", "mixed"]).optional(),
-	expiresAt: timestamp.optional(),
-});
-export type BusinessSource = z.infer<typeof businessSourceSchema>;
-
-export const businessContextSchema = z.object({
-	capturedAt: timestamp,
-	status: z.enum(["ready", "partial", "unavailable", "disabled"]),
-	sources: z.array(businessSourceSchema).max(16),
-	issues: z.array(z.string().max(200)).max(20),
-});
-export type BusinessContext = z.infer<typeof businessContextSchema>;
+export {
+	businessContextSchema,
+	businessSourceSchema,
+	type BusinessContext,
+	type BusinessSource,
+} from "@databuddy/shared/insights";
 
 const metadataSchema = businessSourceSchema
-	.omit({ id: true, content: true, references: true })
+	.omit({ id: true, content: true, references: true, profileVersion: true })
 	.extend({
 		version: z.literal(1),
 		organizationId: z.string().min(1),
@@ -342,9 +328,9 @@ async function recordSources(
 			.max(20)
 			.parse(sources)
 			.map((value) => {
-				// Organization references are supplied from SQL, never mirrored as memory metadata.
+				// Organization provenance is supplied from SQL, never mirrored as memory metadata.
 				const { id, content, ...source } = businessSourceSchema
-					.omit({ references: true })
+					.omit({ references: true, profileVersion: true })
 					.parse(value);
 				return {
 					content:

--- a/packages/shared/src/insights.test.ts
+++ b/packages/shared/src/insights.test.ts
@@ -267,6 +267,62 @@ describe("insightBriefItemSchema", () => {
 });
 
 describe("investigationOutcomeSchema", () => {
+	it.each(["team", "website", "mixed"])("round trips %s context without letting the model author provenance", (origin) => {
+		const snapshot = {
+			capturedAt: "2026-09-08T12:00:00Z",
+			status: "partial",
+			issues: ["Context is bounded; additional source records were omitted."],
+			sources: [
+				{
+					id: "organization-profile:example-org:0",
+					kind: "organization_profile",
+					content:
+						"Report preparation starts a draft, not a completed download.",
+					origin,
+					observedAt: "2026-09-08T11:00:00Z",
+					profileVersion: { revision: 3, updatedAt: "2026-09-08T11:00:00Z" },
+					references: [
+						{ title: "Report guide", url: "https://example.com/reports" },
+					],
+				},
+			],
+		};
+		const persisted = JSON.parse(
+			JSON.stringify({ ...outcomeBase, contextSnapshot: snapshot })
+		);
+		expect(parseInvestigationOutcome(persisted)?.contextSnapshot).toEqual(
+			snapshot
+		);
+		expect(parseInvestigationOutcome(outcomeBase)).not.toHaveProperty(
+			"contextSnapshot"
+		);
+		const authored = agentInvestigationOutcomeSchema.parse({
+			...outcomeBase,
+			...agentFields,
+			publish: true,
+			contextSnapshot: snapshot,
+		});
+		expect(authored).not.toHaveProperty("contextSnapshot");
+		expect(agentInvestigationOutcomeSchema.shape).not.toHaveProperty(
+			"contextSnapshot"
+		);
+		const invalid = {
+			...snapshot,
+			sources: [
+				{
+					...snapshot.sources[0],
+					profileVersion: { revision: 0, updatedAt: "invalid" },
+				},
+			],
+		};
+		expect(
+			investigationOutcomeSchema.safeParse({
+				...outcomeBase,
+				contextSnapshot: invalid,
+			}).success
+		).toBe(false);
+	});
+
 	it("accepts concise titles while rejecting empty titles and raw identifiers", () => {
 		const accepted = {
 			...outcomeBase,

--- a/packages/shared/src/insights.ts
+++ b/packages/shared/src/insights.ts
@@ -4,6 +4,45 @@ import {
 	goalFunnelFilterFieldSet,
 } from "./analytics-filters";
 
+// Shared by the model input, frozen run plan and durable outcome. Keep a single
+// bounded source contract so persistence cannot silently strip provenance.
+const businessContextTimestamp = z.iso
+	.datetime({ offset: true })
+	.refine((value) => Number.isFinite(Date.parse(value)));
+
+export const businessSourceSchema = z.object({
+	id: z.string().min(1).max(500),
+	kind: z.enum(["website", "team_reply", "organization_profile"]),
+	content: z.string().min(1).max(4000),
+	observedAt: businessContextTimestamp,
+	url: z.url().max(2048).optional(),
+	references: z
+		.array(z.object({ url: z.url().max(2048), title: z.string().max(512) }))
+		.max(8)
+		.optional(),
+	internalLinks: z.array(z.string().max(300)).max(10).optional(),
+	subjectKey: z.string().max(500).optional(),
+	author: z.string().max(200).optional(),
+	origin: z.enum(["team", "website", "mixed"]).optional(),
+	expiresAt: businessContextTimestamp.optional(),
+	// Version of the canonical profile supplied with this source, not claim attribution.
+	profileVersion: z
+		.object({
+			revision: z.number().int().positive(),
+			updatedAt: businessContextTimestamp,
+		})
+		.optional(),
+});
+export type BusinessSource = z.infer<typeof businessSourceSchema>;
+
+export const businessContextSchema = z.object({
+	capturedAt: businessContextTimestamp,
+	status: z.enum(["ready", "partial", "unavailable", "disabled"]),
+	sources: z.array(businessSourceSchema).max(16),
+	issues: z.array(z.string().max(200)).max(20),
+});
+export type BusinessContext = z.infer<typeof businessContextSchema>;
+
 export const weekOverWeekPeriodSchema = z
 	.object({
 		current: z
@@ -583,6 +622,8 @@ export const investigationOutcomeSchema = z
 			.describe(
 				"One short, inspected causal mechanism describing the actual failing operation. Use null for unknown, suspected, or merely correlated explanations. Error text, a runtime stack, bundle location, route, browser document line, timing, or annotation is not a source-code mechanism."
 			),
+		// Supplied background only; does not establish which facts influenced a claim.
+		contextSnapshot: businessContextSchema.optional(),
 		evidence: z
 			.array(
 				z
@@ -734,7 +775,7 @@ const agentTitleSchema = z
 
 export const agentInvestigationOutcomeSchema = z
 	.object(investigationOutcomeSchema.shape)
-	.omit({ impact: true, verification: true })
+	.omit({ impact: true, verification: true, contextSnapshot: true })
 	.extend({
 		title: agentTitleSchema,
 		evidenceRefs: z


### PR DESCRIPTION
### Description

Investigation observations currently lose the business background supplied to the model. Persist that bounded snapshot in the existing outcome JSON and expose it in a collapsed **Business context** disclosure on each investigation update, including canonical profile revision/time, supplied text, source names, and recorded URLs.

Generation retains the context from its frozen candidate; resume appends a fresh snapshot without rewriting prior observations. When sources exist, the disclosure says “Background available for this update” and explains once that the snapshot does not identify which facts influenced individual claims. Empty or unavailable snapshots omit the availability introduction and retain their status message and capture time. Application code assigns the snapshot; model-authored output and subsequent observation-history prompts exclude it.

The additions are optional for older investigations. There is no database migration, new API, or additional model turn.

### Slice and integration

- Issue: Maintainer-directed business-context QA follow-up.
- Scope: Investigation generation/resume, shared outcome/source schemas, and investigation detail disclosure.
- Depends on #766 and #768, both merged; also rebased after the domain compatibility follow-up #769 and auth-session fix landed. Rebased onto staging at `cf6f7e2201eebe00593c92db3342b2b3c6efe045`; the diff contains only this attribution slice and its copy follow-up.
- The shared schema extraction preserves `team | website | mixed` origin. Both canonical background and structured team-context chunks retain `profileVersion`.
- The merged adaptive budget is unchanged: normally 16k characters, expanding for the saved profile plus a 4k correction allowance, capped at 24k. The combined maximum-size test retains the complete brief, all three team fields, the correction, and revision metadata on all five profile chunks.
- Canonical services/schema, worker, organization settings, and chat delivery remain as merged on staging.

### Final validation

- Focused schemas, attribution, generation/resume, AI-context, and disclosure tests: **299 passed, 1 gated integration test skipped**.
- Native isolated PostgreSQL snapshot persistence/resume and scope tests: **8 passed**.
- Merged chat compatibility: **46 AI/domain tests and 6 API tests passed** using their configured Bun isolation/Vitest runners.
- Root lint passed; full type checks passed **33/33 tasks** (rerun after the final #769 rebase).
- Pre-push root test suite passed **27/27 tasks** (normal environment-gated skips retained).
- UI validation covers rendered disclosure markup, escaping, source links, and legacy/unavailable states. No authenticated browser session or live model call was run for this attribution slice.

### Review notes

- [x] Rebased after all dependencies and #769 landed; range-diff confirms all three approved attribution commits are unchanged.
- [x] Additive payload compatibility, mixed origin, team fields, adaptive budget, and profile revisions verified.
- [x] Relevant tests, root lint, and root type checks passed.
- [x] No parent settings or chat-delivery edits included in this slice.

AI assistance: Codex implemented, reviewed, and tested this maintainer-directed slice and prepared this PR. Automated validation is described above; human verification is not implied.
