### PR TITLE
fix(insights): preserve canonical replies before public pages

### DIFF
--- a/apps/insights/src/business-context.test.ts
+++ b/apps/insights/src/business-context.test.ts
@@ -425,6 +425,38 @@ describe("saved organization business context", () => {
 	};
 	const input = { scope, asOf, allowRefresh: false };
 
+	it("keeps canonical replies ahead of extra public pages before selection", async () => {
+		const pages = Array.from({ length: 4 }, (_, index) => ({
+			...page,
+			id: `page-${index}`,
+			url: `https://example.com/${index || ""}`,
+			content: "Public background. ".padEnd(4000, "."),
+		}));
+		const result = await loadWebsiteBusinessProfile(
+			input,
+			dependencies({
+				loadProfile: async () => context(pages),
+				readReplies: async () => [statement],
+				readOrganization: async () => ({ profile, generation: null }),
+			})
+		);
+
+		expect(result.sources).toContainEqual(statement);
+		expect(result.sources[0]).toMatchObject({
+			kind: "organization_profile",
+			content: profile.content,
+		});
+		expect(result.sources[1]).toEqual(statement);
+		expect(result.sources.filter((source) => source.kind === "website")).toEqual(
+			pages.slice(0, 3)
+		);
+		expect(
+			result.sources.reduce((total, source) => total + source.content.length, 0)
+		).toBeLessThanOrEqual(16_000);
+		expect(result.status).toBe("partial");
+		expect(businessContextSchema.parse(result)).toEqual(result);
+	});
+
 	it("keeps the complete 12k saved profile and canonical correction ahead of a full homepage", async () => {
 		const content = "A".repeat(4000) + "B".repeat(4000) + "C".repeat(4000);
 		const result = await loadWebsiteBusinessProfile(

--- a/apps/insights/src/business-context.ts
+++ b/apps/insights/src/business-context.ts
@@ -300,6 +300,11 @@ async function reconcileReplies(
 			sources: eligible,
 			issues: issue ? [issue] : [],
 		};
+		// Shared pages must not consume the budget before canonical replies.
+		// Exact-subject recall still keeps relevance ahead of recent replies below.
+		if (!input.subjectKey) {
+			return mergeBusinessContext(context, raw);
+		}
 		const canonical = new Map(eligible.map((reply) => [reply.id, reply]));
 		return mergeBusinessContext(raw, {
 			...context,


### PR DESCRIPTION
Four full public-page excerpts could consume the shared context budget before a current canonical team reply reached investigation selection. Shared-profile reconciliation now merges canonical replies ahead of additional public pages; exact-subject recall retains its existing relevance ordering.

The production `loadWebsiteBusinessProfile` regression injects four 4,000-character public pages, a current canonical reply, and a small saved brief. It failed before the fix because the reply disappeared, and now verifies the complete reply, saved brief, homepage and two additional pages survive within the existing 16,000-character budget.

Scope: finding 2 only; two files, 37 added lines (5 implementation, 32 regression). No prompt, selector, coverage-planner, shared AI helper or evaluation-harness changes. Based on `origin/staging` at `4422cd61d5faa66ee9a40da23f5569e571b12078`, with no unmerged dependency. Known overlap: #751 also changes the context loader and budget tests; coordinate its integration after this bounded fix. The parent's selector/evaluation work remains separate.

Validation:
- The new regression failed before the implementation change and passes afterward.
- `bun test apps/insights/src/business-context.test.ts apps/insights/src/business-context-generation.test.ts apps/insights/src/business-aware-selection.test.ts`: 56 passed.
- In `packages/ai`, `bun test src/lib/business-context.test.ts`: 10 passed, 1 gated DB integration test skipped.
- Root `bun run lint`: passed, including 14 policy tests.
- Root `bun run check-types`: passed, 33 tasks (32 cached, the changed Insights package checked fresh).
- The repository pre-push hook also passed root `bun run test`: 27 tasks (26 cached); Insights ran fresh with 580 passed, 6 live-model tests skipped, and 0 failures.
- `git diff --check`: passed.

Validation ran with a clean environment and automatic env-file loading disabled. The first combined test attempt encountered an unbuilt SDK export after 37 passing tests; after the root type-check build supplied the SDK artifact, the full relevant test command passed. No live LLM or production database was used.

Keep draft and do not merge until parent review and its independent fresh selector comparison. AI-assisted implementation and validation; no human verification is claimed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared-profile context reconciliation so a current canonical team reply survives ahead of full public-page excerpts, instead of being dropped when four 4,000-character pages consume the 16,000-character budget. The fix applies only when no subject key is provided; exact-subject recall keeps its existing relevance ordering.

**Bug Fixes**
- Canonical replies now merge before shared public pages when no subject key is set.
- Adds a regression test covering the four-page scenario and asserting the reply, saved brief, homepage, and two pages fit within budget.
- Coordinate with #751, which also changes the context loader and budget tests, after this fix lands.

<sup>Written for commit c6e0994c6e67b349b749a4f0f6f4cf3f90430dfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

