### PR TITLE
feat(ai): measure identified profile activation retention

### DIFF
--- a/packages/ai/src/ai/tools/get-data.test.ts
+++ b/packages/ai/src/ai/tools/get-data.test.ts
@@ -60,6 +60,82 @@ describe("analytics tool contract", () => {
 		});
 	});
 
+	it.each([
+		{ groupBy: undefined },
+		{ groupBy: [] },
+		{ groupBy: ["namespace"] },
+		{ groupBy: ["namespace", "profile_id"] },
+	])("returns a native retention option error instead of mislabeling grouped data: %j", async ({
+		groupBy,
+	}) => {
+		const query = vi.fn().mockResolvedValue([{ row_type: "overall" }]);
+		vi.spyOn(SimpleQueryBuilder.prototype, "execute").mockImplementation(
+			function () {
+				// Exercise native request parsing and the real SQL compiler;
+				// stub the rows returned after compilation.
+				this.compile();
+				return query();
+			}
+		);
+		const request = {
+			queries: [
+				{
+					type: "identified_profile_retention",
+					from: "2026-08-01",
+					to: "2026-08-14",
+					groupBy,
+					filters: [
+						{
+							field: "activation_event",
+							op: "eq" as const,
+							value: "activated",
+						},
+						{ field: "return_event", op: "eq" as const, value: "returned" },
+						{ field: "horizon_days", op: "eq" as const, value: 7 },
+						{
+							field: "observation_end",
+							op: "eq" as const,
+							value: "2026-08-31",
+						},
+					],
+				},
+			],
+		};
+		const schema = asSchema(getDataTool.inputSchema);
+		if (!(schema.validate && getDataTool.execute))
+			throw new Error("Missing data tool contract");
+		expect((await schema.validate(request)).success).toBe(true);
+		const result = await getDataTool.execute(request, options);
+		if (groupBy?.length) {
+			expect(result).toEqual({
+				results: {
+					identified_profile_retention: {
+						type: "identified_profile_retention",
+						websiteId: "site-test",
+						data: [],
+						rowCount: 0,
+						error:
+							"Invalid retention options: fixed daily cohorts with overall row first; omit groupBy, orderBy and offset.",
+					},
+				},
+			});
+			expect(query).not.toHaveBeenCalled();
+			return;
+		}
+		expect(result).toMatchObject({
+			results: {
+				identified_profile_retention: {
+					data: [{ row_type: "overall" }],
+					rowCount: 1,
+					returnedRows: 1,
+					truncated: false,
+				},
+			},
+		});
+		expect(JSON.stringify(result)).not.toContain("groupBy:");
+		expect(query).toHaveBeenCalledOnce();
+	});
+
 	it("returns the measured scope and distinguishes a truncated result from its query row count", async () => {
 		const execute = vi
 			.spyOn(SimpleQueryBuilder.prototype, "execute")

--- a/packages/ai/src/query/batch-executor.test.ts
+++ b/packages/ai/src/query/batch-executor.test.ts
@@ -37,7 +37,12 @@ function compileSql(type: string): string {
 	].map((field) => ({
 		field,
 		op: "eq" as const,
-		value: `${field}-required-value`,
+		value:
+			field === "horizon_days"
+				? 7
+				: field === "observation_end"
+					? "2026-05-11"
+					: `${field}-required-value`,
 	}));
 	return new SimpleQueryBuilder(config, {
 		filters: requiredFilters,

--- a/packages/ai/src/query/builder-execution.test.ts
+++ b/packages/ai/src/query/builder-execution.test.ts
@@ -103,7 +103,14 @@ function filterFor(field: string): Filter {
 	return {
 		field,
 		op: "eq",
-		value: NUMERIC_FILTER_FIELDS.has(field) ? 1 : `test-${field}`,
+		value:
+			field === "horizon_days"
+				? 7
+				: field === "observation_end"
+					? "2026-02-01"
+					: NUMERIC_FILTER_FIELDS.has(field)
+						? 1
+						: `test-${field}`,
 	};
 }
 

--- a/packages/ai/src/query/builders/index.ts
+++ b/packages/ai/src/query/builders/index.ts
@@ -8,6 +8,7 @@ import { PagesBuilders } from "./pages";
 import { PerformanceBuilders } from "./performance";
 import { ProfilesBuilders } from "./profiles";
 import { RealtimeBuilders } from "./realtime";
+import { RetentionBuilders } from "./retention";
 import { RevenueBuilders } from "./revenue";
 import { SessionsBuilders } from "./sessions";
 import { SummaryBuilders } from "./summary";
@@ -34,6 +35,7 @@ const BASE_QUERY_BUILDERS = {
 	...UptimeBuilders,
 	...RevenueBuilders,
 	...RealtimeBuilders,
+	...RetentionBuilders,
 } satisfies Record<string, SimpleQueryConfig>;
 
 export const PUBLIC_QUERY_TYPES = new Set<string>([

--- a/packages/ai/src/query/builders/retention.integration.test.ts
+++ b/packages/ai/src/query/builders/retention.integration.test.ts
@@ -1,0 +1,448 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { SimpleQueryBuilder } from "../simple-builder";
+import type { Filter, QueryRequest } from "../types";
+import { RetentionBuilders } from "./retention";
+
+// Opt-in, credential-free, synthetic local service only. Never use the shared
+// runtime client or environment URLs: a developer's credentials cannot redirect it.
+const integration =
+	process.env.IDENTIFIED_RETENTION_CLICKHOUSE_TESTS === "true"
+		? describe
+		: describe.skip;
+const table = `analytics.retention_test_${crypto.randomUUID().replaceAll("-", "")}`;
+type Row = Record<string, string | number | null>;
+type Event = {
+	timestamp: string;
+	profile_id: string;
+	event_name?: string;
+	owner_id?: string;
+	website_id?: string | null;
+	namespace?: string | null;
+	anonymous_id?: string | null;
+};
+
+async function sql(query: string, params: Record<string, unknown> = {}) {
+	const url = new URL("http://127.0.0.1:16555/");
+	url.searchParams.set("output_format_json_quote_64bit_integers", "0");
+	url.searchParams.set("join_default_strictness", "ANY");
+	for (const [key, value] of Object.entries(params)) {
+		url.searchParams.set(`param_${key}`, String(value));
+	}
+	const response = await fetch(url, {
+		method: "POST",
+		body: query,
+		signal: AbortSignal.timeout(15_000),
+	});
+	const body = await response.text();
+	if (!response.ok) throw new Error(body);
+	return body;
+}
+
+async function seed(events: Event[]) {
+	const website = `synthetic-${crypto.randomUUID()}`;
+	await sql(
+		`INSERT INTO ${table} FORMAT JSONEachRow\n${events.map((event) => JSON.stringify({ owner_id: website, website_id: website, event_name: "activated", properties: "{}", ...event })).join("\n")}`
+	);
+	return website;
+}
+
+async function measure(
+	website: string,
+	options: Partial<QueryRequest> = {},
+	selectors: Partial<Record<string, string | number>> = {}
+) {
+	const filters: Filter[] = Object.entries({
+		activation_event: "activated",
+		return_event: "returned",
+		horizon_days: 7,
+		observation_end: "2026-07-31",
+		...selectors,
+	}).map(([field, value]) => ({ field, op: "eq", value }));
+	const query = new SimpleQueryBuilder(
+		RetentionBuilders.identified_profile_retention!,
+		{
+			type: "identified_profile_retention",
+			projectId: website,
+			from: "2026-07-01",
+			to: "2026-07-14",
+			filters,
+			limit: 100,
+			...options,
+		}
+	).compile();
+	const result = await sql(
+		`${query.sql.replaceAll("analytics.custom_events", table)} FORMAT JSONEachRow`,
+		query.params
+	);
+	const rows: Row[] = result
+		.trim()
+		.split("\n")
+		.filter(Boolean)
+		.map((line) => JSON.parse(line));
+	expect(rows[0]?.row_type).toBe("overall");
+	expect(rows[0]?.cohort_date).toBeNull();
+	expect(rows.length).toBeLessThanOrEqual(91);
+	return rows;
+}
+
+integration("identified retention SQL on synthetic local ClickHouse", () => {
+	beforeAll(async () => {
+		const ddl = await Bun.file(
+			new URL(
+				"../../../../db/src/clickhouse/schema/analytics/core/custom_events.sql",
+				import.meta.url
+			)
+		).text();
+		await sql(
+			`${ddl.slice(0, ddl.indexOf("ENGINE =")).replace("analytics.custom_events", table)} ENGINE = MergeTree ORDER BY (owner_id, event_name, timestamp)`
+		);
+	});
+	afterAll(async () => {
+		await sql(`DROP TABLE IF EXISTS ${table}`);
+	});
+
+	it("deduplicates activation/return events and counts raw identity coverage separately", async () => {
+		const website = await seed([
+			{ profile_id: "a", timestamp: "2026-07-01 12:00:00.000" },
+			{ profile_id: "a", timestamp: "2026-07-01 12:00:00.000" },
+			{ profile_id: "a", timestamp: "2026-07-02 12:00:00.000" },
+			{
+				profile_id: "a",
+				timestamp: "2026-07-08 12:00:00.000",
+				event_name: "returned",
+			},
+			{
+				profile_id: "a",
+				timestamp: "2026-07-08 12:00:00.000",
+				event_name: "returned",
+			},
+			{ profile_id: "b", timestamp: "2026-07-01 12:00:00.000" },
+			{
+				profile_id: "b",
+				timestamp: "2026-07-01 11:00:00.000",
+				event_name: "returned",
+			},
+			{
+				profile_id: "b",
+				timestamp: "2026-07-01 12:00:00.000",
+				event_name: "returned",
+			},
+			{
+				profile_id: "b",
+				timestamp: "2026-07-08 12:00:00.001",
+				event_name: "returned",
+			},
+			{
+				profile_id: "",
+				anonymous_id: "daily-salted",
+				timestamp: "2026-07-01 12:00:00.000",
+			},
+			{
+				profile_id: "",
+				anonymous_id: "daily-salted",
+				timestamp: "2026-07-01 12:00:00.000",
+			},
+		]);
+		const rows = await measure(website);
+		expect(rows[0]).toMatchObject({
+			activated_profiles: 2,
+			eligible_profiles: 2,
+			retained_profiles: 1,
+			not_retained_profiles: 1,
+			incomplete_profiles: 0,
+			retention_rate: 50,
+			activation_events: 6,
+			identified_activation_events: 4,
+			unidentified_activation_events: 2,
+			activation_identity_coverage: 66.67,
+		});
+		expect(rows[1]).toMatchObject({
+			cohort_date: "2026-07-01",
+			activated_profiles: 2,
+		});
+		expect(rows[2]).toMatchObject({
+			cohort_date: "2026-07-02",
+			activated_profiles: 0,
+			activation_events: 1,
+		});
+	});
+
+	it("excludes incomplete follow-up even when a return has already happened", async () => {
+		const website = await seed([
+			{ profile_id: "last-mature", timestamp: "2026-07-03 23:59:59.999" },
+			{
+				profile_id: "last-mature",
+				timestamp: "2026-07-10 23:59:59.999",
+				event_name: "returned",
+			},
+			{
+				profile_id: "endpoint-at-cutoff",
+				timestamp: "2026-07-04 00:00:00.000",
+			},
+			{
+				profile_id: "endpoint-at-cutoff",
+				timestamp: "2026-07-11 00:00:00.000",
+				event_name: "returned",
+			},
+			{ profile_id: "early-return", timestamp: "2026-07-10 00:00:00.000" },
+			{
+				profile_id: "early-return",
+				timestamp: "2026-07-10 00:00:00.001",
+				event_name: "returned",
+			},
+		]);
+		const rows = await measure(
+			website,
+			{ to: "2026-07-10" },
+			{ observation_end: "2026-07-10" }
+		);
+		expect(rows[0]).toMatchObject({
+			activated_profiles: 3,
+			eligible_profiles: 1,
+			retained_profiles: 1,
+			incomplete_profiles: 2,
+			not_retained_profiles: 0,
+			retention_rate: 100,
+			observed_before: "2026-07-11T00:00:00.000Z",
+		});
+		expect(rows.at(-1)).toMatchObject({
+			eligible_profiles: 0,
+			retention_rate: null,
+		});
+	});
+
+	it("does not join cross-tenant, cross-website or anonymous-only identities", async () => {
+		const website = await seed([
+			{
+				profile_id: "collision",
+				timestamp: "2026-07-01 00:00:00.000",
+				anonymous_id: "same-anon",
+			},
+			{
+				profile_id: "",
+				timestamp: "2026-07-02 00:00:00.000",
+				anonymous_id: "same-anon",
+				event_name: "returned",
+			},
+			{
+				profile_id: "collision",
+				timestamp: "2026-07-02 00:00:00.000",
+				owner_id: "other-owner",
+				website_id: "other-site",
+				event_name: "returned",
+			},
+		]);
+		await sql(
+			`INSERT INTO ${table} FORMAT JSONEachRow\n${JSON.stringify({ owner_id: "other-owner", website_id: website, profile_id: "collision", event_name: "returned", timestamp: "2026-07-02 00:00:00.000", properties: "{}" })}\n${JSON.stringify({ owner_id: "shared-org", website_id: website, profile_id: "org-profile", event_name: "activated", timestamp: "2026-07-01 00:00:00.000", properties: "{}" })}\n${JSON.stringify({ owner_id: "shared-org", website_id: "other-site", profile_id: "org-profile", event_name: "returned", timestamp: "2026-07-02 00:00:00.000", properties: "{}" })}`
+		);
+		expect((await measure(website))[0]).toMatchObject({
+			activated_profiles: 2,
+			retained_profiles: 0,
+			not_retained_profiles: 2,
+		});
+	});
+
+	it("reports anonymous-only and empty populations without fake profile denominators", async () => {
+		const website = await seed([
+			{
+				profile_id: "",
+				anonymous_id: "synthetic-anon",
+				timestamp: "2026-07-01 00:00:00.000",
+			},
+		]);
+		expect((await measure(website))[0]).toMatchObject({
+			activated_profiles: 0,
+			eligible_profiles: 0,
+			retention_rate: null,
+			activation_events: 1,
+			unidentified_activation_events: 1,
+			activation_identity_coverage: 0,
+		});
+		const empty = await measure(`empty-${crypto.randomUUID()}`);
+		expect(empty).toHaveLength(1);
+		expect(empty[0]).toMatchObject({
+			activated_profiles: 0,
+			activation_events: 0,
+			retention_rate: null,
+			activation_identity_coverage: null,
+			cohort_from: "2026-07-01",
+			cohort_to: "2026-07-14",
+		});
+	});
+
+	it("uses exact names and namespace on both phases", async () => {
+		const website = await seed([
+			{
+				profile_id: "a",
+				namespace: "wanted",
+				timestamp: "2026-07-01 00:00:00.000",
+			},
+			{
+				profile_id: "a",
+				namespace: "wrong",
+				timestamp: "2026-07-02 00:00:00.000",
+				event_name: "returned",
+			},
+			{
+				profile_id: "a",
+				namespace: "wanted",
+				timestamp: "2026-07-02 00:00:00.000",
+				event_name: "returned-extra",
+			},
+			{
+				profile_id: "b",
+				namespace: "wrong",
+				timestamp: "2026-07-01 00:00:00.000",
+			},
+			{
+				profile_id: "b",
+				namespace: "wanted",
+				timestamp: "2026-07-02 00:00:00.000",
+				event_name: "returned",
+			},
+		]);
+		expect(
+			(await measure(website, {}, { namespace: "wanted" }))[0]
+		).toMatchObject({
+			activated_profiles: 1,
+			retained_profiles: 0,
+			activation_events: 1,
+		});
+	});
+
+	it("uses observed-in-window activation and handles identical event selectors strictly", async () => {
+		const website = await seed([
+			{ profile_id: "a", timestamp: "2026-06-01 00:00:00.000" },
+			{ profile_id: "a", timestamp: "2026-07-01 00:00:00.000" },
+			{ profile_id: "a", timestamp: "2026-07-01 00:00:00.000" },
+			{ profile_id: "a", timestamp: "2026-07-02 00:00:00.000" },
+			{ profile_id: "b", timestamp: "2026-07-01 00:00:00.000" },
+			{ profile_id: "b", timestamp: "2026-07-01 00:00:00.000" },
+		]);
+		expect(
+			(await measure(website, {}, { return_event: "activated" }))[0]
+		).toMatchObject({
+			activated_profiles: 2,
+			retained_profiles: 1,
+			activation_basis: "first_in_cohort_window",
+		});
+	});
+
+	it("preserves local calendar bounds and fixed 24-hour horizons across DST", async () => {
+		const website = await seed([
+			{ profile_id: "before", timestamp: "2026-03-07 04:59:59.999" },
+			{ profile_id: "edge", timestamp: "2026-03-07 05:00:00.000" },
+			{
+				profile_id: "edge",
+				timestamp: "2026-03-14 05:00:00.000",
+				event_name: "returned",
+			},
+			{ profile_id: "last", timestamp: "2026-03-09 03:59:59.999" },
+			{ profile_id: "after", timestamp: "2026-03-09 04:00:00.000" },
+		]);
+		const rows = await measure(
+			website,
+			{ from: "2026-03-07", to: "2026-03-08", timezone: "America/New_York" },
+			{ observation_end: "2026-03-31" }
+		);
+		expect(rows[0]).toMatchObject({
+			activated_profiles: 2,
+			retained_profiles: 1,
+			cohort_start: "2026-03-07T05:00:00.000Z",
+			cohort_end: "2026-03-09T04:00:00.000Z",
+			observed_before: "2026-04-01T04:00:00.000Z",
+		});
+		expect(rows.map((row) => row.cohort_date)).toEqual([
+			null,
+			"2026-03-07",
+			"2026-03-08",
+		]);
+	});
+
+	it("supports the exact 30-day endpoint and separate observation date", async () => {
+		const website = await seed([
+			{ profile_id: "a", timestamp: "2026-07-01 12:00:00.000" },
+			{
+				profile_id: "a",
+				timestamp: "2026-07-31 12:00:00.000",
+				event_name: "returned",
+			},
+			{ profile_id: "b", timestamp: "2026-07-01 12:00:00.000" },
+			{
+				profile_id: "b",
+				timestamp: "2026-07-31 12:00:00.001",
+				event_name: "returned",
+			},
+		]);
+		expect(
+			(
+				await measure(
+					website,
+					{ to: "2026-07-01" },
+					{ horizon_days: 30, observation_end: "2026-08-01" }
+				)
+			)[0]
+		).toMatchObject({
+			activated_profiles: 2,
+			eligible_profiles: 2,
+			retained_profiles: 1,
+			horizon_days: 30,
+		});
+	});
+
+	it("caps future observation at now and excludes future events", async () => {
+		const now = new Date();
+		const day = now.toISOString().slice(0, 10);
+		const website = await seed([
+			{
+				profile_id: "recent",
+				timestamp: new Date(now.getTime() - 1000)
+					.toISOString()
+					.replace("T", " ")
+					.replace("Z", ""),
+			},
+			{ profile_id: "future", timestamp: `${day} 23:59:59.999` },
+		]);
+		const start = new Date(now.getTime() - 86_400_000)
+			.toISOString()
+			.slice(0, 10);
+		const rows = await measure(
+			website,
+			{ from: start, to: day },
+			{ observation_end: "2099-12-31" }
+		);
+		expect(rows[0]).toMatchObject({
+			activated_profiles: 1,
+			eligible_profiles: 0,
+			retained_profiles: 0,
+			not_retained_profiles: 0,
+			incomplete_profiles: 1,
+		});
+	});
+
+	it("returns at most 91 complete rows when limit100 is requested", async () => {
+		const events = Array.from({ length: 90 }, (_, index) => ({
+			profile_id: `profile-${index}`,
+			timestamp: new Date(Date.UTC(2026, 0, 1 + index))
+				.toISOString()
+				.replace("T", " ")
+				.replace("Z", ""),
+		}));
+		const website = await seed(events);
+		const rows = await measure(
+			website,
+			{ from: "2026-01-01", to: "2026-03-31" },
+			{ observation_end: "2026-04-30" }
+		);
+		expect(rows).toHaveLength(91);
+		expect(rows[0]?.activated_profiles).toBe(90);
+		expect(rows.at(-1)?.cohort_date).toBe("2026-03-31");
+		const limited = await measure(
+			website,
+			{ from: "2026-01-01", to: "2026-03-31", limit: 1 },
+			{ observation_end: "2026-04-30" }
+		);
+		expect(limited).toHaveLength(1);
+		expect(limited[0]?.activated_profiles).toBe(90);
+	});
+});

--- a/packages/ai/src/query/builders/retention.test.ts
+++ b/packages/ai/src/query/builders/retention.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from "bun:test";
+import { discoverQueryTypesTool } from "../../ai/tools/discover-query-types";
+import { QueryBuilders, canReadQueryTypesPublicly } from "./index";
+import { SimpleQueryBuilder } from "../simple-builder";
+import { publicQueryErrorMessage } from "../trait-filters";
+import type { Filter, QueryRequest } from "../types";
+
+const filters: Filter[] = [
+	{ field: "activation_event", op: "eq", value: "activated" },
+	{ field: "return_event", op: "eq", value: "returned" },
+	{ field: "horizon_days", op: "eq", value: 7 },
+	{ field: "observation_end", op: "eq", value: "2026-04-30" },
+];
+
+function compile(overrides: Partial<QueryRequest> = {}) {
+	return new SimpleQueryBuilder(QueryBuilders.identified_profile_retention!, {
+		type: "identified_profile_retention",
+		projectId: "synthetic-site",
+		from: "2026-04-01",
+		to: "2026-04-14",
+		filters,
+		...overrides,
+	}).compile();
+}
+
+describe("identified profile retention contract", () => {
+	it("is privately discoverable with exact selectors and aggregate outputs", async () => {
+		const result = await discoverQueryTypesTool.execute?.(
+			{ search: "identified_profile_retention" },
+			{ toolCallId: "synthetic", messages: [] }
+		);
+		expect(result).toMatchObject({
+			matchCount: 1,
+			types: [
+				{
+					name: "identified_profile_retention",
+					requiredFilters: filters.map((filter) => filter.field),
+					allowedFilterOperators: {
+						activation_event: ["eq"],
+						return_event: ["eq"],
+						horizon_days: ["eq"],
+						observation_end: ["eq"],
+						namespace: ["eq"],
+					},
+				},
+			],
+		});
+		expect(canReadQueryTypesPublicly(["identified_profile_retention"])).toBe(
+			false
+		);
+		expect(
+			QueryBuilders.identified_profile_retention?.meta?.output_fields?.map(
+				(field) => field.name
+			)
+		).not.toContain("profile_id");
+	});
+
+	it("binds exact event values without interpreting SQL or anonymous identities", () => {
+		const value = "activated' OR 1=1 --";
+		const query = compile({
+			filters: filters.map((filter) =>
+				filter.field === "activation_event" ? { ...filter, value } : filter
+			),
+		});
+		expect(query.sql).not.toContain(value);
+		expect(query.params.activation_event).toBe(value);
+		expect(query.sql).not.toContain("anonymous_id");
+		expect(query.sql).not.toContain("analytics.events");
+		expect(query.params.limit).toBe(91);
+		expect(compile({ limit: 100 }).params.limit).toBe(91);
+	});
+
+	it.each([
+		"activation_event",
+		"return_event",
+		"horizon_days",
+		"observation_end",
+	])("requires %s", (field) => {
+		expect(() =>
+			compile({ filters: filters.filter((filter) => filter.field !== field) })
+		).toThrow("Missing required filter");
+	});
+
+	it.each([
+		{ field: "activation_event", op: "contains", value: "activated" },
+		{ field: "activation_event", op: "eq", value: ["activated"] },
+		{ field: "activation_event", op: "eq", value: "" },
+		{ field: "horizon_days", op: "eq", value: 8 },
+		{ field: "horizon_days", op: "eq", value: "7 OR 1=1" },
+		{ field: "observation_end", op: "eq", value: "2026-02-30" },
+		{ field: "observation_end", op: "eq", value: "2026-04-13" },
+		{ field: "return_event", op: "eq", value: "returned", having: true },
+		{ field: "return_event", op: "eq", value: "returned", target: "event" },
+	] satisfies Filter[])("rejects invalid selector %j", (invalid) => {
+		expect(() =>
+			compile({
+				filters: filters.map((filter) =>
+					filter.field === invalid.field ? invalid : filter
+				),
+			})
+		).toThrow();
+	});
+
+	it.each([
+		"anonymous_id",
+		"profile_id",
+		"session_id",
+		"namespace",
+	])("rejects unsafe/ambiguous %s selectors", (field) => {
+		const extra: Filter = { field, op: "eq", value: "synthetic" };
+		expect(() => compile({ filters: [...filters, extra, extra] })).toThrow();
+	});
+
+	it.each([
+		{ from: "2026-04-15" },
+		{ from: "2026-04-01T00:00:00Z" },
+		{ from: "2026-01-01" },
+		{ from: "2026-02-30" },
+		{ orderBy: "activated_profiles DESC" },
+		{ offset: 1 },
+		{ timeUnit: "week" },
+	] satisfies Partial<QueryRequest>[])("rejects invalid date/options %j", (overrides) => {
+		expect(() => compile(overrides)).toThrow();
+	});
+
+	it("keeps safe validation messages available to the native tool loop", () => {
+		expect(
+			publicQueryErrorMessage("Invalid retention dates: synthetic guidance")
+		).toBe("Invalid retention dates: synthetic guidance");
+		expect(publicQueryErrorMessage("database failed with secret detail")).toBe(
+			"Query failed"
+		);
+	});
+});

--- a/packages/ai/src/query/builders/retention.ts
+++ b/packages/ai/src/query/builders/retention.ts
@@ -1,0 +1,250 @@
+import { z } from "zod";
+import { Analytics } from "../../types/tables";
+import type { SimpleQueryConfig } from "../types";
+
+const selectors = z.strictObject({
+	activation_event: z.string().min(1).max(256),
+	return_event: z.string().min(1).max(256),
+	horizon_days: z
+		.union([z.literal(7), z.literal(30), z.literal("7"), z.literal("30")])
+		.transform(Number),
+	observation_end: z.iso.date(),
+	namespace: z.string().min(1).max(256).optional(),
+});
+
+export const RetentionBuilders: Record<string, SimpleQueryConfig> = {
+	identified_profile_retention: {
+		allowedFilters: [
+			"activation_event",
+			"return_event",
+			"horizon_days",
+			"observation_end",
+			"namespace",
+		],
+		requiredFilters: [
+			"activation_event",
+			"return_event",
+			"horizon_days",
+			"observation_end",
+		],
+		allowedFilterOperators: {
+			activation_event: ["eq"],
+			return_event: ["eq"],
+			horizon_days: ["eq"],
+			observation_end: ["eq"],
+			namespace: ["eq"],
+		},
+		noCache: true,
+		meta: {
+			title: "Identified profile activation retention",
+			category: "Custom Events",
+			tags: ["retention", "activation", "cohort", "identified", "coverage"],
+			description:
+				"Directly identified profile retention on exact custom events. Required scalar eq filters: activation_event, return_event, horizon_days (7 or 30), observation_end (YYYY-MM-DD); optional exact namespace scopes both events. from/to are inclusive cohort calendar dates in timezone (default UTC), at most 90 days. observation_end is an inclusive observation date >= to, capped at query time. Each owner-scoped profile activates once at its earliest matching event IN this cohort window, not first-ever. Return interval is (activation, activation + horizon * 24 hours], not day-N retention. Only fully observed profiles enter retained/not_retained and the retention rate; incomplete follow-up is separate even if a return is already observed. No anonymous joins, person, customer or subscription inference. Overall row first, followed by daily cohorts; do not sum the overall row with daily rows. Identity coverage counts raw activation events (including duplicates), not profiles or population coverage. Fixed daily grouping/order; omit groupBy/orderBy. At most 91 SQL rows; limit100 includes all. get_data separately caps returnedRows at 20 and reports rowCount/truncated. No referrer attribution.",
+			default_order: "row_type DESC, cohort_date ASC",
+			default_visualization: "table",
+			output_fields: [
+				{ name: "row_type", type: "string", description: "overall or cohort" },
+				{
+					name: "cohort_date",
+					type: "date",
+					description: "Activation calendar date; null for overall",
+				},
+				{ name: "activated_profiles", type: "number" },
+				{
+					name: "eligible_profiles",
+					type: "number",
+					description: "Full return interval observed",
+				},
+				{
+					name: "retained_profiles",
+					type: "number",
+					description: "Eligible profiles with a qualifying return",
+				},
+				{
+					name: "not_retained_profiles",
+					type: "number",
+					description: "Eligible profiles without a qualifying return",
+				},
+				{
+					name: "incomplete_profiles",
+					type: "number",
+					description: "Excluded from retention denominator and failures",
+				},
+				{
+					name: "retention_rate",
+					type: "number",
+					unit: "%",
+					description: "Null when eligible_profiles is zero",
+				},
+				{ name: "activation_events", type: "number" },
+				{ name: "identified_activation_events", type: "number" },
+				{ name: "unidentified_activation_events", type: "number" },
+				{
+					name: "activation_identity_coverage",
+					type: "number",
+					unit: "%",
+					description:
+						"Event-level percentage with direct profile_id; null for no activation events",
+				},
+				{ name: "cohort_from", type: "date" },
+				{ name: "cohort_to", type: "date" },
+				{
+					name: "cohort_start",
+					type: "datetime",
+					description: "Inclusive cohort start in UTC",
+				},
+				{
+					name: "cohort_end",
+					type: "datetime",
+					description: "Exclusive cohort end in UTC",
+				},
+				{
+					name: "observation_end",
+					type: "date",
+					description: "Requested inclusive observation date",
+				},
+				{
+					name: "observed_before",
+					type: "datetime",
+					description: "Exclusive effective observation cutoff in UTC",
+				},
+				{ name: "timezone", type: "string" },
+				{ name: "horizon_days", type: "number" },
+				{ name: "identity_basis", type: "string" },
+				{ name: "activation_basis", type: "string" },
+			],
+		},
+		customSql: (ctx) => {
+			const filters = ctx.filters ?? [];
+			if (
+				filters.some(
+					(filter) => filter.op !== "eq" || filter.target || filter.having
+				) ||
+				new Set(filters.map((filter) => filter.field)).size !== filters.length
+			) {
+				throw new Error(
+					"Invalid retention selectors: supply each selector once with scalar eq."
+				);
+			}
+			const parsed = selectors.safeParse(
+				Object.fromEntries(
+					filters.map((filter) => [filter.field, filter.value])
+				)
+			);
+			if (!parsed.success) {
+				throw new Error(
+					"Invalid retention selectors: activation_event and return_event must be nonempty strings, horizon_days must be 7 or 30, and observation_end must be YYYY-MM-DD; namespace is optional."
+				);
+			}
+			const dates = z
+				.tuple([z.iso.date(), z.iso.date()])
+				.safeParse([ctx.startDate, ctx.endDate]);
+			if (
+				!dates.success ||
+				ctx.startDate > ctx.endDate ||
+				(Date.parse(ctx.endDate) - Date.parse(ctx.startDate)) / 86_400_000 >=
+					90 ||
+				parsed.data.observation_end < ctx.endDate
+			) {
+				throw new Error(
+					"Invalid retention dates: from/to must be YYYY-MM-DD spanning 1–90 inclusive cohort days, and observation_end must be on or after to."
+				);
+			}
+			if (
+				ctx.orderBy ||
+				ctx.offset ||
+				(ctx.granularity &&
+					ctx.granularity !== "day" &&
+					ctx.granularity !== "daily")
+			) {
+				throw new Error(
+					"Invalid retention options: fixed daily cohorts with overall row first; omit orderBy and offset."
+				);
+			}
+			const scope = ctx.filterParams?.__orgLevel
+				? "owner_id = {projectId:String}"
+				: "(owner_id = {projectId:String} OR website_id = {projectId:String})";
+			return {
+				params: {
+					projectId: ctx.websiteId,
+					cohortFrom: ctx.startDate,
+					cohortTo: ctx.endDate,
+					timezone: ctx.timezone ?? "UTC",
+					limit: Math.min(ctx.limit ?? 91, 91),
+					...parsed.data,
+				},
+				sql: `
+					WITH
+						toDateTime64({cohortFrom:String}, 3, {timezone:String}) AS cohort_start_at,
+						toDateTime64(addDays(toDate({cohortTo:String}), 1), 3, {timezone:String}) AS cohort_end_at,
+						least(toDateTime64(addDays(toDate({observation_end:String}), 1), 3, {timezone:String}), now64(3)) AS observation_cutoff,
+						scoped AS (
+							SELECT owner_id, profile_id, timestamp, event_name
+							FROM ${Analytics.custom_events}
+							WHERE ${scope}
+								AND timestamp >= cohort_start_at
+								AND timestamp < least(observation_cutoff, cohort_end_at + toIntervalHour({horizon_days:UInt8} * 24))
+								AND event_name IN ({activation_event:String}, {return_event:String})
+								${parsed.data.namespace === undefined ? "" : "AND namespace = {namespace:String}"}
+						),
+						activations AS (
+							SELECT owner_id, profile_id, min(timestamp) AS activated_at
+							FROM scoped
+							WHERE event_name = {activation_event:String} AND timestamp < cohort_end_at AND profile_id != ''
+							GROUP BY owner_id, profile_id
+						),
+						profiles AS (
+							SELECT a.owner_id, a.profile_id, a.activated_at,
+								a.activated_at + toIntervalHour({horizon_days:UInt8} * 24) < observation_cutoff AS is_eligible,
+								max(r.timestamp > a.activated_at AND r.timestamp <= a.activated_at + toIntervalHour({horizon_days:UInt8} * 24)) AS has_return
+							FROM activations a
+							LEFT ALL JOIN (SELECT owner_id, profile_id, timestamp FROM scoped WHERE event_name = {return_event:String} AND profile_id != '') r
+								ON a.owner_id = r.owner_id AND a.profile_id = r.profile_id
+							GROUP BY a.owner_id, a.profile_id, a.activated_at
+						),
+						metrics AS (
+							SELECT toDate(activated_at, {timezone:String}) AS day,
+								count() AS activated, countIf(is_eligible) AS eligible,
+								countIf(is_eligible AND has_return) AS retained,
+								toUInt64(0) AS events, toUInt64(0) AS identified_events
+							FROM profiles GROUP BY day
+							UNION ALL
+							SELECT toDate(timestamp, {timezone:String}) AS day,
+								toUInt64(0) AS activated, toUInt64(0) AS eligible, toUInt64(0) AS retained,
+								count() AS events, countIf(profile_id != '') AS identified_events
+							FROM scoped WHERE event_name = {activation_event:String} AND timestamp < cohort_end_at
+							GROUP BY day
+						)
+					SELECT
+						if(grouping(day) = 1, 'overall', 'cohort') AS row_type,
+						if(grouping(day) = 1, NULL, day) AS cohort_date,
+						sum(activated) AS activated_profiles,
+						sum(eligible) AS eligible_profiles,
+						sum(retained) AS retained_profiles,
+						sum(eligible) - sum(retained) AS not_retained_profiles,
+						sum(activated) - sum(eligible) AS incomplete_profiles,
+						round(100.0 * sum(retained) / nullIf(sum(eligible), 0), 2) AS retention_rate,
+						sum(events) AS activation_events,
+						sum(identified_events) AS identified_activation_events,
+						sum(events) - sum(identified_events) AS unidentified_activation_events,
+						round(100.0 * sum(identified_events) / nullIf(sum(events), 0), 2) AS activation_identity_coverage,
+						{cohortFrom:String} AS cohort_from,
+						{cohortTo:String} AS cohort_to,
+						concat(replaceOne(toString(cohort_start_at, 'UTC'), ' ', 'T'), 'Z') AS cohort_start,
+						concat(replaceOne(toString(cohort_end_at, 'UTC'), ' ', 'T'), 'Z') AS cohort_end,
+						{observation_end:String} AS observation_end,
+						concat(replaceOne(toString(observation_cutoff, 'UTC'), ' ', 'T'), 'Z') AS observed_before,
+						{timezone:String} AS timezone,
+						{horizon_days:UInt8} AS horizon_days,
+						'direct_profile_id' AS identity_basis,
+						'first_in_cohort_window' AS activation_basis
+					FROM metrics
+					GROUP BY GROUPING SETS ((day), ())
+					ORDER BY row_type DESC, cohort_date ASC
+					LIMIT {limit:UInt32}
+				`,
+			};
+		},
+	},
+};

--- a/packages/ai/src/query/builders/retention.ts
+++ b/packages/ai/src/query/builders/retention.ts
@@ -152,6 +152,7 @@ export const RetentionBuilders: Record<string, SimpleQueryConfig> = {
 				);
 			}
 			if (
+				ctx.groupBy?.length ||
 				ctx.orderBy ||
 				ctx.offset ||
 				(ctx.granularity &&
@@ -159,7 +160,7 @@ export const RetentionBuilders: Record<string, SimpleQueryConfig> = {
 					ctx.granularity !== "daily")
 			) {
 				throw new Error(
-					"Invalid retention options: fixed daily cohorts with overall row first; omit orderBy and offset."
+					"Invalid retention options: fixed daily cohorts with overall row first; omit groupBy, orderBy and offset."
 				);
 			}
 			const scope = ctx.filterParams?.__orgLevel

--- a/packages/ai/src/query/simple-builder.test.ts
+++ b/packages/ai/src/query/simple-builder.test.ts
@@ -38,7 +38,12 @@ function makeRequiredFilters(config: SimpleQueryConfig): Filter[] {
 	return [...new Set(fields)].map((field) => ({
 		field,
 		op: "eq",
-		value: `${field}-required-value`,
+		value:
+			field === "horizon_days"
+				? 7
+				: field === "observation_end"
+					? "2026-05-11"
+					: `${field}-required-value`,
 	}));
 }
 

--- a/packages/ai/src/query/simple-builder.ts
+++ b/packages/ai/src/query/simple-builder.ts
@@ -1166,6 +1166,7 @@ export class SimpleQueryBuilder {
 			endDate: normalizeClickHouseDateTime(this.request.to),
 			filters: this.request.filters,
 			granularity: this.request.timeUnit,
+			groupBy: this.request.groupBy,
 			limit: this.request.limit,
 			offset: this.request.offset,
 			timezone: this.request.timezone,

--- a/packages/ai/src/query/trait-filters.ts
+++ b/packages/ai/src/query/trait-filters.ts
@@ -11,6 +11,7 @@ import type { Filter, QueryRequest } from "./types";
 export const SANITIZED_QUERY_ERROR = "Query failed";
 
 const PUBLIC_QUERY_ERROR_PATTERNS = [
+	/^Invalid retention (selectors|dates|options):/,
 	/^Unknown query type:/,
 	/^Filter on field '[^']+' is not permitted/,
 	/^Filter target '[^']+' is not permitted/,

--- a/packages/ai/src/query/types.ts
+++ b/packages/ai/src/query/types.ts
@@ -116,6 +116,7 @@ export interface CustomSqlContext {
 	filterParams?: Record<string, Filter["value"]>;
 	filters?: Filter[];
 	granularity?: TimeUnit;
+	groupBy?: string[];
 	helpers?: QueryHelpers;
 	limit?: number;
 	offset?: number;


### PR DESCRIPTION
Adds native activation/retention measurement for directly identified profiles through the existing `get_data` and `discover_query_types` contract. `identified_profile_retention` requires exact activation/return event selectors, a 7- or 30-day horizon, and a separate observation date. Repeated events count once per owner-scoped profile; incomplete follow-up is excluded from both retained and not-retained counts.

The builder returns an overall row plus daily activation cohorts, explicit ISO UTC bounds, and separate event-level identity coverage. Cohort dates span at most 90 days and return scans end within the selected horizon. Activation means first observed within the requested cohort window, and returns occur strictly after activation through the inclusive fixed 24-hour horizon endpoint. There are no anonymous identity joins, referrer inference, or person/customer/subscriber claims.

Scope is limited to `packages/ai` query registration, implementation, native validation errors, and tests. No schema or API dependency. Parent-owned saved measurement context and Insights integration will consume this contract in a separate slice; those files are untouched. Keep this draft unmerged until parent review.

Validation:
- `bun run lint` passes, including 14 policy tests.
- `bun run check-types` passes: 33 tasks.
- Native query/discovery/get-data/public-access regression suite: 476 tests pass.
- Real ClickHouse SQL: 10 synthetic tests pass on hardcoded `127.0.0.1:16555`, using a uniquely named disposable table built from the canonical custom-event DDL. Covers duplicates, cross-tenant and cross-website IDs, anonymous-only/empty populations, incomplete windows, exact namespace/event matching, identical activation/return selectors, millisecond endpoints, DST, 30-day horizons, future cutoffs, and the 91-row bound.

SQL test command from `packages/ai`: `env -i PATH="$PATH" IDENTIFIED_RETENTION_CLICKHOUSE_TESTS=true CLICKHOUSE_URL=http://127.0.0.1:16555 REDIS_URL=redis://127.0.0.1:16554 bun test src/query/builders/retention.integration.test.ts`. Main `.env` and production services were not used. Native `get_data` retains its separate 20-row model-output cap and truncation metadata; a 14-day comparison fits in one result.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `identified_profile_retention` query type to `packages/ai` so directly identified profiles can be measured for activation retention through the existing `get_data` and `discover_query_types` contract. Scope is limited to `packages/ai`; saved measurement context and Insights integration are untouched and will consume this contract in a separate slice.

**Behavior**
- Requires exact activation/return event selectors, a 7- or 30-day horizon, and a separate observation date.
- Rejects `groupBy`, `orderBy`, and `offset` because cohorts are fixed daily with the overall row first.
- Returns an overall row plus daily activation cohorts with explicit ISO UTC bounds and event-level identity coverage.
- Activation means first observed within the requested cohort window; returns occur strictly after activation through the inclusive fixed 24-hour horizon endpoint.
- Repeated events count once per owner-scoped profile; incomplete follow-up is excluded from both retained and not-retained counts.
- No anonymous identity joins, referrer inference, or person/customer/subscriber claims.
- Native validation errors are surfaced while secret details stay hidden; `get_data` keeps its separate 20-row cap.

**Validation**
- Lint, type checks, and the 476-test native regression suite pass.
- 10 synthetic ClickHouse SQL tests cover duplicates, cross-tenant IDs, anonymous-only populations, DST, 30-day horizons, future cutoffs, and the 91-row bound.

<sup>Written for commit 0aa4159aec7d39062a3f39b32e87dc63645b6296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/databuddy-analytics/Databuddy/pull/774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

