### PR TITLE
test(ai): simplify required query selector fixtures

### DIFF
--- a/packages/ai/src/query/batch-executor.test.ts
+++ b/packages/ai/src/query/batch-executor.test.ts
@@ -3,6 +3,7 @@ import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
 import type { RequestLogger } from "evlog";
 import { setAiRequestLoggerProvider } from "../lib/request-logger";
 import { QueryBuilders } from "./builders";
+import { makeRequiredFilters } from "./filter-fixtures";
 import { SimpleQueryBuilder } from "./simple-builder";
 
 const realClickHouseModule = { ...actualClickHouse };
@@ -29,23 +30,8 @@ function compileSql(type: string): string {
 	if (!config) {
 		throw new Error(`Missing config for ${type}`);
 	}
-	const requiredFilters = [
-		...new Set([
-			...(config.requiredFilters ?? []),
-			...(config.requiredAnyFilter?.slice(0, 1) ?? []),
-		]),
-	].map((field) => ({
-		field,
-		op: "eq" as const,
-		value:
-			field === "horizon_days"
-				? 7
-				: field === "observation_end"
-					? "2026-05-11"
-					: `${field}-required-value`,
-	}));
 	return new SimpleQueryBuilder(config, {
-		filters: requiredFilters,
+		filters: makeRequiredFilters(config),
 		projectId: "test-website",
 		type,
 		from: "2026-04-01",

--- a/packages/ai/src/query/builder-execution.test.ts
+++ b/packages/ai/src/query/builder-execution.test.ts
@@ -9,14 +9,10 @@ import {
 import { randomUUIDv7 } from "bun";
 import { chCommand, chQuery } from "@databuddy/db/clickhouse";
 import { QueryBuilders } from "./builders";
+import { filterFor } from "./filter-fixtures";
 import { SimpleQueryBuilder } from "./simple-builder";
 import { ProfilesBuilders } from "./builders/profiles";
-import type {
-	CompiledQuery,
-	Filter,
-	QueryRequest,
-	SimpleQueryConfig,
-} from "./types";
+import type { CompiledQuery, QueryRequest, SimpleQueryConfig } from "./types";
 
 const TEST_CLICKHOUSE_URL = "http://default:@127.0.0.1:8123";
 
@@ -99,21 +95,6 @@ const FILTER_FIELD_OVERRIDES: Partial<
 	},
 };
 
-function filterFor(field: string): Filter {
-	return {
-		field,
-		op: "eq",
-		value:
-			field === "horizon_days"
-				? 7
-				: field === "observation_end"
-					? "2026-02-01"
-					: NUMERIC_FILTER_FIELDS.has(field)
-						? 1
-						: `test-${field}`,
-	};
-}
-
 function requestFor(
 	name: string,
 	config: SimpleQueryConfig,
@@ -124,7 +105,13 @@ function requestFor(
 		type: name,
 		from: "2026-01-01",
 		to: "2026-01-02",
-		filters: fields.map(filterFor),
+		filters: fields.map((field) =>
+			filterFor(
+				field,
+				"2026-02-01",
+				NUMERIC_FILTER_FIELDS.has(field) ? 1 : `test-${field}`
+			)
+		),
 		limit: 5,
 		offset: 0,
 	};

--- a/packages/ai/src/query/builders/retention.integration.test.ts
+++ b/packages/ai/src/query/builders/retention.integration.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { z } from "zod";
 import { SimpleQueryBuilder } from "../simple-builder";
 import type { Filter, QueryRequest } from "../types";
 import { RetentionBuilders } from "./retention";
@@ -21,7 +22,10 @@ type Event = {
 	anonymous_id?: string | null;
 };
 
-async function sql(query: string, params: Record<string, unknown> = {}) {
+async function sql(
+	query: string,
+	params: Record<string, string | number> = {}
+) {
 	const url = new URL("http://127.0.0.1:16555/");
 	url.searchParams.set("output_format_json_quote_64bit_integers", "0");
 	url.searchParams.set("join_default_strictness", "ANY");
@@ -72,7 +76,7 @@ async function measure(
 	).compile();
 	const result = await sql(
 		`${query.sql.replaceAll("analytics.custom_events", table)} FORMAT JSONEachRow`,
-		query.params
+		z.record(z.string(), z.union([z.string(), z.number()])).parse(query.params)
 	);
 	const rows: Row[] = result
 		.trim()

--- a/packages/ai/src/query/filter-fixtures.ts
+++ b/packages/ai/src/query/filter-fixtures.ts
@@ -1,0 +1,21 @@
+import type { Filter, SimpleQueryConfig } from "./types";
+
+export function filterFor(
+	field: string,
+	observationEnd = "2026-05-11",
+	fallback: string | number = `${field}-required-value`
+): Filter {
+	const values: Record<string, string | number> = {
+		horizon_days: 7,
+		observation_end: observationEnd,
+	};
+	return { field, op: "eq", value: values[field] ?? fallback };
+}
+
+export function makeRequiredFilters(config: SimpleQueryConfig): Filter[] {
+	const fields = [
+		...(config.requiredFilters ?? []),
+		...(config.requiredAnyFilter?.slice(0, 1) ?? []),
+	];
+	return [...new Set(fields)].map((field) => filterFor(field));
+}

--- a/packages/ai/src/query/simple-builder.test.ts
+++ b/packages/ai/src/query/simple-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { QueryBuilders } from "./builders";
+import { makeRequiredFilters } from "./filter-fixtures";
 import {
 	getClickHouseQuerySettings,
 	SimpleQueryBuilder,
@@ -29,23 +30,6 @@ function makeConfig(overrides: Partial<SimpleQueryConfig> = {}): SimpleQueryConf
 }
 
 const QUERY_BUILDER_ENTRIES = Object.entries(QueryBuilders);
-
-function makeRequiredFilters(config: SimpleQueryConfig): Filter[] {
-	const fields = [
-		...(config.requiredFilters ?? []),
-		...(config.requiredAnyFilter?.slice(0, 1) ?? []),
-	];
-	return [...new Set(fields)].map((field) => ({
-		field,
-		op: "eq",
-		value:
-			field === "horizon_days"
-				? 7
-				: field === "observation_end"
-					? "2026-05-11"
-					: `${field}-required-value`,
-	}));
-}
 
 function compileBuilder(
 	type: string,


### PR DESCRIPTION
The query test suites duplicated required-filter setup with nested conditionals, and the retention SQL helper accepted parameter types it cannot execute. This change shares the fixture construction and validates SQL parameters as strings or numbers, preserving the existing test cases.

Addresses both review threads from #774. No production query behavior changes.

Validation: root lint and all 33 typecheck tasks passed; 643 targeted tests passed (6 skipped), including 196 builder EXPLAIN checks and 10 native retention SQL tests against synthetic ClickHouse data. Independent diff review and Greptile review of `fa2b9c1201e673b36d07e0f96bd055d0bf5de516` found no actionable issues; CI passed.
